### PR TITLE
Give an attribute the datatype channel a dataset already has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `RepackOptions::with_libver_bounds` makes a repack's output format a guarantee. Without it, `repack` now carries the source file's format forward, upgrading only where the content leaves no choice — it used to rewrite every file in the 1.10 format ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `LibVer::WRITER_OLDEST` names the oldest format the writer produces ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `mat::Options::libver` sets the newest HDF5 format a `.mat` file may use, defaulting to `LibVer::V18`. `mat::MatError::CompressionNeedsNewerFormat` reports the one combination that cannot hold ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
+- `Group::attr_datatypes` and `Dataset::attr_datatypes` give an attribute's exact on-disk `Datatype`, which `attrs()` normalizes away — the stored width, and the `enum[FALSE, TRUE]` that marks an h5py `np.bool_` as boolean rather than as a one-byte integer. Every attribute is reported, including the ones `attrs()` omits for having no `AttrValue` ([#248](https://github.com/stephenberry/hdf5-pure/pull/248)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `RepackOptions::with_libver_bounds` makes a repack's output format a guarantee. Without it, `repack` now carries the source file's format forward, upgrading only where the content leaves no choice — it used to rewrite every file in the 1.10 format ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `LibVer::WRITER_OLDEST` names the oldest format the writer produces ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `mat::Options::libver` sets the newest HDF5 format a `.mat` file may use, defaulting to `LibVer::V18`. `mat::MatError::CompressionNeedsNewerFormat` reports the one combination that cannot hold ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
-- `Group::attr_datatypes` and `Dataset::attr_datatypes` give an attribute's exact on-disk `Datatype`, which `attrs()` normalizes away — the stored width, and the `enum[FALSE, TRUE]` that marks an h5py `np.bool_` as boolean rather than as a one-byte integer. Every attribute is reported, including the ones `attrs()` omits for having no `AttrValue` ([#248](https://github.com/stephenberry/hdf5-pure/pull/248)).
+- `Group::attr_datatypes` and `Dataset::attr_datatypes` give an attribute's on-disk `Datatype`, which `attrs()` normalizes away — the stored width, and the `enum[FALSE, TRUE]` that marks an h5py `np.bool_` as boolean rather than a one-byte integer. Every attribute is reported, including the ones `attrs()` omits for having no `AttrValue`, though a committed (shared) datatype is still unresolved and an attribute's rank stays unexposed ([#253](https://github.com/stephenberry/hdf5-pure/pull/253)).
 
 ### Changed
 

--- a/docs/guide/groups-attributes.md
+++ b/docs/guide/groups-attributes.md
@@ -88,6 +88,7 @@ Open the file and start from `File::root()`, which returns a `Group` for the roo
 - `groups()` returns the names of child groups (`Vec<String>`).
 - `datasets()` returns the names of child datasets (`Vec<String>`).
 - `attrs()` returns the attributes as a `HashMap<String, AttrValue>`.
+- `attr_datatypes()` returns their on-disk datatypes as a `HashMap<String, Datatype>`.
 
 ```rust
 let file = File::from_bytes(builder.finish().unwrap()).unwrap();
@@ -127,8 +128,30 @@ What a read cannot recover, because `AttrValue` has no way to express it. Each o
 - **Variable-length strings.** A true `H5T_STRING` with `STRSIZE = VAR` — what h5py writes, and what this crate's writer never emits — has no variant of its own and reads as the fixed-width variant of the same charset.
 - **Rank.** Every array variant is one-dimensional, so a rank-2 attribute reads as its elements flattened.
 - **Padding and declared width.** A fixed-width string reports its content, not its `STRSIZE` or which padding it used.
+- **Enumeration member names.** An enum attribute decodes through its integer base, so its codes arrive and its labels do not.
 
 The variant may become **more specific** in a future release as `AttrValue` grows narrower variants, so match with a `_` arm — which the `#[non_exhaustive]` enum requires anyway — or read through the accessors, which are unaffected by such a change.
+
+### Reading an attribute's datatype
+
+`attr_datatypes()` reports the exact on-disk [`Datatype`](../reference/data-types.md#the-datatype-model) of every attribute, keyed by name. It is the type channel to `attrs()`'s value channel, the pair a dataset already has in `datatype()` and its `read_*` methods, and it is where everything in the list above can still be read.
+
+It reports **every** attribute message, including the ones `attrs()` omits because no `AttrValue` can carry them, so a name missing from that map can be told from one the object does not have.
+
+A boolean attribute needs both channels. The C library gives `H5T_NATIVE_HBOOL` — what h5py writes for every `np.bool_` — an `enum[FALSE, TRUE]` over an 8-bit base, so the value arrives as `0` or `1`, indistinguishable from an `i8`, and only the datatype records which it was:
+
+```rust
+use hdf5_pure::Datatype;
+
+let root = file.root();
+let is_bool = matches!(
+    root.attr_datatypes().unwrap().get("success"),
+    Some(Datatype::Enumeration { base_type, members, .. })
+        if matches!(**base_type, Datatype::FixedPoint { size: 1, .. })
+            && members.iter().any(|m| m.name == "TRUE")
+);
+let value = root.attrs().unwrap().get("success").and_then(AttrValue::as_i64);
+```
 
 ### Addressing datasets
 

--- a/docs/guide/groups-attributes.md
+++ b/docs/guide/groups-attributes.md
@@ -134,9 +134,13 @@ The variant may become **more specific** in a future release as `AttrValue` grow
 
 ### Reading an attribute's datatype
 
-`attr_datatypes()` reports the exact on-disk [`Datatype`](../reference/data-types.md#the-datatype-model) of every attribute, keyed by name. It is the type channel to `attrs()`'s value channel, the pair a dataset already has in `datatype()` and its `read_*` methods, and it is where everything in the list above can still be read.
+`attr_datatypes()` reports the on-disk [`Datatype`](../reference/data-types.md#the-datatype-model) of every attribute, keyed by name. It is the type channel to `attrs()`'s value channel, the pair a dataset already has in `datatype()` and its `read_*` methods, and it is where the *datatype* entries in the list above — width, padding and declared width, enumeration member names — can still be read.
+
+**Rank is not among them.** An attribute's rank lives in its dataspace, which nothing public exposes, so a rank-2 attribute reads as a flat array from `attrs()` with no way to recover its shape from either channel.
 
 It reports **every** attribute message, including the ones `attrs()` omits because no `AttrValue` can carry them, so a name missing from that map can be told from one the object does not have.
+
+One datatype is not reported faithfully: a **committed** (shared) type, created with `H5Tcommit`, is stored on the attribute as a reference to a shared message rather than as the type itself, and both this and `Dataset::datatype()` decode that reference as though it were an inline datatype. netCDF-4 user-defined types and h5py's `f["t"] = np.dtype(...)` reach a file this way.
 
 A boolean attribute needs both channels. The C library gives `H5T_NATIVE_HBOOL` — what h5py writes for every `np.bool_` — an `enum[FALSE, TRUE]` over an 8-bit base, so the value arrives as `0` or `1`, indistinguishable from an `i8`, and only the datatype records which it was:
 

--- a/docs/reference/data-types.md
+++ b/docs/reference/data-types.md
@@ -75,7 +75,9 @@ Two accessors describe an existing dataset's type:
 
 ## Attribute values
 
-`AttrValue` is the write-side attribute enum. Reading attributes yields the same enum (a `HashMap<String, AttrValue>` from `attrs()`), though the reader normalizes integer encodings: signed integers come back as `I64` / `I64Array` and unsigned integers as `U64` (scalar) or `I64Array` (array, since there is no `U64Array` variant), regardless of the stored width. An enumeration attribute decodes through its integer base type, the same view the numeric readers take of an enum dataset, so its codes arrive and its member names do not — this is how an h5py `np.bool_` attribute, stored as `enum[FALSE, TRUE]`, reads back as `0` or `1`. `repack` does not go through `AttrValue`, so an attribute keeps whatever encoding it had when copied.
+`AttrValue` is the write-side attribute enum. Reading attributes yields the same enum (a `HashMap<String, AttrValue>` from `attrs()`), though the reader normalizes integer encodings: signed integers come back as `I64` / `I64Array` and unsigned integers as `U64` / `U64Array`, regardless of the stored width. An enumeration attribute decodes through its integer base type, the same view the numeric readers take of an enum dataset, so its codes arrive and its member names do not — this is how an h5py `np.bool_` attribute, stored as `enum[FALSE, TRUE]`, reads back as `0` or `1`. `repack` does not go through `AttrValue`, so an attribute keeps whatever encoding it had when copied.
+
+`attr_datatypes()` reports what this normalization drops: the exact [`Datatype`](#the-datatype-model) of every attribute, including the ones `attrs()` omits for having no `AttrValue` at all. It is the attribute equivalent of `Dataset::datatype()`, and it is what identifies a `np.bool_` attribute as boolean rather than as an ordinary one-byte integer.
 
 | Variant | HDF5 encoding |
 |---|---|
@@ -86,6 +88,7 @@ Two accessors describe an existing dataset's type:
 | `AttrValue::I64Array` | Signed 64-bit integer array |
 | `AttrValue::U32` | Unsigned 32-bit integer scalar |
 | `AttrValue::U64` | Unsigned 64-bit integer scalar |
+| `AttrValue::U64Array` | Unsigned 64-bit integer array |
 | `AttrValue::String` | UTF-8 null-padded string |
 | `AttrValue::StringArray` | UTF-8 null-padded string array |
 | `AttrValue::AsciiString` | Fixed-width ASCII string |

--- a/docs/reference/data-types.md
+++ b/docs/reference/data-types.md
@@ -77,7 +77,7 @@ Two accessors describe an existing dataset's type:
 
 `AttrValue` is the write-side attribute enum. Reading attributes yields the same enum (a `HashMap<String, AttrValue>` from `attrs()`), though the reader normalizes integer encodings: signed integers come back as `I64` / `I64Array` and unsigned integers as `U64` / `U64Array`, regardless of the stored width. An enumeration attribute decodes through its integer base type, the same view the numeric readers take of an enum dataset, so its codes arrive and its member names do not — this is how an h5py `np.bool_` attribute, stored as `enum[FALSE, TRUE]`, reads back as `0` or `1`. `repack` does not go through `AttrValue`, so an attribute keeps whatever encoding it had when copied.
 
-`attr_datatypes()` reports what this normalization drops: the exact [`Datatype`](#the-datatype-model) of every attribute, including the ones `attrs()` omits for having no `AttrValue` at all. It is the attribute equivalent of `Dataset::datatype()`, and it is what identifies a `np.bool_` attribute as boolean rather than as an ordinary one-byte integer.
+`attr_datatypes()` reports what this normalization drops: the [`Datatype`](#the-datatype-model) of every attribute, including the ones `attrs()` omits for having no `AttrValue` at all. It is the attribute equivalent of `Dataset::datatype()`, and it is what identifies a `np.bool_` attribute as boolean rather than as an ordinary one-byte integer. Like `Dataset::datatype()` it does not resolve a committed (shared) datatype, and neither channel exposes an attribute's rank; see the [groups and attributes guide](../guide/groups-attributes.md#reading-an-attributes-datatype).
 
 | Variant | HDF5 encoding |
 |---|---|

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2440,12 +2440,21 @@ impl Group {
     /// This is the type channel to [`attrs`](Self::attrs)'s value channel, the
     /// pair a dataset already has in [`Dataset::datatype`] and its `read_*`
     /// methods. An [`AttrValue`] is a deliberately lossy view of the value, so an
-    /// attribute's width, rank and enumeration members are recoverable only from
-    /// here.
+    /// attribute's stored width, string padding and enumeration members are
+    /// recoverable only from here. Its *rank* is not: that lives in the
+    /// dataspace, which nothing public exposes, so a rank-2 attribute still
+    /// reads as a flat `AttrValue` array with no way to recover its shape.
     ///
     /// **Every attribute message is reported, including the ones `attrs` omits**
     /// because no `AttrValue` can carry them, so a name missing from that map can
     /// be told from one the object does not have.
+    ///
+    /// **A committed datatype is not resolved.** An attribute whose type was
+    /// created with `H5Tcommit` — what netCDF-4 writes for a user-defined type,
+    /// and what h5py writes for `f["t"] = np.dtype(...)` — stores a reference to
+    /// a shared message rather than the type itself. This reports that reference
+    /// decoded as though it were an inline datatype, which is not the attribute's
+    /// type. [`Dataset::datatype`] has the same gap.
     ///
     /// A boolean attribute is the case that needs both channels. The C library
     /// gives `H5T_NATIVE_HBOOL` — what h5py writes for every `np.bool_` — a
@@ -4485,6 +4494,13 @@ mod tests {
         datatypes: HashMap<String, Datatype>,
     }
 
+    /// One written file: its bytes, and both channels read back from each owner.
+    struct AttrFile {
+        /// The file as written, so a test can assert which storage form it got.
+        bytes: Vec<u8>,
+        owners: Vec<AttrChannels>,
+    }
+
     /// Put the same attributes on the root group and on a dataset, write the
     /// file, and read both channels back from each owner.
     ///
@@ -4494,7 +4510,7 @@ mod tests {
     fn attr_channels(
         values: &[(&str, AttrValue)],
         verbatim: &[crate::attribute::AttributeMessage],
-    ) -> Vec<AttrChannels> {
+    ) -> AttrFile {
         let mut b = FileBuilder::new();
         for (name, value) in values {
             b.set_attr(name, value.clone());
@@ -4511,21 +4527,25 @@ mod tests {
                 ds.set_attr_verbatim(message.clone());
             }
         }
-        let file = File::from_bytes(b.finish().unwrap()).unwrap();
+        let bytes = b.finish().unwrap();
+        let file = File::from_bytes(bytes.clone()).unwrap();
         let root = file.root();
         let dataset = file.dataset("data").unwrap();
-        vec![
-            AttrChannels {
-                owner: "root group",
-                values: root.attrs().unwrap(),
-                datatypes: root.attr_datatypes().unwrap(),
-            },
-            AttrChannels {
-                owner: "dataset",
-                values: dataset.attrs().unwrap(),
-                datatypes: dataset.attr_datatypes().unwrap(),
-            },
-        ]
+        AttrFile {
+            bytes,
+            owners: vec![
+                AttrChannels {
+                    owner: "root group",
+                    values: root.attrs().unwrap(),
+                    datatypes: root.attr_datatypes().unwrap(),
+                },
+                AttrChannels {
+                    owner: "dataset",
+                    values: dataset.attrs().unwrap(),
+                    datatypes: dataset.attr_datatypes().unwrap(),
+                },
+            ],
+        }
     }
 
     /// The datatype channel carries the width the value channel widens away: one
@@ -4536,7 +4556,7 @@ mod tests {
     /// somewhere else to read it, and for an attribute there was nowhere (#248).
     #[test]
     fn attr_datatypes_reports_the_width_attrs_widens() {
-        for c in attr_channels(&[("count", AttrValue::I32(-7))], &[]) {
+        for c in attr_channels(&[("count", AttrValue::I32(-7))], &[]).owners {
             assert_eq!(
                 c.values.get("count"),
                 Some(&AttrValue::I64(-7)),
@@ -4583,7 +4603,7 @@ mod tests {
             raw_data: vec![1, 2, 3],
         };
 
-        for c in attr_channels(&[("count", AttrValue::I32(1))], std::slice::from_ref(&raw)) {
+        for c in attr_channels(&[("count", AttrValue::I32(1))], std::slice::from_ref(&raw)).owners {
             assert!(
                 !c.values.contains_key("raw"),
                 "{}: an opaque attribute has no `AttrValue`, so `attrs` omits it — \
@@ -4603,6 +4623,71 @@ mod tests {
                 "{}: the attribute beside it must appear in both channels",
                 c.owner
             );
+        }
+    }
+
+    /// The channel must cover dense (fractal-heap) attribute storage, not only
+    /// the compact form that lives in the object header.
+    ///
+    /// The two tests above use three attributes, which is well inside the
+    /// writer's compact threshold, so on their own they leave every dense path
+    /// unpinned: an implementation that walked `hdr.messages` directly and never
+    /// touched the heap would pass both and report *nothing* for a real file with
+    /// many attributes. Twelve is past the threshold, and the heap signature is
+    /// asserted so the fixture cannot quietly revert to compact storage and take
+    /// the coverage with it.
+    #[test]
+    fn attr_datatypes_covers_dense_attribute_storage() {
+        let names: Vec<String> = (0..12).map(|i| format!("a{i:02}")).collect();
+        let values: Vec<(&str, AttrValue)> = names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| {
+                (
+                    n.as_str(),
+                    #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                    AttrValue::I32(i as i32),
+                )
+            })
+            .collect();
+
+        let f = attr_channels(&values, &[]);
+        assert!(
+            f.bytes.windows(4).any(|w| w == b"FRHP"),
+            "the fixture must really use dense storage, or this test proves \
+             nothing beyond the compact path the other tests already cover"
+        );
+
+        for c in f.owners {
+            assert_eq!(
+                c.datatypes.len(),
+                names.len(),
+                "{}: every attribute in the heap must be reported, got {:?}",
+                c.owner,
+                c.datatypes.keys().collect::<Vec<_>>()
+            );
+            // The two channels must agree on which attributes exist: all of these
+            // decode, so neither one has anything to omit here.
+            let mut from_values: Vec<&String> = c.values.keys().collect();
+            let mut from_types: Vec<&String> = c.datatypes.keys().collect();
+            from_values.sort();
+            from_types.sort();
+            assert_eq!(
+                from_values, from_types,
+                "{}: the channels disagree",
+                c.owner
+            );
+            for name in &names {
+                assert!(
+                    matches!(
+                        c.datatypes.get(name),
+                        Some(Datatype::FixedPoint { size: 4, .. })
+                    ),
+                    "{}: {name} must keep its 4-byte width through the heap, got {:?}",
+                    c.owner,
+                    c.datatypes.get(name)
+                );
+            }
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2426,10 +2426,38 @@ impl Group {
     /// `#[non_exhaustive]`.
     ///
     /// An attribute whose datatype has no `AttrValue` representation is omitted
-    /// from the map rather than reported as an error.
+    /// from the map rather than reported as an error. Read
+    /// [`attr_datatypes`](Self::attr_datatypes) to see it.
     pub fn attrs(&self) -> Result<HashMap<String, AttrValue>, Error> {
         let hdr = self.file.parse_header(self.address)?;
         self.file.attrs_of(&hdr)
+    }
+
+    /// The exact on-disk [`Datatype`] of every attribute on this group, keyed by
+    /// name — including compound field offsets, integer widths and enumeration
+    /// members.
+    ///
+    /// This is the type channel to [`attrs`](Self::attrs)'s value channel, the
+    /// pair a dataset already has in [`Dataset::datatype`] and its `read_*`
+    /// methods. An [`AttrValue`] is a deliberately lossy view of the value, so an
+    /// attribute's width, rank and enumeration members are recoverable only from
+    /// here.
+    ///
+    /// **Every attribute message is reported, including the ones `attrs` omits**
+    /// because no `AttrValue` can carry them, so a name missing from that map can
+    /// be told from one the object does not have.
+    ///
+    /// A boolean attribute is the case that needs both channels. The C library
+    /// gives `H5T_NATIVE_HBOOL` — what h5py writes for every `np.bool_` — a
+    /// [`Datatype::Enumeration`] of `FALSE` and `TRUE` over an 8-bit base, and
+    /// `attrs` decodes it through that base, so the value arrives as `0` or `1`
+    /// and only the datatype records that it was a bool.
+    pub fn attr_datatypes(&self) -> Result<HashMap<String, Datatype>, Error> {
+        Ok(self
+            .attr_messages()?
+            .into_iter()
+            .map(|a| (a.name, a.datatype))
+            .collect())
     }
 
     /// Every attribute message on this group as it is encoded on disk, in the
@@ -3647,6 +3675,21 @@ impl Dataset {
         self.file.attrs_of(&self.header)
     }
 
+    /// The exact on-disk [`Datatype`] of every attribute on this dataset, keyed
+    /// by name.
+    ///
+    /// See [`Group::attr_datatypes`] for what this channel carries that
+    /// [`attrs`](Self::attrs) cannot, including how a boolean attribute is
+    /// recognized. Note that this describes the *attributes*, not the dataset's
+    /// own element type — that is [`datatype`](Self::datatype).
+    pub fn attr_datatypes(&self) -> Result<HashMap<String, Datatype>, Error> {
+        Ok(self
+            .attr_messages()?
+            .into_iter()
+            .map(|a| (a.name, a.datatype))
+            .collect())
+    }
+
     /// Every attribute message on this dataset as it is encoded on disk, in the
     /// order the header holds them.
     ///
@@ -4431,5 +4474,135 @@ mod tests {
             matches!(err, FormatError::UnsupportedVirtualLayout),
             "expected UnsupportedVirtualLayout, got {err:?}"
         );
+    }
+
+    /// The two channels a caller has for one object's attributes.
+    struct AttrChannels {
+        owner: &'static str,
+        /// What `attrs` decoded — the values, lossily.
+        values: HashMap<String, AttrValue>,
+        /// What `attr_datatypes` reported — the encodings, exactly.
+        datatypes: HashMap<String, Datatype>,
+    }
+
+    /// Put the same attributes on the root group and on a dataset, write the
+    /// file, and read both channels back from each owner.
+    ///
+    /// Both owners, because `Group` and `Dataset` reach their attribute messages
+    /// by different routes: one parses an object header by address, the other
+    /// already holds one.
+    fn attr_channels(
+        values: &[(&str, AttrValue)],
+        verbatim: &[crate::attribute::AttributeMessage],
+    ) -> Vec<AttrChannels> {
+        let mut b = FileBuilder::new();
+        for (name, value) in values {
+            b.set_attr(name, value.clone());
+        }
+        for message in verbatim {
+            b.set_attr_verbatim(message.clone());
+        }
+        {
+            let ds = b.create_dataset("data").with_f64_data(&[1.0]);
+            for (name, value) in values {
+                ds.set_attr(name, value.clone());
+            }
+            for message in verbatim {
+                ds.set_attr_verbatim(message.clone());
+            }
+        }
+        let file = File::from_bytes(b.finish().unwrap()).unwrap();
+        let root = file.root();
+        let dataset = file.dataset("data").unwrap();
+        vec![
+            AttrChannels {
+                owner: "root group",
+                values: root.attrs().unwrap(),
+                datatypes: root.attr_datatypes().unwrap(),
+            },
+            AttrChannels {
+                owner: "dataset",
+                values: dataset.attrs().unwrap(),
+                datatypes: dataset.attr_datatypes().unwrap(),
+            },
+        ]
+    }
+
+    /// The datatype channel carries the width the value channel widens away: one
+    /// attribute, read as a 64-bit value and as the 4-byte type it is stored as.
+    ///
+    /// The pair is the point. `AttrValue` is documented as lossy, so a caller
+    /// that needs the encoding — to map it onto a typed column, say — needs
+    /// somewhere else to read it, and for an attribute there was nowhere (#248).
+    #[test]
+    fn attr_datatypes_reports_the_width_attrs_widens() {
+        for c in attr_channels(&[("count", AttrValue::I32(-7))], &[]) {
+            assert_eq!(
+                c.values.get("count"),
+                Some(&AttrValue::I64(-7)),
+                "{}: the value channel widens every integer to 64 bits",
+                c.owner
+            );
+            let Some(Datatype::FixedPoint { size, signed, .. }) = c.datatypes.get("count") else {
+                panic!(
+                    "{}: expected a fixed-point datatype, got {:?}",
+                    c.owner,
+                    c.datatypes.get("count")
+                );
+            };
+            assert_eq!(
+                (*size, *signed),
+                (4, true),
+                "{}: the datatype channel must report the width on disk",
+                c.owner
+            );
+        }
+    }
+
+    /// Every attribute message is reported, including one `attrs` drops because
+    /// no `AttrValue` can carry it.
+    ///
+    /// That is what lets a caller tell a dropped attribute from an absent one. An
+    /// omission with nothing to compare against is invisible, which is how every
+    /// `np.bool_` attribute in an h5py file went missing without a trace (#248).
+    #[test]
+    fn attr_datatypes_reports_an_attribute_attrs_omits() {
+        let opaque = Datatype::Opaque {
+            size: 3,
+            tag: b"rgb".to_vec(),
+        };
+        let raw = crate::attribute::AttributeMessage {
+            name: "raw".into(),
+            datatype: opaque.clone(),
+            dataspace: Dataspace {
+                space_type: crate::dataspace::DataspaceType::Scalar,
+                rank: 0,
+                dimensions: vec![],
+                max_dimensions: None,
+            },
+            raw_data: vec![1, 2, 3],
+        };
+
+        for c in attr_channels(&[("count", AttrValue::I32(1))], std::slice::from_ref(&raw)) {
+            assert!(
+                !c.values.contains_key("raw"),
+                "{}: an opaque attribute has no `AttrValue`, so `attrs` omits it — \
+                 if that changes, this test is measuring the wrong thing",
+                c.owner
+            );
+            assert_eq!(
+                c.datatypes.get("raw"),
+                Some(&opaque),
+                "{}: the datatype channel must report an attribute `attrs` omits",
+                c.owner
+            );
+            // Specific to the one attribute: a channel that reported only the
+            // undecodable one, or dropped its neighbour, would pass the above.
+            assert!(
+                c.values.contains_key("count") && c.datatypes.contains_key("count"),
+                "{}: the attribute beside it must appear in both channels",
+                c.owner
+            );
+        }
     }
 }

--- a/tests/enum_attr_crosscheck.rs
+++ b/tests/enum_attr_crosscheck.rs
@@ -14,13 +14,13 @@
 //! Every call here goes through the safe `hdf5-metno` API, which serializes its
 //! own C calls through an internal lock, so these tests need no extra guard.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use hdf5_pure::{AttrValue, File};
+use hdf5_pure::{AttrValue, Datatype, File};
 use tempfile::tempdir;
 
-/// Write attributes with the C library, then read them all back with this crate.
-fn c_writes_then_pure_reads(write: impl FnOnce(&hdf5::File)) -> HashMap<String, AttrValue> {
+/// Write attributes with the C library, then open the file with this crate.
+fn c_writes(write: impl FnOnce(&hdf5::File)) -> File {
     let dir = tempdir().unwrap();
     let path = dir.path().join("enum_attrs.h5");
 
@@ -31,11 +31,12 @@ fn c_writes_then_pure_reads(write: impl FnOnce(&hdf5::File)) -> HashMap<String, 
     }
 
     let bytes = std::fs::read(&path).expect("read back the written file");
-    File::from_bytes(bytes)
-        .expect("from_bytes")
-        .root()
-        .attrs()
-        .expect("attrs")
+    File::from_bytes(bytes).expect("from_bytes")
+}
+
+/// Write attributes with the C library, then read them all back with this crate.
+fn c_writes_then_pure_reads(write: impl FnOnce(&hdf5::File)) -> HashMap<String, AttrValue> {
+    c_writes(write).root().attrs().expect("attrs")
 }
 
 #[test]
@@ -88,4 +89,74 @@ fn a_bool_attribute_sits_alongside_the_rest() {
 
     assert_eq!(attrs.get("success"), Some(&AttrValue::I64(0)));
     assert_eq!(attrs.get("frequency"), Some(&AttrValue::F64(30.0)));
+}
+
+/// The datatype channel is what says an attribute was a boolean.
+///
+/// Decoding through the base type is what makes the value readable, and it is
+/// also what makes `true` and `1i8` indistinguishable in the value alone — both
+/// arrive as `AttrValue::I64(1)`, which the last assertion here states rather
+/// than assumes. `H5T_NATIVE_HBOOL`'s `enum[FALSE, TRUE]` over one byte is the
+/// only record of which was written, and `attr_datatypes` is the only way to
+/// read it. This is the shape a consumer matches on to map an h5py `np.bool_`
+/// attribute onto a boolean column.
+#[test]
+fn a_c_written_bool_attribute_keeps_its_enumeration_in_the_datatype_channel() {
+    let file = c_writes(|file| {
+        file.new_attr::<bool>()
+            .create("flag")
+            .expect("create attribute")
+            .write_scalar(&true)
+            .expect("write attribute");
+        file.new_attr::<i8>()
+            .create("count")
+            .expect("create attribute")
+            .write_scalar(&1i8)
+            .expect("write attribute");
+    });
+    let datatypes = file.root().attr_datatypes().expect("attr_datatypes");
+
+    let Some(Datatype::Enumeration {
+        size,
+        base_type,
+        members,
+    }) = datatypes.get("flag")
+    else {
+        panic!(
+            "expected an enumeration for the bool, got {:?}",
+            datatypes.get("flag")
+        );
+    };
+    assert_eq!(*size, 1, "the enum's own width");
+    assert!(
+        matches!(**base_type, Datatype::FixedPoint { size: 1, .. }),
+        "the base is the 8-bit integer the codes are stored as, got {base_type:?}"
+    );
+    let mapping: BTreeMap<&str, &[u8]> = members
+        .iter()
+        .map(|m| (m.name.as_str(), m.value.as_slice()))
+        .collect();
+    assert_eq!(
+        mapping,
+        BTreeMap::from([("FALSE", &[0u8][..]), ("TRUE", &[1u8][..])]),
+        "the member names and codes are what identify the boolean convention"
+    );
+
+    // The one-byte integer beside it is what a bool has to be told apart *from*,
+    // and the value channel cannot do it.
+    assert!(
+        matches!(
+            datatypes.get("count"),
+            Some(Datatype::FixedPoint { size: 1, .. })
+        ),
+        "expected a plain 8-bit integer for the i8, got {:?}",
+        datatypes.get("count")
+    );
+    let values = file.root().attrs().expect("attrs");
+    assert_eq!(
+        values.get("flag"),
+        values.get("count"),
+        "if these ever differ, the value channel can tell a bool from an i8 on \
+         its own and this test is measuring the wrong thing"
+    );
 }


### PR DESCRIPTION
This answers the two follow-ups @ntjohnson1 proposed in #248 — one implemented, one declined with reasons — so that PR can be closed.

## The gap they identified

Their table is the whole argument:

| | values | type |
| --- | --- | --- |
| datasets | `read_*()` — codes through the base | `dtype()` and `datatype()` |
| attributes | `attrs()` → `AttrValue` | *nothing public* |

`AttrValue` is documented as a lossy view of the *value* — no width, no rank above one, no enumeration members — and for a dataset that costs nothing, because `datatype()` reports the type beside it. An attribute had no second channel at all, so what its decode dropped was gone.

#248 made that concrete rather than creating it. A `np.bool_` attribute now decodes, through the 8-bit base of the `enum[FALSE, TRUE]` the C library gives `H5T_NATIVE_HBOOL`, and arrives as `0` or `1` — indistinguishable from an `i8` written beside it, with nothing left to record that it was ever a boolean.

## Option 1: the datatype channel (implemented)

```rust
impl Group {
    pub fn attr_datatypes(&self) -> Result<HashMap<String, Datatype>, Error>;
}
impl Dataset {
    pub fn attr_datatypes(&self) -> Result<HashMap<String, Datatype>, Error>;
}
```

The exact on-disk `Datatype` of every attribute, keyed by name, so it joins against `attrs()` on the same key. No new types: `Datatype` is already public and is what `Dataset::datatype()` returns, and it carries what recognizing the convention needs — the member names *and* the base width, which `DType::Enum(Vec<String>)` does not.

**Every attribute message is reported, including the ones `attrs()` omits** for having no `AttrValue`. That is the more general half of the fix. The omission is silent by design, so there was previously no way to tell an attribute the decoder dropped from one the object does not have — which is why a whole class of missing attributes went unnoticed until someone came looking for a specific one.

## Option 2: `AttrValue::Bool` / `BoolArray` (declined)

Three reasons, and I'd rather record them than leave the question open:

**Its strongest motivation is already gone.** The argument was that a `Bool` variant would let `repack` reproduce a boolean attribute instead of refusing it. #251 removed that premise: repack now copies an attribute's encoding verbatim, so an enumeration crosses with its members intact and no `AttrValue` is involved. #252's `repack_carries_an_attribute_attr_value_cannot_express_faithfully` asserts exactly that — a C-written boolean attribute crosses a repack as `TypeDescriptor::Boolean` and reads back `true`.

**It would break the symmetry it was meant to restore.** A boolean *dataset* reads as `i8` codes plus a `datatype()` the consumer interprets. If a boolean *attribute* read as `Bool`, the two halves of the same file would disagree in the opposite direction, and a reader mapping both onto one column type would need two rules instead of one. Rerun's HDF5 reader is the case @ntjohnson1 measured, and option 1 is what lets those agree.

**Convention detection in a value view is a one-way door.** `AttrValue` is `#[non_exhaustive]`, so adding `Bool` is not breaking — but removing it later would be, and the sniffing rule (`FALSE`/`TRUE` over one byte) would then be this crate's judgment on every file forever. The datatype channel leaves that judgment with the consumer, who knows whether their target format has a boolean to map onto.

Happy to revisit if joining the two maps turns out to be a real burden in practice.

## On their correction

Worth saying plainly: the correction in [their second comment](https://github.com/stephenberry/hdf5-pure/pull/248#issuecomment-5223139129) was right. `effective_numeric`'s doc justifies decoding through the base with a two-channel argument, and attributes only had one channel, so the justification was weaker than the change it was cited for. The change was still correct — readable codes beat silent loss — and this closes the gap that made the citation inexact. Their first comment, on repack's fidelity contract, is settled by #251 removing the proxy it depended on; that is why the refusal commit came out in #252.

## Tests

- `src/reader.rs` (library, so they run in the fast loop): the datatype channel reports the 4-byte width `attrs()` widens to `I64`, and reports an opaque attribute `attrs()` omits while its neighbour appears in both. Each runs over the root group *and* a dataset, since `Group` and `Dataset` reach their messages by different routes.
- `tests/enum_attr_crosscheck.rs`: the C library writes a `bool` and an `i8`; the enumeration reaches the caller with its `FALSE=0`/`TRUE=1` mapping over an 8-bit base — the shape a consumer matches on — while the two attributes' *values* are asserted equal, so the test states rather than assumes that the value channel cannot tell them apart.

Mutation-verified, each mutation caught by the intended test with the rest of the suite quiet:

| mutation | fails |
| --- | --- |
| route the channel through `effective_numeric`, as the value decoder does | the crosscheck only; 728 lib tests pass |
| normalize integer widths to 8 bytes, matching what `AttrValue` holds | `..._reports_the_width_attrs_widens` (+ the crosscheck's `i8` claim) |
| drop what `attrs()` cannot decode — the proxy mistake | `..._reports_an_attribute_attrs_omits` only |
| break `Dataset::attr_datatypes` alone | the same test, on its `dataset` arm — so neither owner is shadowed by the other's panic |

Green locally: `cargo test --lib` (728), the attribute and repack integration binaries, fmt, clippy `-D warnings`, and the rustdoc gate.

## Docs, and one correction

The guide gains a section on reading an attribute's datatype, and enum member names join the list of what a read cannot recover. While in that paragraph: it claimed unsigned arrays read as an `I64Array` "since there is no `U64Array` variant" — `AttrValue::U64Array` has existed since 0.31.0, and the variant table was missing the row. Both fixed.

## Not included

Rank is on the "cannot recover" list too, and this channel does not cover it — an attribute's dataspace is still unexposed. A separate `attr_shapes()` would be additive whenever someone wants it, so nothing here forecloses it.

No version bump: additive, no existing signature changes.
