### PR TITLE
Decode an enumeration attribute instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- An enumeration attribute reaches the caller, decoded through its integer base type as enum dataset data already is; `attrs()` skipped it before, so every `np.bool_` attribute in an h5py-written file — stored as `enum[FALSE, TRUE]` — went missing without a trace. The member names have no `AttrValue` to live in, so the codes are what survives.
+- An enumeration attribute reaches the caller, decoded through its integer base type as enum dataset data already is; `attrs()` skipped it before, so every `np.bool_` attribute in an h5py-written file — stored as `enum[FALSE, TRUE]` — went missing without a trace. The member names have no `AttrValue` to live in, so the codes are what survives ([#248](https://github.com/stephenberry/hdf5-pure/pull/248)).
 
 ## [0.33.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- An enumeration attribute reaches the caller, decoded through its integer base type as enum dataset data already is; `attrs()` skipped it before, so every `np.bool_` attribute in an h5py-written file — stored as `enum[FALSE, TRUE]` — went missing without a trace. The member names have no `AttrValue` to live in, so the codes are what survives ([#248](https://github.com/stephenberry/hdf5-pure/pull/248)).
+- An enumeration attribute reaches the caller, decoded through its integer base type as enum dataset data already is; `attrs()` skipped it before, so every `np.bool_` attribute in an h5py-written file — stored as `enum[FALSE, TRUE]` — went missing without a trace. The member names have no `AttrValue` to carry them, so `repack` still refuses such an attribute rather than rewrite it as a plain integer ([#248](https://github.com/stephenberry/hdf5-pure/pull/248)).
 
 ## [0.33.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- An enumeration attribute reaches the caller, decoded through its integer base type as enum dataset data already is; `attrs()` skipped it before, so every `np.bool_` attribute in an h5py-written file — stored as `enum[FALSE, TRUE]` — went missing without a trace. The member names have no `AttrValue` to live in, so the codes are what survives.
+
 ## [0.33.0] - 2026-08-02
 
 A file whose superblock marks it as held by a writer is refused rather than opened: `File::open`, `open_streaming`, `open_rw`, `open_swmr_writer` and `repack` report the new `Error::FileMarkedInUse`, which is the check `H5Fopen` makes of the same byte — a file a crashed SWMR writer left flagged used to open, and `open_rw` used to edit it in place under a writer the file still recorded ([#245](https://github.com/stephenberry/hdf5-pure/issues/245)). `File::open_swmr` follows such a file instead of refusing it, since that pairing is what the flag exists for, and `File::from_bytes` does not consult the byte at all, so a caller holding the bytes can still read a flagged file on a read-only mount, where the `File::clear_swmr_flag` recovery (the `h5clear -s` equivalent) cannot get the write access it needs. The check applies to version-3 superblocks, which is where the C library applies it, and `open_swmr_writer` now requires one for the same reason libhdf5 does. Two smaller changes come with it: a read-write open validates the superblock before it builds its backing, so refusing a mirrored file no longer reads the whole file first, and a version-1 superblock's status flags and chunk B-tree K are read from the offsets the C library writes them to rather than swapped. Files written by earlier versions still read.

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -276,7 +276,7 @@ fn ensure_numeric(dt: &Datatype, expected: &'static str) -> Result<(), FormatErr
 /// enum's base is always a leaf integer in practice) and returns any non-enum
 /// datatype unchanged, so the value+name round-trip works: the readers surface
 /// the codes while [`crate::DType::Enum`] surfaces the member names.
-fn effective_numeric(dt: &Datatype) -> &Datatype {
+pub(crate) fn effective_numeric(dt: &Datatype) -> &Datatype {
     match dt {
         Datatype::Enumeration { base_type, .. } => effective_numeric(base_type),
         other => other,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1110,15 +1110,20 @@ impl FileInner {
         }
     }
 
-    /// Names of every attribute message on `hdr`, including ones whose datatype
-    /// [`attrs_of`](Self::attrs_of) cannot decode into an [`AttrValue`] (and so
-    /// silently omits from its map). Repack diffs this against the decoded map to
-    /// refuse rather than drop an attribute it cannot reproduce.
-    pub(crate) fn attr_message_names_of(&self, hdr: &ObjectHeader) -> Result<Vec<String>, Error> {
+    /// The name and datatype of every attribute message on `hdr`, including ones
+    /// whose datatype [`attrs_of`](Self::attrs_of) cannot decode into an
+    /// [`AttrValue`] (and so silently omits from its map). Repack weighs this
+    /// against the decoded map to refuse rather than drop or alter an attribute it
+    /// cannot reproduce — the datatype is what tells it an attribute decoded into
+    /// an `AttrValue` that would be written back as a different type.
+    pub(crate) fn attr_message_types_of(
+        &self,
+        hdr: &ObjectHeader,
+    ) -> Result<Vec<(String, Datatype)>, Error> {
         Ok(self
             .attr_messages_of(hdr)?
             .into_iter()
-            .map(|a| a.name)
+            .map(|a| (a.name, a.datatype))
             .collect())
     }
 
@@ -2406,12 +2411,12 @@ impl Group {
         self.file.attrs_of(&hdr)
     }
 
-    /// Names of every attribute on this group, including any whose datatype
-    /// [`attrs`](Self::attrs) cannot represent. Used by repack to detect an
-    /// attribute it would otherwise drop.
-    pub(crate) fn attr_names(&self) -> Result<Vec<String>, Error> {
+    /// The name and datatype of every attribute on this group, including any
+    /// whose datatype [`attrs`](Self::attrs) cannot represent. Used by repack to
+    /// detect an attribute it cannot reproduce.
+    pub(crate) fn attr_datatypes(&self) -> Result<Vec<(String, Datatype)>, Error> {
         let hdr = self.file.parse_header(self.address)?;
-        self.file.attr_message_names_of(&hdr)
+        self.file.attr_message_types_of(&hdr)
     }
 
     /// Get a dataset within this group by name.
@@ -3617,11 +3622,11 @@ impl Dataset {
         self.file.attrs_of(&self.header)
     }
 
-    /// Names of every attribute on this dataset, including any whose datatype
-    /// [`attrs`](Self::attrs) cannot represent. Used by repack to detect an
-    /// attribute it would otherwise drop.
-    pub(crate) fn attr_names(&self) -> Result<Vec<String>, Error> {
-        self.file.attr_message_names_of(&self.header)
+    /// The name and datatype of every attribute on this dataset, including any
+    /// whose datatype [`attrs`](Self::attrs) cannot represent. Used by repack to
+    /// detect an attribute it cannot reproduce.
+    pub(crate) fn attr_datatypes(&self) -> Result<Vec<(String, Datatype)>, Error> {
+        self.file.attr_message_types_of(&self.header)
     }
 
     /// Returns the exact HDF5 datatype, including compound field offsets and

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -68,10 +68,12 @@
 //! target), and object references in a userblock file (non-zero base address); a
 //! non-string vlen sequence whose base type embeds an address (nested vlen or
 //! reference); virtual and external data layouts; a lossy filter on the
-//! contiguous re-encode or sparse-chunked fallback path; and any attribute whose
-//! datatype the reader cannot decode into an [`AttrValue`] (e.g. an enumeration,
-//! compound, reference, or boolean attribute). An object that cannot be
-//! reproduced fails the repack by name rather than being silently dropped.
+//! contiguous re-encode or sparse-chunked fallback path; any attribute whose
+//! datatype the reader cannot decode into an [`AttrValue`] (e.g. a compound or
+//! reference attribute); and any enumeration attribute, which decodes through its
+//! integer base and so would come back a plain integer rather than the enum (a
+//! boolean attribute is one of these). An object that cannot be reproduced fails
+//! the repack by name rather than being silently dropped.
 //!
 //! # Memory
 //!
@@ -274,7 +276,7 @@ fn populate<S: GroupSink>(
     } else {
         format!("group {path}")
     };
-    check_attr_completeness(&attrs, &src.attr_names()?, &owner)?;
+    check_attr_completeness(&attrs, &src.attr_datatypes()?, &owner)?;
     for (name, value) in sorted(attrs) {
         sink.sink_set_attr(&name, value);
     }
@@ -379,7 +381,7 @@ fn emit_dataset(
         emit_vlen_string_dataset(db, ds, path, &datatype, &dims, &layout, &pipeline)?;
         // VL-string datasets carry attributes the same way as any other.
         let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
             db.set_attr(&name, value);
         }
@@ -394,7 +396,7 @@ fn emit_dataset(
     if is_nonstring_vlen(&datatype) {
         emit_vlen_sequence_dataset(db, ds, path, &datatype, &dims, &layout, &pipeline)?;
         let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
             db.set_attr(&name, value);
         }
@@ -409,7 +411,7 @@ fn emit_dataset(
     if is_object_reference(&datatype) {
         emit_object_reference_dataset(db, ds, path, &dims, &layout, file, drop, addr_map)?;
         let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
             db.set_attr(&name, value);
         }
@@ -443,7 +445,7 @@ fn emit_dataset(
             addr_map,
         )?;
         let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+        check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
         for (name, value) in sorted(attrs) {
             db.set_attr(&name, value);
         }
@@ -505,7 +507,7 @@ fn emit_dataset(
             // Carry the dataset's attributes, refusing any that cannot be
             // represented.
             let attrs = ds.attrs()?;
-            check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+            check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
             for (name, value) in sorted(attrs) {
                 db.set_attr(&name, value);
             }
@@ -543,7 +545,7 @@ fn emit_dataset(
 
     // Carry the dataset's attributes, refusing if any cannot be represented.
     let attrs = ds.attrs()?;
-    check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
+    check_attr_completeness(&attrs, &ds.attr_datatypes()?, &format!("dataset {path}"))?;
     for (name, value) in sorted(attrs) {
         db.set_attr(&name, value);
     }
@@ -949,21 +951,31 @@ fn try_plan_dense_chunks(
     Ok(Some(DenseChunkPlan { meta, grid_order }))
 }
 
-/// Refuse the repack if `owner` has an attribute the reader cannot represent as
-/// an [`AttrValue`] and would therefore drop. `names` is every attribute on the
-/// object; `decoded` is the subset that read back, keyed by name. Any name not
-/// in `decoded` is an attribute that would be silently lost.
+/// Refuse the repack if `owner` has an attribute this crate cannot write back as
+/// it found it. `attrs` is every attribute on the object with its datatype;
+/// `decoded` is the subset that read back, keyed by name.
+///
+/// An attribute is lost in one of two ways. It may not decode into an
+/// [`AttrValue`] at all, in which case the rewrite would simply omit it. Or it
+/// may decode into one that writes a *different* datatype than the disk holds:
+/// an enumeration decodes through its integer base, so rewriting it would turn
+/// `enum[FALSE, TRUE]` into a plain integer. Both are silent, so both refuse.
 fn check_attr_completeness(
     decoded: &std::collections::HashMap<String, AttrValue>,
-    names: &[String],
+    attrs: &[(String, Datatype)],
     owner: &str,
 ) -> Result<(), Error> {
-    for name in names {
-        if !decoded.contains_key(name) {
-            return Err(Error::RepackUnsupported(format!(
-                "{owner}: attribute {name:?} has a datatype that cannot be repacked faithfully yet"
-            )));
-        }
+    for (name, datatype) in attrs {
+        let fault = if !decoded.contains_key(name) {
+            "a datatype that cannot be repacked faithfully yet"
+        } else if matches!(datatype, Datatype::Enumeration { .. }) {
+            "an enumeration datatype, which would be rewritten as its integer base"
+        } else {
+            continue;
+        };
+        return Err(Error::RepackUnsupported(format!(
+            "{owner}: attribute {name:?} has {fault}"
+        )));
     }
     Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -549,7 +549,7 @@ mod tests {
 
     /// An enum attribute decodes through its integer base type rather than being
     /// dropped. h5py writes every `np.bool_` attribute this way, so before this the
-    /// booleans in an h5py-written file were missing from `attrs()` entirely.
+    /// booleans in an h5py-written file were missing from `attrs()` entirely (#248).
     #[test]
     fn an_enum_attribute_decodes_as_its_base_type() {
         let h5py_bool =

--- a/src/types.rs
+++ b/src/types.rs
@@ -198,6 +198,9 @@ pub(crate) fn attrs_to_map<S: crate::source::Source + ?Sized>(
 ///
 /// - **Width.** Integers and floats widen to `i64`/`u64`/`f64`; there are no
 ///   narrower array variants.
+/// - **Enumeration members.** An enum attribute decodes through its integer base
+///   type, so its codes survive and the member names do not. This is how h5py's
+///   `np.bool_` attributes arrive, written as `enum[FALSE, TRUE]`: as `0`/`1`.
 /// - **Variable-length strings.** A true `H5T_STRING` with `STRSIZE = VAR`,
 ///   which this crate's writer never emits, has no variant of its own and reads
 ///   as the fixed-width variant of the same charset and arity.
@@ -229,7 +232,9 @@ fn decode_attr_value<S: crate::source::Source + ?Sized>(
     // at length one.
     let scalar = attr.dataspace.space_type == DataspaceType::Scalar;
 
-    match &attr.datatype {
+    // An enumeration is stored as values of its integer base type, so it decodes
+    // through that base — the same view the numeric readers take of an enum dataset.
+    match crate::data_read::effective_numeric(&attr.datatype) {
         Datatype::FloatingPoint { .. } => {
             let vals = attr.read_as_f64().ok()?;
             if scalar {
@@ -511,6 +516,75 @@ mod tests {
         for (name, written) in &cases {
             assert_eq!(read.get(*name), Some(written), "attribute {name}");
         }
+    }
+
+    /// Decode one attribute of an arbitrary datatype, which the writer cannot
+    /// stage because [`AttrValue`] has no variant to write it from.
+    fn decode_raw(
+        datatype: Datatype,
+        raw_data: Vec<u8>,
+        dimensions: Vec<u64>,
+    ) -> Option<AttrValue> {
+        use crate::dataspace::{Dataspace, DataspaceType};
+
+        let scalar = dimensions.is_empty();
+        let attr = crate::attribute::AttributeMessage {
+            name: "a".into(),
+            datatype,
+            dataspace: Dataspace {
+                space_type: if scalar {
+                    DataspaceType::Scalar
+                } else {
+                    DataspaceType::Simple
+                },
+                #[expect(clippy::cast_possible_truncation)]
+                rank: dimensions.len() as u8,
+                dimensions,
+                max_dimensions: None,
+            },
+            raw_data,
+        };
+        decode_attr_value(&attr, &crate::source::BytesSource::new(Vec::new()), 8, 8, 0)
+    }
+
+    /// An enum attribute decodes through its integer base type rather than being
+    /// dropped. h5py writes every `np.bool_` attribute this way, so before this the
+    /// booleans in an h5py-written file were missing from `attrs()` entirely.
+    #[test]
+    fn an_enum_attribute_decodes_as_its_base_type() {
+        let h5py_bool =
+            crate::type_builders::EnumTypeBuilder::with_base(crate::type_builders::make_i8_type())
+                .value("FALSE", 0)
+                .value("TRUE", 1)
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            decode_raw(h5py_bool.clone(), vec![1], vec![]),
+            Some(AttrValue::I64(1))
+        );
+        // Array-ness comes from the dataspace here as it does for every other type.
+        assert_eq!(
+            decode_raw(h5py_bool, vec![1, 0, 1], vec![3]),
+            Some(AttrValue::I64Array(vec![1, 0, 1]))
+        );
+    }
+
+    /// The base type's signedness and width carry through, so an enum over an
+    /// unsigned base lands in the unsigned variant with its value intact.
+    #[test]
+    fn an_unsigned_enum_attribute_keeps_its_base_signedness() {
+        let mode =
+            crate::type_builders::EnumTypeBuilder::with_base(crate::type_builders::make_u16_type())
+                .value("low", 1)
+                .value("high", 40_000)
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            decode_raw(mode, 40_000_u16.to_le_bytes().to_vec(), vec![]),
+            Some(AttrValue::U64(40_000))
+        );
     }
 
     /// Array-ness survives at length one for numbers too.

--- a/tests/enum_attr_crosscheck.rs
+++ b/tests/enum_attr_crosscheck.rs
@@ -1,0 +1,91 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// gated to 64-bit-pointer targets.
+#![cfg(not(target_pointer_width = "32"))]
+//! An enumeration *attribute* written by the reference C library must reach the
+//! caller, decoded through the enum's integer base type.
+//!
+//! This is the read direction of `enum_base_crosscheck.rs`, and it matters because
+//! the C library is what writes the files in the wild: `H5T_NATIVE_HBOOL` — what
+//! h5py gives every `np.bool_` and what `hdf5-metno` gives Rust's `bool` — is an
+//! `enum[FALSE, TRUE]` over an 8-bit integer, so a boolean attribute is an enum
+//! attribute. `attrs()` used to drop those silently, taking with it flags like
+//! DROID's per-episode `success`.
+//!
+//! Every call here goes through the safe `hdf5-metno` API, which serializes its
+//! own C calls through an internal lock, so these tests need no extra guard.
+
+use std::collections::HashMap;
+
+use hdf5_pure::{AttrValue, File};
+use tempfile::tempdir;
+
+/// Write attributes with the C library, then read them all back with this crate.
+fn c_writes_then_pure_reads(write: impl FnOnce(&hdf5::File)) -> HashMap<String, AttrValue> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("enum_attrs.h5");
+
+    {
+        let file = hdf5::File::create(&path).expect("the C library should create the file");
+        write(&file);
+        file.close().expect("close");
+    }
+
+    let bytes = std::fs::read(&path).expect("read back the written file");
+    File::from_bytes(bytes)
+        .expect("from_bytes")
+        .root()
+        .attrs()
+        .expect("attrs")
+}
+
+#[test]
+fn a_c_written_bool_attribute_reaches_the_caller() {
+    let attrs = c_writes_then_pure_reads(|file| {
+        file.new_attr::<bool>()
+            .create("flag")
+            .expect("create attribute")
+            .write_scalar(&true)
+            .expect("write attribute");
+    });
+
+    // The codes survive; `FALSE`/`TRUE` do not, since no `AttrValue` carries them.
+    assert_eq!(attrs.get("flag"), Some(&AttrValue::I64(1)));
+}
+
+#[test]
+fn a_c_written_bool_array_attribute_reaches_the_caller() {
+    let attrs = c_writes_then_pure_reads(|file| {
+        file.new_attr::<bool>()
+            .shape([3])
+            .create("flags")
+            .expect("create attribute")
+            .write(&[true, false, true])
+            .expect("write attribute");
+    });
+
+    assert_eq!(
+        attrs.get("flags"),
+        Some(&AttrValue::I64Array(vec![1, 0, 1]))
+    );
+}
+
+/// A boolean attribute must not cost the object its other attributes: the decoder
+/// skips what it cannot represent, so a regression here would be silent.
+#[test]
+fn a_bool_attribute_sits_alongside_the_rest() {
+    let attrs = c_writes_then_pure_reads(|file| {
+        file.new_attr::<bool>()
+            .create("success")
+            .expect("create attribute")
+            .write_scalar(&false)
+            .expect("write attribute");
+        file.new_attr::<f64>()
+            .create("frequency")
+            .expect("create attribute")
+            .write_scalar(&30.0)
+            .expect("write attribute");
+    });
+
+    assert_eq!(attrs.get("success"), Some(&AttrValue::I64(0)));
+    assert_eq!(attrs.get("frequency"), Some(&AttrValue::F64(30.0)));
+}

--- a/tests/enum_attr_crosscheck.rs
+++ b/tests/enum_attr_crosscheck.rs
@@ -2,7 +2,7 @@
 // gated to 64-bit-pointer targets.
 #![cfg(not(target_pointer_width = "32"))]
 //! An enumeration *attribute* written by the reference C library must reach the
-//! caller, decoded through the enum's integer base type.
+//! caller, decoded through the enum's integer base type (#248).
 //!
 //! This is the read direction of `enum_base_crosscheck.rs`, and it matters because
 //! the C library is what writes the files in the wild: `H5T_NATIVE_HBOOL` — what

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -549,10 +549,12 @@ fn repack_roundtrips_filtered_and_resizable_vlen_string_datasets() {
 
 #[test]
 fn repack_refuses_unrepresentable_attribute() {
-    // The C library writes a boolean attribute, which is an HDF5 enumeration —
-    // a datatype the reader cannot decode into an AttrValue and would silently
-    // drop. Repack must refuse by name rather than write a file missing the
-    // attribute, upholding the fail-loud fidelity contract.
+    // The C library writes a boolean attribute, which is an HDF5 enumeration.
+    // The reader decodes one — through its integer base, as it does enum dataset
+    // data — but `AttrValue` cannot carry the enum back, so a rewrite would turn
+    // `enum[FALSE, TRUE]` into a plain integer. Repack must refuse by name rather
+    // than quietly change the attribute's type, upholding the fail-loud fidelity
+    // contract.
     let dir = tempdir().unwrap();
     let src = dir.path().join("c_boolattr.h5");
     let dst = dir.path().join("boolattr_repacked.h5");
@@ -581,6 +583,12 @@ fn repack_refuses_unrepresentable_attribute() {
             assert!(
                 msg.contains("active") && msg.contains("data"),
                 "error should name the attribute and its dataset: {msg}"
+            );
+            // The reason matters as much as the refusal: it must be the rewrite
+            // that is refused, not a failure to read the attribute at all.
+            assert!(
+                msg.contains("enumeration"),
+                "error should name the enumeration as the reason: {msg}"
             );
         }
         other => panic!("expected RepackUnsupported, got {other:?}"),


### PR DESCRIPTION
## The problem

An enum is stored as values of its integer base type, and the numeric readers already decode enum *dataset* data through that base — `effective_numeric` exists for exactly that, and its doc spells out the rule.

Attribute decoding never got the same treatment. `decode_attr_value` matches the datatype as it finds it, so an `Enumeration` matches no arm, returns `None`, and `attrs_to_map` skips it.

That is quieter than it sounds. The reference C library gives `H5T_NATIVE_HBOOL` an `enum[FALSE, TRUE]` over an 8-bit integer, so **every boolean attribute is an enum attribute** — and every one was missing from `attrs()` with no error and no warning. It is also how h5py writes `np.bool_`, which is how these reach real files:

```python
f.attrs["success"] = True   # -> enum[FALSE, TRUE], invisible to attrs()
```

I hit this reading the [DROID robotics dataset](https://droid-dataset.github.io/), where each episode's `trajectory.h5` carries `success`, `failure`, `controller_on` and `movement_enabled` as root attributes. All four silently disappeared; the string and float attributes beside them came through fine.

## The fix

Dispatch on the effective numeric type, so the base-type rule that already governs enum datasets governs enum attributes too:

```rust
-    match &attr.datatype {
+    match crate::data_read::effective_numeric(&attr.datatype) {
```

Signedness and width follow the base, so a scalar lands in `I64`/`U64` and an array in `I64Array`/`U64Array`, exactly as the same integer would without the enum wrapper. The member names have no `AttrValue` to live in, so the codes are what survives — I added that to the function's existing list of what a round trip does not recover.

## Tests

- `tests/enum_attr_crosscheck.rs` (new) — the reference C library writes the attribute, this crate reads it back. This is the case that matters, since libhdf5 (and therefore h5py) is what writes these files. Covers a scalar bool, a bool array, and a bool sitting alongside an ordinary `f64` attribute, since the failure mode is a silent skip that could take out one attribute and leave the rest.
- Two library tests in `src/types.rs` covering the decode directly, including an enum over an unsigned 16-bit base to pin the signedness/width behaviour.

All three crosschecks and both library tests fail without the one-line change. Full `cargo test --lib` is green (714), as are the attribute-, enum- and MATLAB-related integration binaries.

## A question for you

I kept this to the general rule — codes through the base type — rather than adding an `AttrValue::Bool`, because it matches what the crate already does for enum datasets and needs no new public API. If you would rather `np.bool_` attributes round-trip as booleans, an `AttrValue::Bool`/`BoolArray` pair detecting the `FALSE`/`TRUE`-over-8-bit convention would do it, and there is precedent in the MATLAB-shaped variants. Happy to follow up with that if you prefer it.

No version bump: additive-only, no public API change (`effective_numeric` becomes `pub(crate)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)