### PR TITLE
Copy an attribute's encoding instead of rebuilding it from a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - An object header holding compact attributes declares how many it has, so `H5Oget_info().num_attrs` agrees with iteration instead of reporting zero — an `h5repack` round trip used to strip every `MATLAB_*` attribute from a `.mat` file without warning ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - A file with a userblock reads whole when it holds an object-header continuation block or dense link storage, which the C library writes and this crate does not; `File::open` used to fail outright on such a file ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - An empty MAT value carries `MATLAB_class` and `MATLAB_empty` and nothing else, matching MATLAB, and both emitters agree on its dimensions — including for an empty `Matrix`, which one of them wrote as a plain zero-element dataset ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
+- `repack` keeps each attribute's own datatype and shape instead of rebuilding it from an `AttrValue`, which widened every integer and float to 64 bits, turned a variable-length string into a fixed-width one, and flattened a rank-2 attribute to rank 1. Enumeration, compound, bit-field and opaque attributes are now carried across rather than refused; a reference attribute still is ([#241](https://github.com/stephenberry/hdf5-pure/issues/241)).
 
 ## [0.33.0] - 2026-08-02
 

--- a/docs/guide/groups-attributes.md
+++ b/docs/guide/groups-attributes.md
@@ -121,7 +121,7 @@ let fields: Option<Vec<&str>> = attrs.get("MATLAB_fields").and_then(AttrValue::a
 
 `as_i64`, `as_u64`, `as_f64`, `to_i64s`, `to_u64s` and `to_f64s` do the same for numbers. The prefix states the cost: `as_*` borrows or copies, `to_*` allocates. `as_i64` widens the narrower integer variants and reports `None` for a value above `i64::MAX` rather than wrapping it — per element, so the same holds for `to_i64s` at any length. The float accessors do not convert integers, so a caller that accepts either asks for both.
 
-What a read cannot recover, because `AttrValue` has no way to express it. Each of these reads correctly but would be rewritten differently:
+What a read cannot recover, because `AttrValue` has no way to express it. Each of these reads correctly, and each would come back differently if it were *rewritten from the value* — which is why [`repack`](repack.md) copies an attribute's encoding rather than rebuilding it from one:
 
 - **Width.** Integers and floats widen to `i64`/`u64`/`f64`; there are no narrower array variants.
 - **Variable-length strings.** A true `H5T_STRING` with `STRSIZE = VAR` — what h5py writes, and what this crate's writer never emits — has no variant of its own and reads as the fixed-width variant of the same charset.

--- a/docs/guide/repack.md
+++ b/docs/guide/repack.md
@@ -60,10 +60,13 @@ The operation is all-or-nothing: the entire source is validated and staged in me
 | Layout | contiguous / compact or chunked |
 | Filters | deflate, shuffle, fletcher32, LZF, and/or lossless integer scale-offset |
 | Structure | group hierarchy of arbitrary depth |
-| Attributes | numbers, fixed- and variable-length strings and their arrays, on datasets, groups, and root |
+| Attributes | every datatype above, carried across with the source's own encoding — width, charset, string padding, and rank included — on datasets, groups, and root |
 | File-space strategy | the source's strategy, page size, and threshold (carried forward as non-persistent) |
 
 A repacked file has no free space to persist, so even when the source recorded a persistent file-space strategy the compact output carries that strategy forward as non-persistent. See [File-space strategy](file-space.md) for what that controls.
+
+!!! note "Attributes keep their own encoding"
+    An attribute is copied as the source encoded it, not as `AttrValue` renders it. That matters because `AttrValue` is a deliberately lossy convenience view: it has no integer narrower than 64 bits, no variable-length string, and no rank above one, so an attribute rebuilt from one would come back widened and flattened. Only an attribute whose element bytes hold a *location* — variable-length data, or a reference — cannot be copied as-is; a variable-length string keeps its datatype and dataspace while its strings are restaged into the new file's heap, and a reference attribute is refused. See [Attributes](groups-attributes.md#attributes) for what a *read* still normalizes.
 
 !!! note "Lossless filters only"
     `repack` reads each dataset's *decompressed* bytes and re-applies its filters. It can therefore reproduce only **lossless** filters, where the re-encoded chunks decompress to the exact same bytes. This includes deflate, shuffle, fletcher32, LZF, and lossless integer scale-offset. See [Compression](compression.md) for the full filter list.
@@ -81,7 +84,7 @@ These are reported as `Error::RepackUnsupported` naming the object, never silent
 | virtual and external data layouts | not reproducible by rewriting |
 | lossy filters: float D-scale scale-offset and ZFP | re-encoding is not guaranteed idempotent |
 | SZIP filter | this crate cannot write it |
-| an attribute the reader cannot decode | e.g. an enumeration, compound, or boolean attribute |
+| an attribute whose datatype is or contains a reference | its stored address is not rewritten yet, and no `AttrValue` can re-encode it |
 
 ## Verifying the result
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -19,7 +19,11 @@ use crate::shared_message;
 use crate::source::Source;
 
 /// A parsed HDF5 attribute message.
-#[derive(Debug, Clone)]
+///
+/// `PartialEq` compares every field, which is what makes "this attribute crossed
+/// a rewrite unchanged" a single assertion — the shape repack's fidelity tests
+/// take.
+#[derive(Debug, Clone, PartialEq)]
 pub struct AttributeMessage {
     /// Attribute name.
     pub name: String,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -6637,15 +6637,15 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     };
     let mut attrs: Vec<crate::attribute::AttributeMessage> = Vec::with_capacity(db.attrs.len());
     for (n, v) in &db.attrs {
-        attrs.push(build_attr_message(n, v));
+        attrs.push(v.to_message(n));
     }
-    // `build_attr_message` already writes a placeholder (heap address 0) for a
-    // `VarLenAsciiArray` attribute; stage its self-contained global heap
-    // collections here (no address of their own to resolve yet) and record which
-    // `attrs` slot they patch once the apply loop places them.
+    // The message above already carries a placeholder (heap address 0) for each
+    // element of a variable-length string attribute; stage its self-contained
+    // global heap collections here (no address of their own to resolve yet) and
+    // record which `attrs` slot they patch once the apply loop places them.
     let mut vl_attrs: Vec<(usize, Vec<Vec<u8>>)> = Vec::new();
     for (i, (_, v)) in db.attrs.iter().enumerate() {
-        if let AttrValue::VarLenAsciiArray(strings) = v {
+        if let Some(strings) = v.var_len_strings() {
             let str_refs: Vec<&str> = strings.iter().map(String::as_str).collect();
             vl_attrs.push((i, build_global_heap_collections(&str_refs)));
         }

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -37,7 +37,7 @@ use crate::message_type::MessageType;
 use crate::object_header_writer::ObjectHeaderWriter;
 use crate::superblock::Superblock;
 use crate::type_builders::{
-    DatasetBuilder, FinishedGroup, GroupBuilder, VlStringStaging, build_attr_message,
+    AttrSpec, DatasetBuilder, FinishedGroup, GroupBuilder, VlStringStaging,
     build_global_heap_collections, patch_vl_refs, patch_vl_refs_masked, write_reference_address,
 };
 
@@ -748,7 +748,7 @@ pub(crate) fn write_undef_offset(buf: &mut Vec<u8>, offset_size: u8) {
 /// The main file creation API.
 pub struct FileWriter {
     root_datasets: Vec<DatasetBuilder>,
-    root_attrs: Vec<(String, AttrValue)>,
+    root_attrs: Vec<(String, AttrSpec)>,
     groups: Vec<FinishedGroup>,
     userblock_size: u64,
     /// Bytes to emit at the head of the userblock region, from
@@ -985,7 +985,33 @@ impl FileWriter {
     }
 
     pub fn set_root_attr(&mut self, name: &str, value: AttrValue) {
-        self.root_attrs.push((name.to_string(), value));
+        self.root_attrs
+            .push((name.to_string(), AttrSpec::Value(value)));
+    }
+
+    /// Attach an already-encoded attribute message to the root group, written
+    /// exactly as given.
+    ///
+    /// See [`AttrSpec::Verbatim`] for what this preserves that `set_root_attr`
+    /// cannot, and for the datatypes it must not be used with.
+    pub(crate) fn set_root_attr_verbatim(&mut self, message: crate::attribute::AttributeMessage) {
+        self.root_attrs
+            .push((message.name.clone(), AttrSpec::Verbatim(message)));
+    }
+
+    /// Attach a variable-length string attribute to the root group with the given
+    /// datatype and dataspace, staging `strings` into a heap of this file's own.
+    /// See [`AttrSpec::VerbatimVarLen`].
+    pub(crate) fn set_root_attr_var_len_verbatim(
+        &mut self,
+        mut message: crate::attribute::AttributeMessage,
+        strings: Vec<String>,
+    ) {
+        message.raw_data = crate::type_builders::vl_string_reference_bytes(&strings);
+        self.root_attrs.push((
+            message.name.clone(),
+            AttrSpec::VerbatimVarLen { message, strings },
+        ));
     }
 
     pub fn finish(self) -> Result<Vec<u8>, FormatError> {
@@ -1419,7 +1445,7 @@ impl FileWriter {
             let patches = collect_vl_patches(&db.attrs);
             let mut attrs = Vec::new();
             for (n, v) in &db.attrs {
-                attrs.push(build_attr_message(n, v));
+                attrs.push(v.to_message(n));
             }
             #[cfg(feature = "provenance")]
             if let Some(ref prov) = db.provenance {
@@ -1470,7 +1496,7 @@ impl FileWriter {
             let patches = collect_vl_patches(&g.attrs);
             let mut gattrs = Vec::new();
             for (n, v) in &g.attrs {
-                gattrs.push(build_attr_message(n, v));
+                gattrs.push(v.to_message(n));
             }
             let mut ds_idx = Vec::new();
             for db in g.datasets {
@@ -1532,10 +1558,10 @@ impl FileWriter {
                 .collect()
         }
 
-        fn collect_vl_patches(attrs_raw: &[(String, AttrValue)]) -> Vec<VlPatch> {
+        fn collect_vl_patches(attrs_raw: &[(String, AttrSpec)]) -> Vec<VlPatch> {
             let mut patches = Vec::new();
             for (i, (_n, v)) in attrs_raw.iter().enumerate() {
-                if let AttrValue::VarLenAsciiArray(strings) = v {
+                if let Some(strings) = v.var_len_strings() {
                     let str_refs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
                     patches.push(VlPatch {
                         collections: build_global_heap_collections(&str_refs),
@@ -1550,7 +1576,7 @@ impl FileWriter {
 
         let mut root_attrs: Vec<AttributeMessage> = Vec::new();
         for (n, v) in &self.root_attrs {
-            root_attrs.push(build_attr_message(n, v));
+            root_attrs.push(v.to_message(n));
         }
 
         let root_dense = needs_dense_attrs(&root_attrs);
@@ -2831,6 +2857,7 @@ mod tests {
     use crate::link_info::LinkInfoMessage;
     use crate::object_header::ObjectHeader;
     use crate::signature;
+    use crate::type_builders::build_attr_message;
 
     fn parse_file(bytes: &[u8]) -> (Superblock, ObjectHeader) {
         let sig = signature::find_signature(bytes).unwrap();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1148,21 +1148,9 @@ impl FileInner {
         }
     }
 
-    /// Names of every attribute message on `hdr`, including ones whose datatype
-    /// [`attrs_of`](Self::attrs_of) cannot decode into an [`AttrValue`] (and so
-    /// silently omits from its map). Repack diffs this against the decoded map to
-    /// refuse rather than drop an attribute it cannot reproduce.
-    pub(crate) fn attr_message_names_of(&self, hdr: &ObjectHeader) -> Result<Vec<String>, Error> {
-        Ok(self
-            .attr_messages_of(hdr)?
-            .into_iter()
-            .map(|a| a.name)
-            .collect())
-    }
-
     /// Extract every attribute message attached to an object header (compact,
     /// shared, and dense storage), dispatching on the backend.
-    fn attr_messages_of(
+    pub(crate) fn attr_messages_of(
         &self,
         hdr: &ObjectHeader,
     ) -> Result<Vec<crate::attribute::AttributeMessage>, Error> {
@@ -2444,12 +2432,16 @@ impl Group {
         self.file.attrs_of(&hdr)
     }
 
-    /// Names of every attribute on this group, including any whose datatype
-    /// [`attrs`](Self::attrs) cannot represent. Used by repack to detect an
-    /// attribute it would otherwise drop.
-    pub(crate) fn attr_names(&self) -> Result<Vec<String>, Error> {
+    /// Every attribute message on this group as it is encoded on disk, in the
+    /// order the header holds them.
+    ///
+    /// [`attrs`](Self::attrs) decodes each into an [`AttrValue`], which loses the
+    /// encoding; this keeps it. Repack copies from here so an attribute survives
+    /// a rewrite unchanged, and falls back to the decoded map only where the
+    /// bytes are not position-independent.
+    pub(crate) fn attr_messages(&self) -> Result<Vec<crate::attribute::AttributeMessage>, Error> {
         let hdr = self.file.parse_header(self.address)?;
-        self.file.attr_message_names_of(&hdr)
+        self.file.attr_messages_of(&hdr)
     }
 
     /// Get a dataset within this group by name.
@@ -3655,11 +3647,13 @@ impl Dataset {
         self.file.attrs_of(&self.header)
     }
 
-    /// Names of every attribute on this dataset, including any whose datatype
-    /// [`attrs`](Self::attrs) cannot represent. Used by repack to detect an
-    /// attribute it would otherwise drop.
-    pub(crate) fn attr_names(&self) -> Result<Vec<String>, Error> {
-        self.file.attr_message_names_of(&self.header)
+    /// Every attribute message on this dataset as it is encoded on disk, in the
+    /// order the header holds them.
+    ///
+    /// See [`Group::attr_messages`] for why repack reads these rather than the
+    /// decoded map.
+    pub(crate) fn attr_messages(&self) -> Result<Vec<crate::attribute::AttributeMessage>, Error> {
+        self.file.attr_messages_of(&self.header)
     }
 
     /// Returns the exact HDF5 datatype, including compound field offsets and

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -44,8 +44,10 @@
 //!   rewritten to its target object's new location in the compacted file (null
 //!   and undefined references are carried verbatim).
 //! - Group hierarchy of arbitrary depth.
-//! - Attributes representable as [`AttrValue`] (numbers, fixed and
-//!   variable-length strings and their arrays), on datasets, groups, and root.
+//! - Attributes, on datasets, groups, and root, carried across with the
+//!   encoding the source gave them rather than rebuilt from an [`AttrValue`],
+//!   which is a decoded view and cannot express a narrow width, a
+//!   variable-length string, or a rank above one.
 //! - The source file's file-space management strategy (with its page size and
 //!   threshold), carried into the compact output as non-persistent — a repacked
 //!   file has no free space to persist.
@@ -68,10 +70,10 @@
 //! target), and object references in a userblock file (non-zero base address); a
 //! non-string vlen sequence whose base type embeds an address (nested vlen or
 //! reference); virtual and external data layouts; a lossy filter on the
-//! contiguous re-encode or sparse-chunked fallback path; and any attribute whose
-//! datatype the reader cannot decode into an [`AttrValue`] (e.g. an enumeration,
-//! compound, reference, or boolean attribute). An object that cannot be
-//! reproduced fails the repack by name rather than being silently dropped.
+//! contiguous re-encode or sparse-chunked fallback path; and an attribute whose
+//! datatype is or contains a reference (its stored address is not rewritten yet,
+//! and no [`AttrValue`] can re-encode it). An object that cannot be reproduced
+//! fails the repack by name rather than being silently dropped.
 //!
 //! # Memory
 //!
@@ -85,10 +87,11 @@
 //!
 //! [#82]: https://github.com/stephenberry/hdf5-pure/issues/82
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::attribute::AttributeMessage;
 use crate::chunked_read::ChunkInfo;
 use crate::chunked_write::{ChunkMeta, ChunkProvider};
 use crate::convert::TryToUsize;
@@ -302,10 +305,54 @@ pub fn repack<P: AsRef<Path>, Q: AsRef<Path>>(
 /// A destination that group contents can be added to. Implemented for both the
 /// top-level [`FileBuilder`] (the root group) and [`GroupBuilder`] (subgroups)
 /// so one recursive walk handles every level.
-trait GroupSink {
+trait GroupSink: AttrSink {
     fn sink_dataset(&mut self, name: &str) -> &mut DatasetBuilder;
     fn sink_add_group(&mut self, group: FinishedGroup);
+}
+
+/// Anything a repacked attribute can be attached to: the root group, a subgroup,
+/// or a dataset. Split from [`GroupSink`] because a dataset takes attributes but
+/// holds no children, so one attribute-copying routine serves all three.
+trait AttrSink {
     fn sink_set_attr(&mut self, name: &str, value: AttrValue);
+    fn sink_set_attr_verbatim(&mut self, message: AttributeMessage);
+    fn sink_set_attr_var_len_verbatim(&mut self, message: AttributeMessage, strings: Vec<String>);
+}
+
+impl AttrSink for FileBuilder {
+    fn sink_set_attr(&mut self, name: &str, value: AttrValue) {
+        self.set_attr(name, value);
+    }
+    fn sink_set_attr_verbatim(&mut self, message: AttributeMessage) {
+        self.set_attr_verbatim(message);
+    }
+    fn sink_set_attr_var_len_verbatim(&mut self, message: AttributeMessage, strings: Vec<String>) {
+        self.set_attr_var_len_verbatim(message, strings);
+    }
+}
+
+impl AttrSink for GroupBuilder {
+    fn sink_set_attr(&mut self, name: &str, value: AttrValue) {
+        self.set_attr(name, value);
+    }
+    fn sink_set_attr_verbatim(&mut self, message: AttributeMessage) {
+        self.set_attr_verbatim(message);
+    }
+    fn sink_set_attr_var_len_verbatim(&mut self, message: AttributeMessage, strings: Vec<String>) {
+        self.set_attr_var_len_verbatim(message, strings);
+    }
+}
+
+impl AttrSink for DatasetBuilder {
+    fn sink_set_attr(&mut self, name: &str, value: AttrValue) {
+        self.set_attr(name, value);
+    }
+    fn sink_set_attr_verbatim(&mut self, message: AttributeMessage) {
+        self.set_attr_verbatim(message);
+    }
+    fn sink_set_attr_var_len_verbatim(&mut self, message: AttributeMessage, strings: Vec<String>) {
+        self.set_attr_var_len_verbatim(message, strings);
+    }
 }
 
 impl GroupSink for FileBuilder {
@@ -315,9 +362,6 @@ impl GroupSink for FileBuilder {
     fn sink_add_group(&mut self, group: FinishedGroup) {
         self.add_group(group);
     }
-    fn sink_set_attr(&mut self, name: &str, value: AttrValue) {
-        self.set_attr(name, value);
-    }
 }
 
 impl GroupSink for GroupBuilder {
@@ -326,9 +370,6 @@ impl GroupSink for GroupBuilder {
     }
     fn sink_add_group(&mut self, group: FinishedGroup) {
         self.add_group(group);
-    }
-    fn sink_set_attr(&mut self, name: &str, value: AttrValue) {
-        self.set_attr(name, value);
     }
 }
 
@@ -344,18 +385,14 @@ fn populate<S: GroupSink>(
     file: &Arc<File>,
     addr_map: &HashMap<u64, String>,
 ) -> Result<(), Error> {
-    // Attributes, in name order for a deterministic output. Refuse if any
-    // attribute on this group cannot be represented (and would be dropped).
-    let attrs = src.attrs()?;
+    // Attributes, copied verbatim where their bytes travel and re-encoded where
+    // they do not; refused rather than dropped if neither is possible.
     let owner = if path.is_empty() {
         "root group".to_string()
     } else {
         format!("group {path}")
     };
-    check_attr_completeness(&attrs, &src.attr_names()?, &owner)?;
-    for (name, value) in sorted(attrs) {
-        sink.sink_set_attr(&name, value);
-    }
+    copy_attrs(sink, src.attr_messages()?, || src.attrs(), &owner)?;
 
     // Datasets, sorted by name.
     let mut dataset_names = src.datasets()?;
@@ -456,11 +493,12 @@ fn emit_dataset(
     if is_vlen_string_datatype(&datatype) {
         emit_vlen_string_dataset(db, ds, path, &datatype, &dims, &layout, &pipeline)?;
         // VL-string datasets carry attributes the same way as any other.
-        let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-        for (name, value) in sorted(attrs) {
-            db.set_attr(&name, value);
-        }
+        copy_attrs(
+            db,
+            ds.attr_messages()?,
+            || ds.attrs(),
+            &format!("dataset {path}"),
+        )?;
         return Ok(());
     }
 
@@ -471,11 +509,12 @@ fn emit_dataset(
     // path so a chunked one is refused (not copied with stale references).
     if is_nonstring_vlen(&datatype) {
         emit_vlen_sequence_dataset(db, ds, path, &datatype, &dims, &layout, &pipeline)?;
-        let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-        for (name, value) in sorted(attrs) {
-            db.set_attr(&name, value);
-        }
+        copy_attrs(
+            db,
+            ds.attr_messages()?,
+            || ds.attrs(),
+            &format!("dataset {path}"),
+        )?;
         return Ok(());
     }
 
@@ -486,11 +525,12 @@ fn emit_dataset(
     // chunked one is refused (not copied with stale addresses).
     if is_object_reference(&datatype) {
         emit_object_reference_dataset(db, ds, path, &dims, &layout, file, drop, addr_map)?;
-        let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-        for (name, value) in sorted(attrs) {
-            db.set_attr(&name, value);
-        }
+        copy_attrs(
+            db,
+            ds.attr_messages()?,
+            || ds.attrs(),
+            &format!("dataset {path}"),
+        )?;
         return Ok(());
     }
 
@@ -520,11 +560,12 @@ fn emit_dataset(
             drop,
             addr_map,
         )?;
-        let attrs = ds.attrs()?;
-        check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-        for (name, value) in sorted(attrs) {
-            db.set_attr(&name, value);
-        }
+        copy_attrs(
+            db,
+            ds.attr_messages()?,
+            || ds.attrs(),
+            &format!("dataset {path}"),
+        )?;
         return Ok(());
     }
 
@@ -582,11 +623,12 @@ fn emit_dataset(
 
             // Carry the dataset's attributes, refusing any that cannot be
             // represented.
-            let attrs = ds.attrs()?;
-            check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-            for (name, value) in sorted(attrs) {
-                db.set_attr(&name, value);
-            }
+            copy_attrs(
+                db,
+                ds.attr_messages()?,
+                || ds.attrs(),
+                &format!("dataset {path}"),
+            )?;
             return Ok(());
         }
 
@@ -620,11 +662,12 @@ fn emit_dataset(
     );
 
     // Carry the dataset's attributes, refusing if any cannot be represented.
-    let attrs = ds.attrs()?;
-    check_attr_completeness(&attrs, &ds.attr_names()?, &format!("dataset {path}"))?;
-    for (name, value) in sorted(attrs) {
-        db.set_attr(&name, value);
-    }
+    copy_attrs(
+        db,
+        ds.attr_messages()?,
+        || ds.attrs(),
+        &format!("dataset {path}"),
+    )?;
 
     Ok(())
 }
@@ -1027,17 +1070,107 @@ fn try_plan_dense_chunks(
     Ok(Some(DenseChunkPlan { meta, grid_order }))
 }
 
-/// Refuse the repack if `owner` has an attribute the reader cannot represent as
-/// an [`AttrValue`] and would therefore drop. `names` is every attribute on the
-/// object; `decoded` is the subset that read back, keyed by name. Any name not
-/// in `decoded` is an attribute that would be silently lost.
-fn check_attr_completeness(
-    decoded: &std::collections::HashMap<String, AttrValue>,
-    names: &[String],
+/// Whether an attribute's element bytes mean the same thing in another file.
+///
+/// An attribute message is otherwise self-contained — name, datatype, dataspace
+/// and data all travel together — so the only thing that stops a byte-for-byte
+/// copy is an element that stores a *location* rather than a value: a
+/// variable-length datum, whose bytes are a global-heap collection address plus
+/// an index, and a reference, whose bytes are an object-header address. Both
+/// point into the source file and would dangle in the destination.
+///
+/// Nested occurrences count: a compound with a variable-length member, or an
+/// array of references, embeds the same address inside each element.
+///
+/// Every class is named rather than defaulted through a `_` arm, so adding one to
+/// [`Datatype`] stops the build here and forces the question to be answered. A
+/// wrong answer in the permissive direction writes a dangling address into the
+/// copy and returns `Ok`, which is precisely the failure this function exists to
+/// prevent, so the compiler is the right place to catch a new class rather than
+/// a default that silently picks a side.
+fn attr_bytes_are_position_independent(dt: &Datatype) -> bool {
+    match dt {
+        Datatype::FixedPoint { .. }
+        | Datatype::FloatingPoint { .. }
+        | Datatype::Time { .. }
+        | Datatype::String { .. }
+        | Datatype::BitField { .. }
+        | Datatype::Opaque { .. } => true,
+        Datatype::Compound { members, .. } => members
+            .iter()
+            .all(|m| attr_bytes_are_position_independent(&m.datatype)),
+        Datatype::Enumeration { base_type, .. } | Datatype::Array { base_type, .. } => {
+            attr_bytes_are_position_independent(base_type)
+        }
+        Datatype::VariableLength { .. } | Datatype::Reference { .. } => false,
+    }
+}
+
+/// Copy every attribute of `owner` onto `sink`, in name order for a
+/// deterministic output.
+///
+/// An attribute whose bytes are position-independent is copied *verbatim*: the
+/// source's own datatype, dataspace and element bytes go straight into the
+/// destination message. That is what keeps a rewrite faithful, because
+/// [`AttrValue`] is a decoded view and cannot express an integer narrower than
+/// 64 bits, a variable-length string, a rank above one, or a string's padding —
+/// so anything routed through it comes out re-encoded as the widest variant of
+/// its class, flattened to rank 1 (issue #241).
+///
+/// The rest — variable-length data and references — hold source-file addresses,
+/// so their bytes cannot travel. Those fall back to `decode`, the decoded
+/// [`AttrValue`] map, which the writer re-encodes against a heap of the
+/// destination's own. An attribute that has no representation there either is
+/// refused rather than dropped.
+///
+/// A variable-length *string* takes a third path, because the two above each get
+/// half of it wrong: its element bytes address the source heap and cannot be
+/// copied, but its datatype and dataspace say "variable-length UTF-8" and
+/// "scalar", neither of which [`AttrValue`] can express — so a plain re-encode
+/// turns `str` into `bytes` for every consumer. Keeping the source's datatype and
+/// dataspace while restaging only the strings gets both halves. This is the
+/// common case in practice, not an exotic one: it is what `h5py` writes for
+/// every plain-string attribute.
+///
+/// `decode` is a closure so the decoding pass is paid for only when some
+/// attribute actually needs it, which for most objects is never.
+fn copy_attrs<S, F>(
+    sink: &mut S,
+    mut messages: Vec<AttributeMessage>,
+    decode: F,
     owner: &str,
-) -> Result<(), Error> {
-    for name in names {
-        if !decoded.contains_key(name) {
+) -> Result<(), Error>
+where
+    S: AttrSink + ?Sized,
+    F: FnOnce() -> Result<std::collections::HashMap<String, AttrValue>, Error>,
+{
+    messages.sort_by(|a, b| a.name.cmp(&b.name));
+    let any_needs_decoding = messages
+        .iter()
+        .any(|m| !attr_bytes_are_position_independent(&m.datatype));
+    let decoded = if any_needs_decoding {
+        decode()?
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    for message in messages {
+        if attr_bytes_are_position_independent(&message.datatype) {
+            sink.sink_set_attr_verbatim(message);
+        } else if let Some(value) = decoded.get(&message.name) {
+            // A variable-length datatype the decode resolved into strings is
+            // exactly the case that keeps its datatype and dataspace but restages
+            // its payload. Gating on what the decode *produced* rather than
+            // re-classifying the datatype here keeps the two from drifting apart.
+            match (&message.datatype, value.as_strings()) {
+                (Datatype::VariableLength { .. }, Some(strings)) => {
+                    let strings = strings.to_vec();
+                    sink.sink_set_attr_var_len_verbatim(message, strings);
+                }
+                _ => sink.sink_set_attr(&message.name, value.clone()),
+            }
+        } else {
+            let name = &message.name;
             return Err(Error::RepackUnsupported(format!(
                 "{owner}: attribute {name:?} has a datatype that cannot be repacked faithfully yet"
             )));
@@ -1506,15 +1639,6 @@ fn check_pipeline(pipeline: Option<&FilterPipeline>, path: &str) -> Result<(), E
     Ok(())
 }
 
-/// Sort a name→value attribute map into a deterministic, ordered list.
-fn sorted(attrs: std::collections::HashMap<String, AttrValue>) -> Vec<(String, AttrValue)> {
-    attrs
-        .into_iter()
-        .collect::<BTreeMap<_, _>>()
-        .into_iter()
-        .collect()
-}
-
 /// Canonicalize a path to slash-free form: split on `/`, drop empty components,
 /// rejoin. `"/a//b/"` and `"a/b"` both become `"a/b"`.
 fn normalize(path: &str) -> String {
@@ -1632,5 +1756,384 @@ mod tests {
         assert!(!is_dropped("g/older", &drop));
         assert!(!is_dropped("lonely", &drop));
         assert!(!is_dropped("other/old", &drop));
+    }
+}
+
+/// Repack must carry an attribute across *as it is encoded*, not as
+/// [`AttrValue`] renders it.
+///
+/// These sit at the library level rather than in `tests/` because the encoding
+/// is the thing under test and only [`Group::attr_messages`] exposes it; a
+/// public read decodes, and a decode is exactly what erases the difference
+/// (issue #241).
+#[cfg(test)]
+mod attribute_fidelity_tests {
+    use super::*;
+    use crate::dataspace::{Dataspace, DataspaceType};
+    use crate::datatype::{
+        CharacterSet, CompoundMember, DatatypeByteOrder, ReferenceType, StringPadding,
+    };
+    use crate::{File, FileBuilder, RepackOptions};
+    use std::collections::BTreeMap;
+
+    fn i32_type() -> Datatype {
+        Datatype::FixedPoint {
+            size: 4,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            signed: true,
+            bit_offset: 0,
+            bit_precision: 32,
+        }
+    }
+
+    /// Attribute messages keyed by name, for an object reached by `path`
+    /// (`""` for the root group).
+    fn messages_at(path: &str, file: &Path) -> BTreeMap<String, AttributeMessage> {
+        let f = File::open(file).unwrap();
+        let messages = if path.is_empty() {
+            f.root().attr_messages().unwrap()
+        } else if let Ok(ds) = f.dataset(path) {
+            ds.attr_messages().unwrap()
+        } else {
+            f.group(path).unwrap().attr_messages().unwrap()
+        };
+        messages.into_iter().map(|m| (m.name.clone(), m)).collect()
+    }
+
+    /// The core claim, stated as an identity rather than as a list of properties:
+    /// every attribute whose bytes are position-independent comes out of a repack
+    /// as the very message that went in.
+    ///
+    /// Asserting the whole message covers width, charset, string padding,
+    /// dataspace kind and rank, and the element bytes together — including the
+    /// ones no accessor on this crate would notice, since a decode normalizes a
+    /// narrow integer to `i64` on *both* sides of the comparison and so cannot
+    /// see the widening at all. It also covers all three kinds of owner, because
+    /// the root group, a subgroup and a dataset each reach the writer by a
+    /// different path.
+    #[test]
+    fn a_position_independent_attribute_crosses_a_repack_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let (src, dst) = (dir.path().join("src.h5"), dir.path().join("dst.h5"));
+
+        let attrs = || {
+            [
+                // The width cases: `AttrValue` has no narrow *array* variants and
+                // no narrow scalars past 32 bits, so each of these is a decode
+                // that would widen.
+                ("i32", AttrValue::I32(-7)),
+                ("u32", AttrValue::U32(4_294_967_295)),
+                // Charset and padding: an ASCII string and a UTF-8 one differ only
+                // in the datatype's charset bit.
+                ("ascii", AttrValue::AsciiString("m/s".into())),
+                ("utf8", AttrValue::String("µm".into())),
+                // A scalar and a one-element array are different dataspaces.
+                ("one_elem", AttrValue::I64Array(vec![9])),
+                ("scalar", AttrValue::I64(9)),
+                ("f64s", AttrValue::F64Array(vec![1.5, -2.5])),
+            ]
+        };
+
+        let mut b = FileBuilder::new();
+        for (name, value) in attrs() {
+            b.set_attr(name, value);
+        }
+        let ds = b.create_dataset("data").with_f64_data(&[1.0, 2.0]);
+        for (name, value) in attrs() {
+            ds.set_attr(name, value);
+        }
+        let mut g = b.create_group("grp");
+        for (name, value) in attrs() {
+            g.set_attr(name, value);
+        }
+        g.create_dataset("inner").with_i32_data(&[1]);
+        b.add_group(g.finish());
+        b.write(&src).unwrap();
+
+        repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+        for owner in ["", "data", "grp"] {
+            let before = messages_at(owner, &src);
+            let after = messages_at(owner, &dst);
+            assert_eq!(
+                before.keys().collect::<Vec<_>>(),
+                after.keys().collect::<Vec<_>>(),
+                "repack changed which attributes {owner:?} has"
+            );
+            for (name, source_message) in &before {
+                assert_eq!(
+                    after.get(name),
+                    Some(source_message),
+                    "attribute {name:?} on {owner:?} was re-encoded rather than copied"
+                );
+            }
+        }
+    }
+
+    /// The two rows of issue #241's table that the reference C library's own API
+    /// cannot express, so no crosscheck can state them: a fixed-width string's
+    /// *padding*, and a Null dataspace.
+    ///
+    /// The source here is built through the same verbatim seam the fix
+    /// introduced, which is the only way this crate can write these encodings —
+    /// but the file is written, closed and re-read, so what is compared is what
+    /// two independent parses of two real files made of them, not a struct
+    /// handed back to itself.
+    #[test]
+    fn an_encoding_this_crate_has_no_attr_value_for_still_crosses_a_repack() {
+        let dir = tempfile::tempdir().unwrap();
+        let (src, dst) = (dir.path().join("src.h5"), dir.path().join("dst.h5"));
+
+        let exotic = [
+            // Declared width 16 for three bytes of content, null-*terminated* —
+            // the writer's own fixed-width path hardcodes null-padding, so a
+            // rebuild from a value changes both.
+            AttributeMessage {
+                name: "units".into(),
+                datatype: Datatype::String {
+                    size: 16,
+                    padding: StringPadding::NullTerminate,
+                    charset: CharacterSet::Ascii,
+                },
+                dataspace: Dataspace {
+                    space_type: DataspaceType::Scalar,
+                    rank: 0,
+                    dimensions: vec![],
+                    max_dimensions: None,
+                },
+                raw_data: {
+                    let mut v = b"m/s".to_vec();
+                    v.resize(16, 0);
+                    v
+                },
+            },
+            // Space-padded, to prove the padding field is carried rather than
+            // normalized to whichever value happens to be first.
+            AttributeMessage {
+                name: "spaced".into(),
+                datatype: Datatype::String {
+                    size: 8,
+                    padding: StringPadding::SpacePad,
+                    charset: CharacterSet::Utf8,
+                },
+                dataspace: Dataspace {
+                    space_type: DataspaceType::Scalar,
+                    rank: 0,
+                    dimensions: vec![],
+                    max_dimensions: None,
+                },
+                raw_data: b"ab      ".to_vec(),
+            },
+            // A Null dataspace holds no elements at all, which is distinct from a
+            // rank-1 dataspace of length zero — the shape a decode gives it.
+            AttributeMessage {
+                name: "nothing".into(),
+                datatype: i32_type(),
+                dataspace: Dataspace {
+                    space_type: DataspaceType::Null,
+                    rank: 0,
+                    dimensions: vec![],
+                    max_dimensions: None,
+                },
+                raw_data: vec![],
+            },
+            // Rank 2, which every `AttrValue` array variant flattens.
+            AttributeMessage {
+                name: "grid".into(),
+                datatype: i32_type(),
+                dataspace: Dataspace {
+                    space_type: DataspaceType::Simple,
+                    rank: 2,
+                    dimensions: vec![2, 3],
+                    max_dimensions: None,
+                },
+                raw_data: (1i32..=6).flat_map(i32::to_le_bytes).collect(),
+            },
+        ];
+
+        let mut b = FileBuilder::new();
+        for message in &exotic {
+            b.set_attr_verbatim(message.clone());
+        }
+        let ds = b.create_dataset("data").with_f64_data(&[1.0]);
+        for message in &exotic {
+            ds.set_attr_verbatim(message.clone());
+        }
+        b.write(&src).unwrap();
+
+        repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+        for owner in ["", "data"] {
+            let before = messages_at(owner, &src);
+            let after = messages_at(owner, &dst);
+            for message in &exotic {
+                let name = &message.name;
+                // The source file must really hold what was asked for, or the
+                // comparison below would only prove repack is self-consistent.
+                assert_eq!(
+                    before.get(name),
+                    Some(message),
+                    "the source file did not record {name:?} as written"
+                );
+                assert_eq!(
+                    after.get(name),
+                    Some(message),
+                    "attribute {name:?} on {owner:?} changed across the repack"
+                );
+            }
+        }
+        c_library_reads_every_attribute(&dst, exotic.len());
+    }
+
+    /// The repacked file, read by the reference C library rather than by the
+    /// reader that wrote it.
+    ///
+    /// Without this the test above proves only that this crate agrees with
+    /// itself, which a message it encodes wrongly and parses back just as wrongly
+    /// would satisfy. These encodings reach the file through an internal seam
+    /// with no public spelling, so nothing else in the suite would catch that.
+    #[cfg(not(target_pointer_width = "32"))]
+    fn c_library_reads_every_attribute(file: &Path, expected: usize) {
+        let c = hdf5::File::open(file).expect("the C library must open the repacked file");
+        for names in [
+            c.attr_names().expect("root attribute names"),
+            c.dataset("data")
+                .expect("dataset")
+                .attr_names()
+                .expect("dataset attribute names"),
+        ] {
+            assert_eq!(
+                names.len(),
+                expected,
+                "the C library found {names:?}, not all {expected} attributes"
+            );
+            for name in names {
+                // Opening reads the datatype and dataspace, which is where a
+                // malformed one is caught.
+                c.attr(&name)
+                    .unwrap_or_else(|e| panic!("the C library could not open {name:?}: {e}"));
+            }
+        }
+    }
+
+    /// The C library is a 64-bit-only dev-dependency, so the check compiles out
+    /// on 32-bit and the pure-Rust half of the test still runs there.
+    #[cfg(target_pointer_width = "32")]
+    fn c_library_reads_every_attribute(_file: &Path, _expected: usize) {}
+
+    /// The other half of the rule: an attribute whose bytes are a *location* must
+    /// not be copied, because the location is in the source file.
+    ///
+    /// A variable-length string attribute stores a global-heap collection address,
+    /// so the repacked message is required to differ in exactly that way — same
+    /// datatype and dataspace, different raw bytes — while the value it resolves
+    /// to stays put. Asserting the raw bytes moved is what distinguishes a correct
+    /// re-encode from a verbatim copy that happens to still resolve because the
+    /// destination heap landed at the same address.
+    #[test]
+    fn an_attribute_addressing_the_heap_is_re_encoded_not_copied() {
+        let dir = tempfile::tempdir().unwrap();
+        let (src, dst) = (dir.path().join("src.h5"), dir.path().join("dst.h5"));
+        let fields: Vec<String> = vec!["x".into(), "y".into(), "velocity".into()];
+
+        let mut b = FileBuilder::new();
+        // Bulk that only the source carries, so the destination's heap cannot
+        // land at the source's address by coincidence.
+        b.create_dataset("bulk").with_f64_data(&vec![0.0; 4096]);
+        b.set_attr("fields", AttrValue::VarLenAsciiArray(fields.clone()));
+        b.write(&src).unwrap();
+
+        repack(&src, &dst, &RepackOptions::new().drop_path("bulk")).unwrap();
+
+        let before = &messages_at("", &src)["fields"];
+        let after = &messages_at("", &dst)["fields"];
+        assert_eq!(
+            after.datatype, before.datatype,
+            "the attribute must stay variable-length"
+        );
+        assert_eq!(after.dataspace, before.dataspace);
+        assert_ne!(
+            after.raw_data, before.raw_data,
+            "a heap reference copied verbatim would point into the source file"
+        );
+        assert_eq!(
+            File::open(&dst).unwrap().root().attrs().unwrap()["fields"],
+            AttrValue::VarLenAsciiArray(fields),
+            "and it must still resolve to its own strings"
+        );
+    }
+
+    /// A datatype that merely *contains* a heap reference or an address is
+    /// position-dependent too — the address sits inside each element rather than
+    /// being the whole of it, and copying the element copies the address.
+    #[test]
+    fn a_nested_address_makes_the_whole_datatype_position_dependent() {
+        let vlen = Datatype::VariableLength {
+            is_string: true,
+            padding: None,
+            charset: Some(CharacterSet::Ascii),
+            base_type: Box::new(i32_type()),
+        };
+        let reference = Datatype::Reference {
+            size: 8,
+            ref_type: ReferenceType::Object,
+        };
+        let compound_of = |member: Datatype| Datatype::Compound {
+            size: 24,
+            members: vec![
+                CompoundMember {
+                    name: "plain".into(),
+                    byte_offset: 0,
+                    datatype: i32_type(),
+                },
+                CompoundMember {
+                    name: "nested".into(),
+                    byte_offset: 8,
+                    datatype: member,
+                },
+            ],
+        };
+        let array_of = |base: Datatype| Datatype::Array {
+            base_type: Box::new(base),
+            dimensions: vec![2, 3],
+        };
+
+        for dependent in [
+            vlen.clone(),
+            reference.clone(),
+            compound_of(vlen.clone()),
+            compound_of(reference.clone()),
+            array_of(vlen.clone()),
+            array_of(reference.clone()),
+            // Two levels down, which a non-recursive check would let through.
+            array_of(compound_of(vlen)),
+            compound_of(array_of(reference)),
+        ] {
+            assert!(
+                !attr_bytes_are_position_independent(&dependent),
+                "{dependent:?} holds an address and must not be copied verbatim"
+            );
+        }
+
+        for independent in [
+            i32_type(),
+            Datatype::String {
+                size: 8,
+                padding: crate::datatype::StringPadding::NullPad,
+                charset: CharacterSet::Utf8,
+            },
+            compound_of(i32_type()),
+            array_of(i32_type()),
+            Datatype::Enumeration {
+                size: 4,
+                base_type: Box::new(i32_type()),
+                members: vec![],
+            },
+        ] {
+            assert!(
+                attr_bytes_are_position_independent(&independent),
+                "{independent:?} holds no address and can be copied verbatim"
+            );
+        }
     }
 }

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -581,6 +581,70 @@ fn int_fits(v: i64, width: usize, signed: bool) -> bool {
 
 // ---- Attribute helper ----
 
+/// How a builder holds one attribute until the writer turns it into bytes.
+///
+/// Most callers describe an attribute by *value* and let the writer choose an
+/// encoding for it — that is [`Value`](AttrSpec::Value), and the encoding it
+/// gets is whatever [`build_attr_message`] picks for the variant.
+///
+/// [`Verbatim`](AttrSpec::Verbatim) carries an already-encoded message instead,
+/// so the datatype, dataspace and element bytes reach the file exactly as
+/// given. Repack uses it to copy an attribute across without routing it through
+/// [`AttrValue`], which is a decoded view and cannot express a narrow width, a
+/// variable-length string, a rank above one, or a string's padding — every one
+/// of which the value path would therefore rewrite (see [`AttrValue`]'s docs on
+/// what a decode does not recover).
+///
+/// The element bytes are copied as-is, so a verbatim message is only correct for
+/// a datatype whose bytes mean the same thing in another file: anything holding
+/// a global-heap reference or an object address must not take this path, since
+/// those addresses point into the *source*. Repack decides that with
+/// `attr_bytes_are_position_independent`.
+pub(crate) enum AttrSpec {
+    /// A decoded value the writer encodes with [`build_attr_message`].
+    Value(AttrValue),
+    /// An already-encoded message, written as given.
+    Verbatim(AttributeMessage),
+    /// A message whose datatype and dataspace are given, but whose element bytes
+    /// are global-heap references the writer builds and patches from `strings`.
+    ///
+    /// This is the middle ground a variable-length string attribute needs. Its
+    /// datatype and dataspace *can* travel — they say "variable-length UTF-8",
+    /// or "scalar" — while its element bytes cannot, because they address the
+    /// source file's heap. `Verbatim` would carry a dangling address across and
+    /// `Value` would rewrite a variable-length string as a fixed-width one (and
+    /// a scalar as a one-element array), so neither alone is faithful.
+    ///
+    /// `message.raw_data` must already be [`vl_string_reference_bytes`] over the
+    /// same `strings`, so the placeholder count matches the heap objects the
+    /// writer will place.
+    VerbatimVarLen {
+        message: AttributeMessage,
+        strings: Vec<String>,
+    },
+}
+
+impl AttrSpec {
+    /// The message this attribute writes, encoding a [`Value`](AttrSpec::Value)
+    /// and handing back an already-encoded one unchanged.
+    pub(crate) fn to_message(&self, name: &str) -> AttributeMessage {
+        match self {
+            Self::Value(v) => build_attr_message(name, v),
+            Self::Verbatim(m) | Self::VerbatimVarLen { message: m, .. } => m.clone(),
+        }
+    }
+
+    /// The variable-length strings whose global-heap collections the writer must
+    /// build and patch, or `None` when the attribute needs no heap.
+    pub(crate) fn var_len_strings(&self) -> Option<&[String]> {
+        match self {
+            Self::Value(AttrValue::VarLenAsciiArray(strings))
+            | Self::VerbatimVarLen { strings, .. } => Some(strings),
+            _ => None,
+        }
+    }
+}
+
 pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMessage {
     match value {
         AttrValue::F64(v) => AttributeMessage {
@@ -722,26 +786,9 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
             // address + object index per element; heap object holds raw
             // bytes without null terminator), so only the datatype
             // descriptor changes.
-            let vl_ref_size = 16usize; // 4 + 8 + 4 for offset_size=8
-            let mut raw = Vec::with_capacity(strings.len() * vl_ref_size);
-            for (i, s) in strings.iter().enumerate() {
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "VLEN string length is written into the 4-byte length prefix of the variable-length reference"
-                )]
-                raw.extend_from_slice(&(s.len() as u32).to_le_bytes());
-                raw.extend_from_slice(&0u64.to_le_bytes()); // patched later
-                // 1-based index within this element's own collection; the
-                // writer splits the strings across collections the same way
-                // (see `build_global_heap_collections`).
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "1-based heap object index is written into the 4-byte object-index field of the variable-length reference"
-                )]
-                raw.extend_from_slice(&((i % MAX_HEAP_OBJECTS + 1) as u32).to_le_bytes());
-            }
             AttributeMessage {
                 name: name.to_string(),
+                raw_data: vl_string_reference_bytes(strings),
                 datatype: Datatype::VariableLength {
                     is_string: false,
                     padding: None,
@@ -753,10 +800,42 @@ pub(crate) fn build_attr_message(name: &str, value: &AttrValue) -> AttributeMess
                     }),
                 },
                 dataspace: simple_1d(strings.len() as u64),
-                raw_data: raw,
             }
         }
     }
+}
+
+/// The element bytes of a variable-length string value: one 16-byte global-heap
+/// reference per string, with the collection address left as a placeholder for
+/// the writer to patch once it has placed the collections.
+///
+/// Both variable-length string encodings this crate handles share these bytes —
+/// a true `H5T_STRING` with `STRSIZE = VAR`, and the `H5T_VLEN` of 1-byte
+/// strings that MATLAB and matio emit — so only the datatype descriptor around
+/// them differs. That is what lets repack keep a source attribute's own datatype
+/// while rebuilding its payload against the destination's heap.
+///
+/// The object index is 1-based *within each collection*, and the split into
+/// collections must match [`build_global_heap_collections`] exactly: the two
+/// walk the same strings in the same order, and a divergence would point an
+/// element at the wrong heap object. Keeping one encoder for every caller is
+/// what holds that invariant to a single place.
+pub(crate) fn vl_string_reference_bytes(strings: &[String]) -> Vec<u8> {
+    let mut raw = Vec::with_capacity(strings.len() * VL_REF_SIZE);
+    for (i, s) in strings.iter().enumerate() {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "VLEN string length is written into the 4-byte length prefix of the variable-length reference"
+        )]
+        raw.extend_from_slice(&(s.len() as u32).to_le_bytes());
+        raw.extend_from_slice(&0u64.to_le_bytes()); // patched later
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "1-based heap object index is written into the 4-byte object-index field of the variable-length reference"
+        )]
+        raw.extend_from_slice(&((i % MAX_HEAP_OBJECTS + 1) as u32).to_le_bytes());
+    }
+    raw
 }
 
 /// Maximum number of objects one global heap collection can index.
@@ -1465,7 +1544,7 @@ pub struct DatasetBuilder {
     pub(crate) shape: Option<Vec<u64>>,
     pub(crate) maxshape: Option<Vec<u64>>,
     pub(crate) data: Option<Vec<u8>>,
-    pub(crate) attrs: Vec<(String, AttrValue)>,
+    pub(crate) attrs: Vec<(String, AttrSpec)>,
     pub(crate) chunk_options: ChunkOptions,
     /// When set, this dataset's chunks are copied verbatim from a source file
     /// (repack's verbatim path): the already-compressed chunk bytes, the source
@@ -2118,7 +2197,33 @@ impl DatasetBuilder {
     }
 
     pub fn set_attr(&mut self, name: &str, value: AttrValue) -> &mut Self {
-        self.attrs.push((name.to_string(), value));
+        self.attrs.push((name.to_string(), AttrSpec::Value(value)));
+        self
+    }
+
+    /// Attach an already-encoded attribute message, written exactly as given.
+    ///
+    /// See [`AttrSpec::Verbatim`] for what this preserves that `set_attr` cannot,
+    /// and for the datatypes it must not be used with.
+    pub(crate) fn set_attr_verbatim(&mut self, message: AttributeMessage) -> &mut Self {
+        self.attrs
+            .push((message.name.clone(), AttrSpec::Verbatim(message)));
+        self
+    }
+
+    /// Attach a variable-length string attribute with the given datatype and
+    /// dataspace, staging `strings` into a heap of this file's own.
+    /// See [`AttrSpec::VerbatimVarLen`].
+    pub(crate) fn set_attr_var_len_verbatim(
+        &mut self,
+        mut message: AttributeMessage,
+        strings: Vec<String>,
+    ) -> &mut Self {
+        message.raw_data = vl_string_reference_bytes(&strings);
+        self.attrs.push((
+            message.name.clone(),
+            AttrSpec::VerbatimVarLen { message, strings },
+        ));
         self
     }
 
@@ -2274,7 +2379,7 @@ pub struct GroupBuilder {
     pub(crate) name: String,
     pub(crate) datasets: Vec<DatasetBuilder>,
     pub(crate) sub_groups: Vec<FinishedGroup>,
-    pub(crate) attrs: Vec<(String, AttrValue)>,
+    pub(crate) attrs: Vec<(String, AttrSpec)>,
 }
 
 impl GroupBuilder {
@@ -2304,7 +2409,31 @@ impl GroupBuilder {
     }
 
     pub fn set_attr(&mut self, name: &str, value: AttrValue) {
-        self.attrs.push((name.to_string(), value));
+        self.attrs.push((name.to_string(), AttrSpec::Value(value)));
+    }
+
+    /// Attach an already-encoded attribute message, written exactly as given.
+    ///
+    /// See [`AttrSpec::Verbatim`] for what this preserves that `set_attr` cannot,
+    /// and for the datatypes it must not be used with.
+    pub(crate) fn set_attr_verbatim(&mut self, message: AttributeMessage) {
+        self.attrs
+            .push((message.name.clone(), AttrSpec::Verbatim(message)));
+    }
+
+    /// Attach a variable-length string attribute with the given datatype and
+    /// dataspace, staging `strings` into a heap of this file's own.
+    /// See [`AttrSpec::VerbatimVarLen`].
+    pub(crate) fn set_attr_var_len_verbatim(
+        &mut self,
+        mut message: AttributeMessage,
+        strings: Vec<String>,
+    ) {
+        message.raw_data = vl_string_reference_bytes(&strings);
+        self.attrs.push((
+            message.name.clone(),
+            AttrSpec::VerbatimVarLen { message, strings },
+        ));
     }
 
     /// Consume the builder, returning a FinishedGroup to add to FileWriter.
@@ -2323,7 +2452,7 @@ pub struct FinishedGroup {
     pub(crate) name: String,
     pub(crate) datasets: Vec<DatasetBuilder>,
     pub(crate) sub_groups: Vec<FinishedGroup>,
-    pub(crate) attrs: Vec<(String, AttrValue)>,
+    pub(crate) attrs: Vec<(String, AttrSpec)>,
 }
 
 #[cfg(test)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -223,6 +223,27 @@ impl FileBuilder {
         self.writer.set_root_attr(name, value);
     }
 
+    /// Attach an already-encoded attribute message to the root group, written
+    /// exactly as given.
+    ///
+    /// See [`AttrSpec::Verbatim`](crate::type_builders::AttrSpec::Verbatim) for
+    /// what this preserves that [`set_attr`](Self::set_attr) cannot, and for the
+    /// datatypes it must not be used with.
+    pub(crate) fn set_attr_verbatim(&mut self, message: crate::attribute::AttributeMessage) {
+        self.writer.set_root_attr_verbatim(message);
+    }
+
+    /// Attach a variable-length string attribute to the root group with the given
+    /// datatype and dataspace, staging `strings` into a heap of this file's own.
+    /// See [`AttrSpec::VerbatimVarLen`](crate::type_builders::AttrSpec::VerbatimVarLen).
+    pub(crate) fn set_attr_var_len_verbatim(
+        &mut self,
+        message: crate::attribute::AttributeMessage,
+        strings: Vec<String>,
+    ) {
+        self.writer.set_root_attr_var_len_verbatim(message, strings);
+    }
+
     /// Whether the staged content needs the 1.10 format — see
     /// [`FileWriter::needs_latest_format`](crate::file_writer::FileWriter::needs_latest_format).
     pub(crate) fn needs_latest_format(&self) -> bool {

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -547,12 +547,20 @@ fn repack_roundtrips_filtered_and_resizable_vlen_string_datasets() {
     }
 }
 
+/// A boolean attribute is an HDF5 enumeration, which [`AttrValue`] has no
+/// variant for. Repack used to refuse the whole file over one — the only honest
+/// answer while every attribute went through a decode, since the alternative was
+/// dropping it silently.
+///
+/// Copying the message verbatim answers it properly instead: an enumeration
+/// carries no address, so its bytes mean the same thing in the destination and
+/// the attribute simply survives. This is the general form of the refusal that
+/// went away, not a special case for booleans — a compound or opaque attribute
+/// travels for the same reason (issue #241).
 #[test]
-fn repack_refuses_unrepresentable_attribute() {
-    // The C library writes a boolean attribute, which is an HDF5 enumeration —
-    // a datatype the reader cannot decode into an AttrValue and would silently
-    // drop. Repack must refuse by name rather than write a file missing the
-    // attribute, upholding the fail-loud fidelity contract.
+fn repack_carries_an_attribute_no_attr_value_can_express() {
+    use hdf5::types::TypeDescriptor;
+
     let dir = tempdir().unwrap();
     let src = dir.path().join("c_boolattr.h5");
     let dst = dir.path().join("boolattr_repacked.h5");
@@ -565,7 +573,6 @@ fn repack_refuses_unrepresentable_attribute() {
             .create("data")
             .unwrap();
         ds.write(&[1.0f64, 2.0]).unwrap();
-        // A boolean (enum) attribute the pure reader cannot represent.
         ds.new_attr::<bool>()
             .shape(())
             .create("active")
@@ -575,11 +582,76 @@ fn repack_refuses_unrepresentable_attribute() {
         file.close().unwrap();
     }
 
+    let source_type = {
+        let c = hdf5::File::open(&src).unwrap();
+        c.dataset("data")
+            .unwrap()
+            .attr("active")
+            .unwrap()
+            .dtype()
+            .unwrap()
+            .to_descriptor()
+            .unwrap()
+    };
+    assert!(
+        matches!(source_type, TypeDescriptor::Boolean),
+        "the C library should have written an enumeration: {source_type:?}"
+    );
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let attr = c.dataset("data").unwrap().attr("active").unwrap();
+    assert_eq!(
+        attr.dtype().unwrap().to_descriptor().unwrap(),
+        source_type,
+        "the enumeration must cross the repack as itself"
+    );
+    assert!(
+        attr.read_scalar::<bool>().unwrap(),
+        "and still hold its value"
+    );
+}
+
+/// What the fail-loud contract still covers once verbatim copying has taken the
+/// address-free datatypes off the refusal list.
+///
+/// An object-reference attribute stores an object-header address, so its bytes
+/// cannot be copied, and [`AttrValue`] has no variant to re-encode it from
+/// either. Repack must still name it and refuse rather than write a file the
+/// attribute is missing from — dropping it silently is the failure this test
+/// exists to catch, and the shrinking refusal list makes it the last one holding
+/// that line for attributes.
+#[test]
+fn repack_refuses_an_attribute_whose_address_it_cannot_rewrite() {
+    use hdf5::{ObjectReference, ObjectReference1};
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_refattr.h5");
+    let dst = dir.path().join("refattr_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let ds = file
+            .new_dataset::<f64>()
+            .shape((2,))
+            .create("data")
+            .unwrap();
+        ds.write(&[1.0f64, 2.0]).unwrap();
+        ds.new_attr::<ObjectReference1>()
+            .shape(())
+            .create("points_at")
+            .unwrap()
+            .write_scalar(&ObjectReference1::create(&file, "data").unwrap())
+            .unwrap();
+        file.close().unwrap();
+    }
+
     let err = repack(&src, &dst, &RepackOptions::new()).unwrap_err();
     match err {
         hdf5_pure::Error::RepackUnsupported(msg) => {
             assert!(
-                msg.contains("active") && msg.contains("data"),
+                msg.contains("points_at") && msg.contains("data"),
                 "error should name the attribute and its dataset: {msg}"
             );
         }
@@ -1218,5 +1290,206 @@ fn repack_refuses_chunked_compound_with_both_vlen_and_reference_members() {
             "error should name the dataset and the reason: {msg}"
         ),
         other => panic!("expected RepackUnsupported, got {other:?}"),
+    }
+}
+
+/// The attribute encodings the reference C library can write and this crate
+/// cannot, carried across a repack and read back by that same library
+/// (issue #241).
+///
+/// This is the half of the fidelity contract no pure-Rust test can reach.
+/// `AttrValue` has no narrow integer array, no variable-length string, and no
+/// rank above one, so a source this crate *writes* cannot exhibit those losses
+/// at all — only a C-written file can, which is exactly the file a user repacks.
+/// Every assertion is made through the C library's own type system, so it states
+/// what a consumer sees rather than what this crate's reader reports.
+#[test]
+fn c_written_attribute_encodings_survive_a_repack() {
+    use hdf5::types::{FixedAscii, FloatSize, IntSize, TypeDescriptor, VarLenUnicode};
+    use std::str::FromStr;
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_attr_src.h5");
+    let dst = dir.path().join("c_attr_dst.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let ds = file
+            .new_dataset::<f64>()
+            .shape((4,))
+            .create("data")
+            .unwrap();
+        ds.write(&[1.0f64, 2.0, 3.0, 4.0]).unwrap();
+
+        // One writer for both owners: an attribute on the root group takes a
+        // different path through the repack walk than one on a dataset, and the
+        // widening hit both.
+        let (ds_loc, root_loc): (&hdf5::Location, &hdf5::Location) = (&ds, &file);
+        for owner in [ds_loc, root_loc] {
+            owner
+                .new_attr::<i8>()
+                .create("i8")
+                .unwrap()
+                .write_scalar(&-3i8)
+                .unwrap();
+            owner
+                .new_attr::<i32>()
+                .create("i32")
+                .unwrap()
+                .write_scalar(&-7i32)
+                .unwrap();
+            owner
+                .new_attr::<u16>()
+                .create("u16")
+                .unwrap()
+                .write_scalar(&65535u16)
+                .unwrap();
+            owner
+                .new_attr::<f32>()
+                .create("f32")
+                .unwrap()
+                .write_scalar(&1.5f32)
+                .unwrap();
+            owner
+                .new_attr::<i16>()
+                .shape([3])
+                .create("i16arr")
+                .unwrap()
+                .write(&[1i16, 2, 3])
+                .unwrap();
+            // Rank 2: `AttrValue`'s array variants are all one-dimensional, so a
+            // decode flattens this to six elements.
+            owner
+                .new_attr::<i32>()
+                .shape([2, 3])
+                .create("rank2")
+                .unwrap()
+                .write_raw(&[1i32, 2, 3, 4, 5, 6])
+                .unwrap();
+            // A true variable-length string, which this crate's writer never
+            // emits and a decode turns into a fixed-width one.
+            owner
+                .new_attr::<VarLenUnicode>()
+                .create("vlstr")
+                .unwrap()
+                .write_scalar(&VarLenUnicode::from_str("hello").unwrap())
+                .unwrap();
+            // The same, as an array: a scalar and a one-element-per-entry array
+            // reach the writer by different paths.
+            owner
+                .new_attr::<VarLenUnicode>()
+                .shape([2])
+                .create("vlstrs")
+                .unwrap()
+                .write_raw(&[
+                    VarLenUnicode::from_str("alpha").unwrap(),
+                    VarLenUnicode::from_str("beta").unwrap(),
+                ])
+                .unwrap();
+            // A fixed-width string declared far wider than its content: the
+            // declared width is the part a decode drops, since it reports the
+            // content and nothing else.
+            owner
+                .new_attr::<FixedAscii<16>>()
+                .create("units")
+                .unwrap()
+                .write_scalar(&FixedAscii::<16>::from_ascii("m/s").unwrap())
+                .unwrap();
+            // Rank 2 over strings rather than numbers, which is the shape
+            // issue #241 measured being flattened.
+            owner
+                .new_attr::<FixedAscii<4>>()
+                .shape([2, 2])
+                .create("grid")
+                .unwrap()
+                .write_raw(&[
+                    FixedAscii::<4>::from_ascii("ab").unwrap(),
+                    FixedAscii::<4>::from_ascii("cd").unwrap(),
+                    FixedAscii::<4>::from_ascii("ef").unwrap(),
+                    FixedAscii::<4>::from_ascii("gh").unwrap(),
+                ])
+                .unwrap();
+        }
+        file.close().unwrap();
+    }
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    // One row per entry in issue #241's table of what a decode loses.
+    let expected: [(&str, TypeDescriptor, Vec<usize>); 10] = [
+        ("i8", TypeDescriptor::Integer(IntSize::U1), vec![]),
+        ("i32", TypeDescriptor::Integer(IntSize::U4), vec![]),
+        ("u16", TypeDescriptor::Unsigned(IntSize::U2), vec![]),
+        ("f32", TypeDescriptor::Float(FloatSize::U4), vec![]),
+        ("i16arr", TypeDescriptor::Integer(IntSize::U2), vec![3]),
+        ("rank2", TypeDescriptor::Integer(IntSize::U4), vec![2, 3]),
+        ("vlstr", TypeDescriptor::VarLenUnicode, vec![]),
+        ("vlstrs", TypeDescriptor::VarLenUnicode, vec![2]),
+        // 16, not 3: the declared width outlives the content.
+        ("units", TypeDescriptor::FixedAscii(16), vec![]),
+        ("grid", TypeDescriptor::FixedAscii(4), vec![2, 2]),
+    ];
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let ds = c.dataset("data").unwrap();
+    let (ds_loc, root_loc): (&hdf5::Location, &hdf5::Location) = (&ds, &c);
+    for (owner_name, owner) in [("dataset data", ds_loc), ("root group", root_loc)] {
+        for (name, descriptor, shape) in &expected {
+            let attr = owner
+                .attr(name)
+                .unwrap_or_else(|e| panic!("{owner_name} lost attribute {name:?}: {e}"));
+            assert_eq!(
+                &attr.dtype().unwrap().to_descriptor().unwrap(),
+                descriptor,
+                "{owner_name}: attribute {name:?} changed datatype across the repack"
+            );
+            assert_eq!(
+                &attr.shape(),
+                shape,
+                "{owner_name}: attribute {name:?} changed shape across the repack"
+            );
+        }
+        // The variable-length string is the one whose bytes cannot be copied, so
+        // it proves the fallback re-encoded it against the destination's own heap
+        // rather than leaving an address pointing into the source.
+        assert_eq!(
+            owner
+                .attr("vlstr")
+                .unwrap()
+                .read_scalar::<VarLenUnicode>()
+                .unwrap()
+                .as_str(),
+            "hello",
+            "{owner_name}: the variable-length string must still resolve"
+        );
+        assert_eq!(
+            owner.attr("rank2").unwrap().read_raw::<i32>().unwrap(),
+            vec![1, 2, 3, 4, 5, 6]
+        );
+        assert_eq!(
+            owner
+                .attr("units")
+                .unwrap()
+                .read_scalar::<FixedAscii<16>>()
+                .unwrap()
+                .as_str(),
+            "m/s"
+        );
+        assert_eq!(
+            owner
+                .attr("vlstrs")
+                .unwrap()
+                .read_raw::<VarLenUnicode>()
+                .unwrap()
+                .iter()
+                .map(|s| s.as_str().to_owned())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(owner.attr("i8").unwrap().read_scalar::<i8>().unwrap(), -3);
+        assert_eq!(
+            owner.attr("f32").unwrap().read_scalar::<f32>().unwrap(),
+            1.5
+        );
     }
 }


### PR DESCRIPTION
Closes #241.

`repack` copied attributes by *reading* them into an `AttrValue` and writing that back. `AttrValue` is a deliberately lossy convenience view — it has no integer narrower than 64 bits, no variable-length string, and no rank above one — so every attribute came out re-encoded as the widest variant of its class, flattened to rank 1, with its string padding and declared width replaced. `repack` returned `Ok(())` throughout.

This takes direction **B** from the issue: copy the attribute *message* instead of rebuilding it from a value, leaving `AttrValue` free to stay a lossy read-side view.

## What changes

An attribute whose element bytes are position-independent is copied verbatim — the source's own datatype, dataspace and element bytes go straight into the destination. Only an element that stores a *location* rather than a value can't travel:

- **Variable-length strings** keep their datatype and dataspace while their strings are restaged into the destination's own heap. This is the common case in the wild, not an exotic one: it is what `h5py` writes for every plain-string attribute, and rewriting it as fixed-width is what flipped `attrs["x"] == "hello"` from `True` to `False`.
- **References** still hold an object address `repack` cannot rewrite for an attribute, so they are still refused by name.

Measured against the reference C library — it writes, `repack` copies, it reads the copy:

| attribute | before | after |
| --- | --- | --- |
| `int8` / `int32` scalar | `int64` | unchanged |
| `uint16` scalar | `uint64` | unchanged |
| `float32` scalar | `float64` | unchanged |
| `int16` array | `int64` | unchanged |
| rank-2 `(2,3)` | rank 1, `(6,)` | unchanged |
| `FixedAscii<16>` holding `"m/s"` | width 3 | width 16 |
| rank-2 `2x2` fixed ASCII | rank 1, `(4,)` | unchanged |
| `STRSIZE=VAR` scalar and array | fixed-width | unchanged |
| `NULLTERM` padding | `NULLPAD` | unchanged |
| Null dataspace | `Simple` rank 1 dim 0 | unchanged |

## The refusal list shrank

An enumeration, compound, bit-field or opaque attribute carries no address, so it now simply survives rather than failing the whole repack. That was the honest answer only while every attribute went through a decode — the alternative then was dropping it silently. A boolean attribute is an enumeration, which is why `repack_refuses_unrepresentable_attribute` became `repack_carries_an_attribute_no_attr_value_can_express`.

This also removes the reason #248 needs its `RepackUnsupported` for enumeration attributes; that refusal can come back out rather than the refused-datatype list growing over time.

`repack_refuses_an_attribute_whose_address_it_cannot_rewrite` is new, and holds the fail-loud line for what is still refused — worth having explicitly, since the shrinking list left the contract with nothing else covering it for attributes.

## Where the seam is

The writer already worked in terms of `AttributeMessage` internally; `AttrValue` was converted to one at the last moment. The change is a `pub(crate) AttrSpec` in front of that conversion, holding either a value to encode, a message to write as-is, or a message plus the strings whose heap the writer must build. Nothing public gains a way to hand the writer raw messages.

`attr_bytes_are_position_independent` names every datatype class rather than defaulting through a `_` arm, so adding a class stops the build and forces the question. Getting it wrong permissively writes a dangling address and returns `Ok`, which is exactly the failure the function exists to prevent.

## Tests

Three lib tests (fast loop, since only the internal `attr_messages()` can see an encoding — a public read decodes, and a decode is what erases the difference) and two crosscheck tests against the reference C library.

Each was mutation-verified against the specific defect it targets, and each mutation is caught by that test **and no other** — the pre-fix behaviour passes all 722 other lib tests, which is why this went unnoticed:

| mutation | caught by | others failing |
| --- | --- | --- |
| never copy verbatim (the pre-fix behaviour) | the two fidelity tests | 0 |
| always copy verbatim | the heap-reference test | 0 |
| stop recursing into compound/array/enum | the nested-address test | 0 |

The C-written crosscheck covers what no pure-Rust test can reach: this crate's writer cannot *produce* a narrow array, a variable-length string, or a rank-2 attribute, so a source it writes cannot exhibit those losses at all. The two rows the C library's own API cannot express either — string padding and a Null dataspace — are covered in the lib test, whose repacked output is then handed to the C library to open, so the assertion is not just this crate agreeing with itself.

## Not included

No version bump: every new item is `pub(crate)`, and `AttributeMessage` only gains `PartialEq`. The behaviour changes (attributes keep their encoding; enum/compound/bit-field/opaque attributes stop being refused) are improvements within the documented fidelity contract.
