### PR TITLE
Read a run of adjacent chunks in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `File::open_streaming` reads a dataset's adjacent chunks in one call instead of one call per chunk, which nearly halves the time to read a file written a row at a time — 20,440 tiny chunks in a 2.7 MB file went from 19.9 ms to 11.4 ms. A read never fetches a byte outside the chunks it was asked for, and holds at most 256 KiB of span beyond its own buffers ([#250](https://github.com/stephenberry/hdf5-pure/pull/250)).
+
 ## [0.33.0] - 2026-08-02
 
 A file whose superblock marks it as held by a writer is refused rather than opened: `File::open`, `open_streaming`, `open_rw`, `open_swmr_writer` and `repack` report the new `Error::FileMarkedInUse`, which is the check `H5Fopen` makes of the same byte — a file a crashed SWMR writer left flagged used to open, and `open_rw` used to edit it in place under a writer the file still recorded ([#245](https://github.com/stephenberry/hdf5-pure/issues/245)). `File::open_swmr` follows such a file instead of refusing it, since that pairing is what the flag exists for, and `File::from_bytes` does not consult the byte at all, so a caller holding the bytes can still read a flagged file on a read-only mount, where the `File::clear_swmr_flag` recovery (the `h5clear -s` equivalent) cannot get the write access it needs. The check applies to version-3 superblocks, which is where the C library applies it, and `open_swmr_writer` now requires one for the same reason libhdf5 does. Two smaller changes come with it: a read-write open validates the superblock before it builds its backing, so refusing a mirrored file no longer reads the whole file first, and a version-1 superblock's status flags and chunk B-tree K are read from the offsets the C library writes them to rather than swapped. Files written by earlier versions still read.

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -8,6 +8,8 @@ This page covers working with HDF5 files that are too large to buffer in memory,
 
 `File::open_streaming(path)` opens the same file with a lazy backing store. It fetches metadata and dataset chunks from the file as they are needed instead of buffering it whole, so it never holds the entire file in memory at once. Peak memory tracks what you actually read: one dataset, decompressed, with its chunks fetched on demand, plus the metadata being parsed.
 
+Chunks that lie next to each other on disk are fetched together, in reads of at most 256 KiB. This matters for a file a recorder wrote a row at a time, which carries one small chunk per row: reading such a file one chunk per read costs about four times what the same read costs buffered, and coalescing the runs takes most of that back. A read never fetches bytes outside the chunks it was asked for, so this costs read volume nothing.
+
 ```rust
 use hdf5_pure::File;
 
@@ -67,7 +69,9 @@ The window is clamped to the dataset, so the final short window needs no special
 
 `File::open_streaming_with_options(path, FileAccessProperties)` bounds the memory the streaming backend retains. `FileAccessProperties::new()` returns the crate's default access behavior; you layer on two independent caches with its builder methods.
 
-`MetadataCacheConfig` mirrors the memory-budget role of HDF5's `H5Pset_mdc_config`: it caps the bytes retained for parsed metadata reads. `MetadataCacheConfig::new(max_bytes)` sets the total byte budget, and `.with_max_entry_bytes(...)` caps the size of any single cached metadata read so one large heap or index block cannot monopolize the cache.
+`MetadataCacheConfig` mirrors the memory-budget role of HDF5's `H5Pset_mdc_config`: it caps the bytes retained for parsed metadata reads. `MetadataCacheConfig::new(max_bytes)` sets the total byte budget, and `.with_max_entry_bytes(...)` caps the size of any single cached metadata read so one large heap or index block cannot monopolize the cache. It is disabled unless you ask for it.
+
+It is worth asking for on a file holding many datasets. Opening one walks the root group's link storage, and every dataset repeats that walk: reading all 73 datasets of a 2.7 MB recording spent 11,615 of its 12,491 metadata reads opening datasets rather than reading them. Budgeting 1 MiB for metadata took that read from 11.3 ms to 6.0 ms, against 4.7 ms for the same read buffered — what coalescing does not remove, this does.
 
 `ChunkCacheConfig` mirrors the raw-data chunk-cache settings from `H5Pset_cache`. `ChunkCacheConfig::from_h5p_cache(rdcc_nslots, rdcc_nbytes)` builds one directly from the familiar HDF5 slot count and byte budget. It controls decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
 

--- a/src/chunk_span.rs
+++ b/src/chunk_span.rs
@@ -1,0 +1,375 @@
+//! Coalesced chunk reads for the streaming reader.
+//!
+//! # Why this exists
+//!
+//! The streaming chunked readers fetch one chunk per [`Source::read_exact_at`].
+//! That is one `seek` plus one `read` per chunk, which is fine for the
+//! megabyte-sized chunks a file written in one pass carries, and disastrous for
+//! a file written as the data arrived: a recorder that appends a row at a time
+//! produces one chunk per row, so a 2.7 MB file with 73 datasets over 280 rows
+//! holds 20,440 chunks of 8 to 256 bytes. Reading all of it cost about four
+//! times what the same read costs from a buffered [`crate::File::open`], and the
+//! whole difference was read *granularity* — the file was read exactly once,
+//! 90 bytes at a time.
+//!
+//! Those chunks are almost always adjacent on disk. libhdf5 allocates a chunk
+//! when its chunk cache flushes, not when the write is issued, so even a writer
+//! that fills 73 datasets a row at a time lays each dataset's chunks down in one
+//! run (measured at 98.4% adjacent, and byte-identical to writing the datasets
+//! one at a time). A reader that asks for the whole run in one call therefore
+//! gets the same bytes in a few hundred reads instead of tens of thousands: on
+//! the file above, 20,661 data reads became 616 and the read halved, from
+//! 19.9 ms to 10.7 ms against 4.7 ms buffered.
+//!
+//! # What this does not do
+//!
+//! It does not turn a streaming read into a whole-file read. A span stops at
+//! [`MAX_SPAN_BYTES`], so what this holds beyond the caller's own buffers is
+//! bounded by that however large the dataset is — the reason `open_streaming`
+//! exists is that a file larger than memory still opens, and this must not
+//! spend that. The one span that may exceed the cap is a single chunk larger
+//! than it, which is read alone, exactly as it was before. The cap is also what
+//! keeps a windowed row read inside the peak `tests/windowed_read_memory.rs`
+//! bounds.
+//!
+//! It also never reads a byte the caller did not ask for: only chunks that are
+//! exactly adjacent are merged, so a coalesced read fetches the same bytes the
+//! per-chunk reads would have. Bridging a gap between two nearby chunks would
+//! trade read count for read volume; on the layouts this targets there is no gap
+//! to bridge.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::chunked_read::ChunkInfo;
+use crate::convert::TryToUsize;
+use crate::error::FormatError;
+use crate::source::Source;
+
+/// Largest span read in one call, and so the most this holds at a time.
+///
+/// The runs this coalesces are broken by the chunk index's own blocks every few
+/// kilobytes, so on the motivating file 64 KiB already captured the whole win
+/// (the mean span was 2.8 KB) and raising it changed nothing. The value is a
+/// ceiling for the layouts where runs *are* long — a dataset of 4 KiB chunks
+/// written in one pass — not a target.
+pub(crate) const MAX_SPAN_BYTES: usize = 256 * 1024;
+
+/// One contiguous byte range of the file covering one or more chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Span {
+    start: u64,
+    end: u64,
+}
+
+impl Span {
+    fn covers(&self, start: u64, end: u64) -> bool {
+        start >= self.start && end <= self.end
+    }
+}
+
+/// Reads a dataset's chunks through coalesced spans.
+///
+/// Construct it with the chunks a single read will fetch — for a windowed read,
+/// only the chunks the window overlaps, so a span never bridges chunks outside
+/// it — then ask for each chunk's bytes with [`chunk_bytes`](Self::chunk_bytes).
+/// A chunk in the same span as the last one is served from the buffer already
+/// held; otherwise its whole span is read first.
+pub(crate) struct ChunkSpanReader {
+    /// Spans, sorted by `start` and non-overlapping.
+    spans: Vec<Span>,
+    /// The span currently held in `buf`.
+    held: Option<Span>,
+    buf: Vec<u8>,
+    /// Holds a chunk that belongs to no span, so one such request does not
+    /// evict the span the surrounding chunks are being served from.
+    scratch: Vec<u8>,
+}
+
+impl ChunkSpanReader {
+    /// Build a reader over `chunks`, or `None` when coalescing them would not
+    /// pay.
+    ///
+    /// `None` means the caller should read each chunk directly, which is the
+    /// answer whenever no two chunks are adjacent: every span would be a single
+    /// chunk, and serving it through the buffer would only add a copy. Reading
+    /// a chunk-per-row file whose writer had its chunk cache disabled — the one
+    /// layout measured with no adjacency at all — pays nothing for this.
+    pub(crate) fn new(chunks: &[ChunkInfo]) -> Option<Self> {
+        if chunks.len() < 2 {
+            return None;
+        }
+
+        let mut ranges: Vec<Span> = chunks
+            .iter()
+            .map(|c| Span {
+                start: c.address,
+                // A crafted address near `u64::MAX` saturates rather than
+                // wrapping; the read itself is bounds-checked by the source.
+                end: c.address.saturating_add(u64::from(c.chunk_size)),
+            })
+            .collect();
+        ranges.sort_unstable_by_key(|s| s.start);
+
+        let mut spans: Vec<Span> = Vec::new();
+        for range in ranges {
+            match spans.last_mut() {
+                // Adjacent to (or contained in) the span being built, and still
+                // within the budget measured from its start.
+                Some(last)
+                    if range.start <= last.end
+                        && range.end.saturating_sub(last.start) <= MAX_SPAN_BYTES as u64 =>
+                {
+                    last.end = last.end.max(range.end);
+                }
+                _ => spans.push(range),
+            }
+        }
+
+        // Nothing merged: every span is one chunk, so there is nothing to gain.
+        if spans.len() == chunks.len() {
+            return None;
+        }
+        Some(Self {
+            spans,
+            held: None,
+            buf: Vec::new(),
+            scratch: Vec::new(),
+        })
+    }
+
+    /// The bytes of the chunk at `address`, reading its span if it is not the
+    /// one already held.
+    pub(crate) fn chunk_bytes<S: Source + ?Sized>(
+        &mut self,
+        source: &S,
+        address: u64,
+        len: usize,
+    ) -> Result<&[u8], FormatError> {
+        let end = address.saturating_add(len as u64);
+
+        if !matches!(self.held, Some(span) if span.covers(address, end)) {
+            let Some(span) = self.span_containing(address, end) else {
+                // Not a chunk this reader was built over. Serve it directly and
+                // leave the held span alone.
+                self.scratch = source.read_exact_at(address, len)?;
+                return Ok(&self.scratch);
+            };
+            self.buf = source.read_exact_at(span.start, (span.end - span.start).to_usize()?)?;
+            self.held = Some(span);
+        }
+
+        let span = self.held.expect("held span set above");
+        let lo = (address - span.start).to_usize()?;
+        self.buf
+            .get(lo..lo + len)
+            .ok_or(FormatError::UnexpectedEof {
+                expected: lo + len,
+                available: self.buf.len(),
+            })
+    }
+
+    /// The span covering `[start, end)`, if this reader was built over a chunk
+    /// there.
+    fn span_containing(&self, start: u64, end: u64) -> Option<Span> {
+        let idx = match self.spans.binary_search_by_key(&start, |s| s.start) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        self.spans
+            .get(idx)
+            .copied()
+            .filter(|s| s.covers(start, end))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::BytesSource;
+    use core::cell::Cell;
+
+    /// A source that records every read it serves.
+    struct CountingSource {
+        bytes: Vec<u8>,
+        reads: Cell<usize>,
+        bytes_read: Cell<usize>,
+        largest: Cell<usize>,
+    }
+
+    impl CountingSource {
+        fn new(len: usize) -> Self {
+            Self {
+                bytes: (0..len).map(|i| i as u8).collect(),
+                reads: Cell::new(0),
+                bytes_read: Cell::new(0),
+                largest: Cell::new(0),
+            }
+        }
+    }
+
+    impl Source for CountingSource {
+        fn len(&self) -> u64 {
+            self.bytes.len() as u64
+        }
+
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.reads.set(self.reads.get() + 1);
+            self.bytes_read.set(self.bytes_read.get() + buf.len());
+            self.largest.set(self.largest.get().max(buf.len()));
+            BytesSource::new(&self.bytes).read_at(offset, buf)
+        }
+    }
+
+    /// `count` chunks of `size` bytes laid end to end from `start`.
+    fn run(start: u64, size: u32, count: usize) -> Vec<ChunkInfo> {
+        (0..count)
+            .map(|i| ChunkInfo {
+                chunk_size: size,
+                filter_mask: 0,
+                offsets: vec![i as u64],
+                address: start + i as u64 * u64::from(size),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn one_read_serves_a_whole_run_of_chunks() {
+        let chunks = run(16, 8, 100);
+        let source = CountingSource::new(4096);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("run of adjacent chunks coalesces");
+
+        for chunk in &chunks {
+            let bytes = reader.chunk_bytes(&source, chunk.address, 8).unwrap();
+            let expected: Vec<u8> = (chunk.address..chunk.address + 8)
+                .map(|b| b as u8)
+                .collect();
+            assert_eq!(bytes, &expected[..], "chunk at {}", chunk.address);
+        }
+
+        // One read for the whole run, and not a byte beyond it.
+        assert_eq!(source.reads.get(), 1);
+        assert_eq!(source.bytes_read.get(), 800);
+    }
+
+    #[test]
+    fn a_long_run_is_split_at_the_budget() {
+        // 40 chunks of 8 KiB is 320 KiB: more than one span, none over budget.
+        let chunks = run(0, 8192, 40);
+        let source = CountingSource::new(40 * 8192);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("adjacent chunks coalesce");
+
+        for chunk in &chunks {
+            let bytes = reader
+                .chunk_bytes(&source, chunk.address, chunk.chunk_size as usize)
+                .unwrap();
+            assert_eq!(bytes.len(), 8192);
+            assert_eq!(bytes[0], chunk.address as u8);
+        }
+
+        assert!(source.reads.get() > 1, "the run must not be read in one go");
+        assert!(
+            source.largest.get() <= MAX_SPAN_BYTES,
+            "a span read {} bytes, over the {MAX_SPAN_BYTES}-byte budget",
+            source.largest.get()
+        );
+        // Still exactly the chunk bytes, spread over the spans.
+        assert_eq!(source.bytes_read.get(), 40 * 8192);
+    }
+
+    #[test]
+    fn chunks_that_are_not_adjacent_are_left_to_the_direct_path() {
+        let scattered: Vec<ChunkInfo> = (0..16)
+            .map(|i| ChunkInfo {
+                chunk_size: 8,
+                filter_mask: 0,
+                offsets: vec![i],
+                address: i * 4096, // a gap between every pair
+            })
+            .collect();
+        assert!(ChunkSpanReader::new(&scattered).is_none());
+    }
+
+    #[test]
+    fn a_single_chunk_is_left_to_the_direct_path() {
+        assert!(ChunkSpanReader::new(&run(0, 64, 1)).is_none());
+    }
+
+    #[test]
+    fn a_partly_adjacent_layout_still_coalesces_its_runs() {
+        // Two runs of four, far apart: two spans, so two reads for eight chunks.
+        let mut chunks = run(0, 32, 4);
+        chunks.extend(run(100_000, 32, 4));
+        let source = CountingSource::new(200_000);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("two runs coalesce");
+
+        for chunk in &chunks {
+            reader.chunk_bytes(&source, chunk.address, 32).unwrap();
+        }
+        assert_eq!(source.reads.get(), 2);
+        assert_eq!(source.bytes_read.get(), 8 * 32);
+    }
+
+    #[test]
+    fn a_chunk_outside_every_span_is_read_directly() {
+        let chunks = run(0, 32, 8);
+        let source = CountingSource::new(200_000);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("adjacent chunks coalesce");
+
+        reader.chunk_bytes(&source, 0, 32).unwrap();
+        assert_eq!(source.reads.get(), 1);
+
+        // A chunk this reader was not built over still reads correctly...
+        let stray = reader.chunk_bytes(&source, 100_000, 4).unwrap().to_vec();
+        assert_eq!(stray, vec![160u8, 161, 162, 163]);
+        assert_eq!(source.reads.get(), 2);
+
+        // ...and does not cost the held span, which still serves its chunks.
+        reader.chunk_bytes(&source, 224, 32).unwrap();
+        assert_eq!(source.reads.get(), 2);
+    }
+
+    #[test]
+    fn a_chunk_larger_than_the_budget_is_read_on_its_own() {
+        // One 300 KiB chunk, then a run of small ones. The big chunk cannot
+        // join a span, so it is read alone — the same read it would have been
+        // without coalescing — and does not drag its neighbours over budget.
+        let big = MAX_SPAN_BYTES + 40 * 1024;
+        let mut chunks = vec![ChunkInfo {
+            chunk_size: big as u32,
+            filter_mask: 0,
+            offsets: vec![0],
+            address: 0,
+        }];
+        chunks.extend(run(big as u64, 64, 8));
+
+        let source = CountingSource::new(big + 8 * 64);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("the small chunks coalesce");
+
+        assert_eq!(reader.chunk_bytes(&source, 0, big).unwrap().len(), big);
+        assert_eq!(source.largest.get(), big, "the big chunk was read alone");
+
+        for chunk in &chunks[1..] {
+            reader.chunk_bytes(&source, chunk.address, 64).unwrap();
+        }
+        // The big chunk, then one span over the eight small ones.
+        assert_eq!(source.reads.get(), 2);
+        assert_eq!(source.bytes_read.get(), big + 8 * 64);
+    }
+
+    #[test]
+    fn chunks_are_served_whatever_order_they_are_asked_for() {
+        // The readers walk chunks in index order, which is not always address
+        // order; a span already held must serve either way.
+        let chunks = run(64, 16, 8);
+        let source = CountingSource::new(1024);
+        let mut reader = ChunkSpanReader::new(&chunks).expect("adjacent chunks coalesce");
+
+        for chunk in chunks.iter().rev() {
+            let bytes = reader.chunk_bytes(&source, chunk.address, 16).unwrap();
+            assert_eq!(bytes[0], chunk.address as u8);
+        }
+        assert_eq!(source.reads.get(), 1);
+    }
+}

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -4,10 +4,13 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec, vec::Vec};
+use alloc::{borrow::Cow, format, vec, vec::Vec};
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 use crate::btree_v1::btree_v1_node_header_size;
 use crate::chunk_cache::ChunkCache;
+use crate::chunk_span::ChunkSpanReader;
 use crate::convert::{TryToUsize, slice_range, u32_from};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
@@ -82,13 +85,20 @@ fn decompress_all_chunks_from_source<S: Source + ?Sized>(
     ctx: ChunkContext<'_>,
 ) -> Result<Vec<Vec<u8>>, FormatError> {
     let mut result = Vec::with_capacity(chunks.len());
+    let mut spans = ChunkSpanReader::new(chunks);
     for chunk_info in chunks {
-        let raw_chunk =
-            source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
-        let decompressed = if let Some(pl) = pipeline {
-            decompress_chunk(&raw_chunk, pl, ctx, chunk_info.filter_mask)?
-        } else {
-            raw_chunk
+        let len = chunk_info.chunk_size.to_usize()?;
+        let decompressed = match (spans.as_mut(), pipeline) {
+            (Some(sp), Some(pl)) => {
+                let raw = sp.chunk_bytes(source, chunk_info.address, len)?;
+                decompress_chunk(raw, pl, ctx, chunk_info.filter_mask)?
+            }
+            (Some(sp), None) => sp.chunk_bytes(source, chunk_info.address, len)?.to_vec(),
+            (None, Some(pl)) => {
+                let raw = source.read_exact_at(chunk_info.address, len)?;
+                decompress_chunk(&raw, pl, ctx, chunk_info.filter_mask)?
+            }
+            (None, None) => source.read_exact_at(chunk_info.address, len)?,
         };
         result.push(decompressed);
     }
@@ -987,6 +997,19 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
     let cd0 = chunk_dims[0];
 
+    // Coalesce over the chunks this window overlaps, not the dataset's whole
+    // chunk list: a span built over all of them would bridge chunks outside the
+    // window and read bytes the window does not want.
+    let overlapping: Vec<ChunkInfo> = chunks
+        .iter()
+        .filter(|chunk| {
+            let c0 = chunk.offsets.first().copied().unwrap_or(0).to_usize();
+            c0.is_ok_and(|c0| c0 < row_hi && c0.saturating_add(cd0) > row_lo)
+        })
+        .cloned()
+        .collect();
+    let mut spans = ChunkSpanReader::new(&overlapping);
+
     for chunk in &chunks {
         let c0 = chunk.offsets.first().copied().unwrap_or(0).to_usize()?;
         // This chunk's exclusive leading-dim end. The saturating add/mul here and
@@ -1056,7 +1079,11 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             continue;
         }
 
-        let raw = source.read_exact_at(chunk.address, chunk.chunk_size as usize)?;
+        let len = chunk.chunk_size as usize;
+        let raw = match spans.as_mut() {
+            Some(sp) => Cow::Borrowed(sp.chunk_bytes(source, chunk.address, len)?),
+            None => Cow::Owned(source.read_exact_at(chunk.address, len)?),
+        };
         match pipeline {
             Some(pl) => {
                 let dec = decompress_chunk(&raw, pl, ctx, chunk.filter_mask)?;
@@ -1204,6 +1231,8 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
 
+    let mut spans = ChunkSpanReader::new(&chunks);
+
     for chunk_info in &chunks {
         let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
         let chunk_offsets: Vec<usize> = chunk_info
@@ -1231,13 +1260,22 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
             continue;
         }
 
-        // Cache miss: fetch the chunk's bytes from the source (already owned).
-        let raw_chunk =
-            source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
-        let dec = if let Some(pl) = pipeline {
-            decompress_chunk(&raw_chunk, pl, ctx, chunk_info.filter_mask)?
-        } else {
-            raw_chunk
+        // Cache miss: fetch the chunk's bytes from the source.
+        let len = chunk_info.chunk_size.to_usize()?;
+        let raw_chunk = match spans.as_mut() {
+            Some(sp) => Cow::Borrowed(sp.chunk_bytes(source, chunk_info.address, len)?),
+            None => Cow::Owned(source.read_exact_at(chunk_info.address, len)?),
+        };
+        let dec = match pipeline {
+            Some(pl) => Cow::Owned(decompress_chunk(
+                &raw_chunk,
+                pl,
+                ctx,
+                chunk_info.filter_mask,
+            )?),
+            // Unfiltered: the chunk's stored bytes are its data, so they are
+            // copied out of the span only if the cache admits them.
+            None => raw_chunk,
         };
         place_chunk(
             &dec,
@@ -1250,7 +1288,10 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
             elem_size,
             rank,
         );
-        cache.put_decompressed(coord, dec); // move; dropped if not admitted
+        match dec {
+            Cow::Owned(bytes) => cache.put_decompressed(coord, bytes), // move
+            Cow::Borrowed(bytes) => cache.put_decompressed_slice(coord, bytes),
+        } // dropped if not admitted
     }
 
     Ok(output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub(crate) mod btree_v2;
 pub(crate) mod btree_v2_write;
 pub(crate) mod checksum;
 pub(crate) mod chunk_cache;
+pub(crate) mod chunk_span;
 pub(crate) mod chunked_read;
 pub(crate) mod chunked_write;
 pub(crate) mod compound;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -447,7 +447,11 @@ impl FileInner {
     /// This lets a host read a file larger than its address space — the original
     /// motivation being 32-bit targets reading multi-gigabyte files (issue #27).
     /// Metadata and dataset chunks are read through a `ReadSeekSource`, so peak
-    /// memory stays close to one chunk plus the metadata being parsed.
+    /// memory stays close to one chunk plus the metadata being parsed. Chunks
+    /// that sit next to each other on disk are fetched in one read of at most
+    /// 256 KiB rather than one read each, which is what makes a file written a
+    /// row at a time — thousands of chunks of a few dozen bytes — read at a
+    /// sensible speed.
     ///
     /// Reads match the buffered [`File::open`]: every storage layout and chunk
     /// index type, both group forms (v2 and v1 symbol-table), and compact,
@@ -1535,7 +1539,8 @@ impl File {
     ///
     /// This lets a host read a file larger than its address space. Metadata and
     /// dataset chunks are read through a `ReadSeekSource`, so peak memory stays
-    /// close to one chunk plus the metadata being parsed. Attribute reading and
+    /// close to one chunk plus the metadata being parsed; chunks adjacent on
+    /// disk are fetched in one read of at most 256 KiB. Attribute reading and
     /// v1 symbol-table groups on the resolved path are not yet supported on this
     /// backend.
     ///
@@ -4067,6 +4072,7 @@ fn is_group(header: &ObjectHeader) -> bool {
 mod tests {
     use super::*;
     use crate::FileBuilder;
+    use std::sync::atomic::AtomicUsize;
 
     /// Read everything a read-write file can serve through the paired read
     /// paths, as comparable text.
@@ -4398,6 +4404,123 @@ mod tests {
         assert!(
             matches!(err, FormatError::UnsupportedVirtualLayout),
             "expected UnsupportedVirtualLayout, got {err:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Coalesced chunk reads (see `crate::chunk_span`)
+    // -----------------------------------------------------------------------
+
+    /// A `Source` over a file image that counts the reads it serves, so a test
+    /// can assert what the streaming reader asks the file for.
+    struct CountingSource {
+        bytes: Vec<u8>,
+        reads: Arc<AtomicUsize>,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Source for CountingSource {
+        fn len(&self) -> u64 {
+            self.bytes.len() as u64
+        }
+
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            self.bytes_read.fetch_add(buf.len(), Ordering::Relaxed);
+            BytesSource::new(&self.bytes).read_at(offset, buf)
+        }
+    }
+
+    /// A streaming `File` over `bytes` whose reads are counted, as
+    /// `File::open_streaming` builds one over a file handle.
+    fn counting_streaming_file(
+        bytes: Vec<u8>,
+        reads: Arc<AtomicUsize>,
+        bytes_read: Arc<AtomicUsize>,
+    ) -> File {
+        let source: Box<dyn Source + Send + Sync> = Box::new(CountingSource {
+            bytes,
+            reads,
+            bytes_read,
+        });
+        let (superblock, addr_offset) =
+            FileInner::parse_superblock_source(source.as_ref()).expect("parse superblock");
+        File {
+            inner: Arc::new(FileInner::from_parts(
+                Backend::Streaming(source),
+                superblock,
+                addr_offset,
+                None,
+                FileAccessProperties::new(),
+            )),
+        }
+    }
+
+    /// One chunk per row is what a writer that appends as data arrives
+    /// produces; the rows land next to each other, so the streaming reader must
+    /// fetch them in a few spans rather than one read each.
+    #[test]
+    fn a_streaming_read_coalesces_a_run_of_small_chunks() {
+        let n = 1024usize;
+        let data: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let mut builder = FileBuilder::new();
+        builder
+            .create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[n as u64])
+            .with_chunks(&[1]);
+        let bytes = builder.finish().expect("write file");
+
+        let reads = Arc::new(AtomicUsize::new(0));
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let file = counting_streaming_file(bytes, Arc::clone(&reads), Arc::clone(&bytes_read));
+
+        let before = reads.load(Ordering::Relaxed);
+        let got = file.dataset("d").unwrap().read_f64().unwrap();
+        assert_eq!(got, data, "the coalesced read must return the same values");
+
+        // Reading each of the 1024 chunks on its own would cost at least that
+        // many reads; the whole run plus its metadata fits in far fewer.
+        let reads = reads.load(Ordering::Relaxed) - before;
+        assert!(
+            reads < n / 8,
+            "expected the {n} chunks to be coalesced into few reads, got {reads}"
+        );
+    }
+
+    /// A windowed read must coalesce only the chunks its window overlaps: a
+    /// span built over the dataset's whole chunk list would bridge the ones
+    /// outside it and read bytes the window never asked for.
+    #[test]
+    fn a_windowed_streaming_read_fetches_only_its_own_window() {
+        let rows = 4096usize;
+        let data: Vec<f64> = (0..rows).map(|i| i as f64).collect();
+        let mut builder = FileBuilder::new();
+        builder
+            .create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[rows as u64])
+            .with_chunks(&[4]);
+        let bytes = builder.finish().expect("write file");
+
+        let reads = Arc::new(AtomicUsize::new(0));
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let file = counting_streaming_file(bytes, Arc::clone(&reads), Arc::clone(&bytes_read));
+        let ds = file.dataset("d").unwrap();
+
+        // The first window walks (and caches on this handle) the chunk index,
+        // so measure the second: what it reads is the window's own chunks.
+        assert_eq!(ds.read_f64_rows(0, 8).unwrap(), data[0..8]);
+        let before = bytes_read.load(Ordering::Relaxed);
+        assert_eq!(ds.read_f64_rows(2048, 8).unwrap(), data[2048..2056]);
+        let window_bytes = bytes_read.load(Ordering::Relaxed) - before;
+
+        // Eight rows are two 32-byte chunks. A span over the whole chunk list
+        // would pull kilobytes of neighbouring rows instead.
+        assert!(
+            window_bytes < 256,
+            "a {}-row window read {window_bytes} bytes; it needs 64",
+            8
         );
     }
 }


### PR DESCRIPTION
`File::open_streaming` fetched one chunk per read. That is fine for the megabyte chunks a file written in one pass carries, and disastrous for a file written as the data arrived: a recorder appending a row at a time produces one chunk per row, so a 2.7 MB file of 73 datasets over 280 rows holds 20,440 chunks of 8 to 256 bytes. Reading it took 19.9 ms against 4.7 ms for the same read buffered — the file was read exactly once, 90 bytes at a time.

Those chunks are adjacent on disk. libhdf5 allocates a chunk when its chunk cache flushes rather than when the write is issued, so even a writer filling 73 datasets a row at a time lays each dataset's chunks down in one run (98.4% adjacent here, and byte-identical to writing the datasets one at a time). `ChunkSpanReader` merges a read's chunks into those runs and fetches each run in one call.

| Fixture (median of 10, warm cache) | Buffered | Streaming before | after |
| --- | --- | --- | --- |
| 73 datasets, one chunk per row, 20,440 chunks | 4.7 ms | 19.9 ms (4.2x) | 11.3 ms (2.4x) |
| the same file written with libhdf5's chunk cache off (no adjacency) | 4.8 ms | 20.8 ms | 20.8 ms |
| 8 datasets, 128 KiB chunks | 8.5 ms | 8.5 ms | 8.3 ms |

Data reads on the first file went from 20,661 to 616.

## What it does not spend

- **The memory bound.** A span stops at 256 KiB, so what this holds is bounded however large the dataset is. `tests/windowed_read_memory.rs` fails at 1 MiB, which is what pins the constant. A single chunk larger than the budget is read alone, as before.
- **Read volume.** Only exactly adjacent chunks merge, so a coalesced read fetches the same bytes the per-chunk reads would have. No gap bridging.
- **The layouts it does not help.** Where no two chunks are adjacent the reader declines and the direct path is unchanged, rather than paying a copy per chunk.
- **A window's precision.** A windowed row read coalesces only the chunks its window overlaps. Spans built over the dataset's whole chunk list made an eight-row window read 32 KB where it needed 64 bytes; that is a test.

## What is left on the table

The metadata reads this does not remove are now the larger cost: 11,615 of the 12,491 metadata reads that whole-file read issued were spent *opening* datasets, not reading them. Budgeting 1 MiB for `MetadataCacheConfig` takes the same read from 11.3 ms to 6.0 ms, against 4.7 ms buffered. That default is unchanged here — it retains memory per open file, which is a call worth making on its own — and the streaming guide records the measurement so it can be flipped on evidence.

## Verification

- `cargo test` green; `cargo test --lib --features parallel,zfp,ndarray` green.
- Mutation-checked: disabling coalescing fails six tests, and building window spans over the full chunk list fails the window test with `read 32768 bytes; it needs 64`.
- `cargo clippy --all-targets`, `cargo fmt --check`, `cargo check --no-default-features`, and `--target wasm32-unknown-unknown` clean.

No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)