### PR TITLE
Point the 1.8 format check at a committed datatype

### DIFF
--- a/examples/libver_fixtures.rs
+++ b/examples/libver_fixtures.rs
@@ -15,7 +15,7 @@
 //! between them is the format and nothing else.
 
 use hdf5_pure::mat::{self, Options};
-use hdf5_pure::{AttrValue, FileBuilder, LibVer};
+use hdf5_pure::{AttrValue, FileBuilder, LibVer, make_i32_type};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -46,7 +46,8 @@ fn demo() -> Demo {
 }
 
 /// A plain `.h5` alongside the `.mat` pair: attributes on all three kinds of
-/// object, which is what the attribute-count fix touches.
+/// object, which is what the attribute-count fix touches, and a committed
+/// datatype, which is an object kind of its own.
 fn write_h5(path: &Path, libver: LibVer) {
     let mut b = FileBuilder::new();
     b.with_libver_bounds(LibVer::Earliest, libver);
@@ -54,6 +55,20 @@ fn write_h5(path: &Path, libver: LibVer) {
     b.create_dataset("values")
         .with_f64_data(&[1.0, 2.0, 3.0])
         .set_attr("units", AttrValue::AsciiString("m/s".into()));
+
+    // A committed (`H5Tcommit`) datatype, named by a dataset and by an
+    // attribute. Its users carry a reference to its object header in place of an
+    // encoding, and the object itself carries a reference count — a shape no
+    // other fixture here writes, and one an old library has to decode rather
+    // than merely skip. A reference it cannot follow costs more than the type's
+    // name: the C library abandons an object's whole attribute list when one
+    // attribute fails to decode, so the repack count below sees it too.
+    b.commit_datatype("reading_t", make_i32_type());
+    b.create_dataset("typed")
+        .with_i32_data(&[3, 1, 4])
+        .with_committed_datatype("reading_t")
+        .set_attr_committed("baseline", AttrValue::I32(9), "reading_t");
+
     let mut g = b.create_group("grp");
     g.set_attr("tag", AttrValue::I64(7));
     g.create_dataset("inner").with_i32_data(&[7, 8]);

--- a/scripts/check-hdf5-18.sh
+++ b/scripts/check-hdf5-18.sh
@@ -29,6 +29,18 @@
 #   superblock 2 (0.34.0 default) -> h5dump reads data, groups and attributes
 #   h5repack round trip           -> preserves every attribute (it dropped all
 #                                    of them before the Attribute Info fix)
+#   committed (H5Tcommit) type    -> listed as a named datatype, and the dataset
+#                                    and attribute typed through it both read
+#
+# One thing that measurement showed about this file's shape: 1.8's h5dump gives
+# up on the *whole file* when a committed datatype does not decode, so the plain
+# checks above fail alongside the committed ones. The committed fixture is what
+# makes any of them sensitive to it — before it there was no named type in the
+# file to get wrong — and the committed checks say which thing broke rather than
+# leaving "the file will not open" to be interpreted. The exception is a type
+# that is written and referenced but never linked: the file then reads correctly
+# end to end and 1.8 lists the type as `/#324`, its address standing in for the
+# name it lost. Only `check_named_type` sees that one.
 #
 # The checks below compare dataset and attribute *values*, not just exit status.
 # A file whose headers all decode while its data resolves to the wrong offset
@@ -119,8 +131,14 @@ check() {  # check <description> <expected: open|refuse> <file>
 # drops the dataset's own attributes, which `h5dump -d` prints after it. Done
 # this way rather than with `-A 0` because that spelling is a 1.10 addition:
 # 1.8's `-A` takes no argument, so passing one there dumps the wrong thing.
+#
+# A failing h5dump yields no values rather than killing the run: under `set -e`
+# and `pipefail` its exit status would abort the script at the first bad file,
+# and every check after it would go unanswered. This is run by hand and rarely,
+# so one run has to report every check, not just the ones before the first
+# failure.
 dump_values() {  # dump_values <h5dump args...>
-  "$H5DUMP" "$@" 2>/dev/null |
+  { "$H5DUMP" "$@" 2>/dev/null || true; } |
     awk '
       /^[[:space:]]*DATA[[:space:]]*[{]/ { blocks++; if (blocks > 1) exit; next }
       blocks == 1 && /^[[:space:]]*[(][0-9,]+[)]:/ {
@@ -154,7 +172,8 @@ check_data() {  # check_data <description> <expected values> <h5dump args...>
 # present — so this sees a header that opens but is not what it claims.
 check_named_type() {  # check_named_type <description> <name> <file>
   local desc="$1" name="$2" file="$3" out
-  out="$("$H5DUMP" -n "$file" 2>&1)"
+  # As in `dump_values`: a failing h5dump must fail this check, not the run.
+  out="$("$H5DUMP" -n "$file" 2>&1)" || true
   if printf '%s\n' "$out" | grep -qE "datatype[[:space:]]+$name\$"; then
     echo "  ok   $desc — 1.8 lists $name as a named datatype"
   else

--- a/scripts/check-hdf5-18.sh
+++ b/scripts/check-hdf5-18.sh
@@ -148,6 +148,22 @@ check_data() {  # check_data <description> <expected values> <h5dump args...>
   fi
 }
 
+# `h5dump -n` lists each object with its kind first, so a committed datatype
+# appears as `datatype /reading_t`. It is listed as one only if the object header
+# decoded as a named type — which `H5O__dtype_isa` decides from the messages
+# present — so this sees a header that opens but is not what it claims.
+check_named_type() {  # check_named_type <description> <name> <file>
+  local desc="$1" name="$2" file="$3" out
+  out="$("$H5DUMP" -n "$file" 2>&1)"
+  if printf '%s\n' "$out" | grep -qE "datatype[[:space:]]+$name\$"; then
+    echo "  ok   $desc — 1.8 lists $name as a named datatype"
+  else
+    echo "  FAIL $desc — $name is not listed as a named datatype"
+    printf '%s\n' "$out" | sed 's/^/       /'
+    failures=$((failures + 1))
+  fi
+}
+
 echo "==> the 1.10 format must be unreadable by 1.8 (or the bound buys nothing)"
 check "mat_v110.mat"  refuse "$FIXTURES/mat_v110.mat"
 check "plain_v110.h5" refuse "$FIXTURES/plain_v110.h5"
@@ -169,6 +185,18 @@ echo "==> 1.8 must read attribute values on all three kinds of object"
 check_data "plain_v18.h5 /values units" '"m/s"' -a /values/units "$FIXTURES/plain_v18.h5"
 check_data "plain_v18.h5 / root_attr"   '"r"'   -a /root_attr    "$FIXTURES/plain_v18.h5"
 check_data "plain_v18.h5 /grp tag"      "7"     -a /grp/tag      "$FIXTURES/plain_v18.h5"
+
+# A committed (`H5Tcommit`) datatype is an object of its own, and everything
+# using it stores a reference to that object's header in place of an encoding.
+# An old library that cannot follow the reference does not fail loudly: it reads
+# the reference bytes as a datatype and reports the wrong element type, or drops
+# the attribute list the reference hangs off. So name the object, then read
+# through it — the dataset whose element type it is, and the attribute whose
+# datatype it is.
+echo "==> 1.8 must resolve a committed datatype, not merely list it"
+check_named_type "plain_v18.h5" /reading_t "$FIXTURES/plain_v18.h5"
+check_data "plain_v18.h5 /typed"          "3 1 4" -d /typed          "$FIXTURES/plain_v18.h5"
+check_data "plain_v18.h5 /typed baseline" "9"     -a /typed/baseline "$FIXTURES/plain_v18.h5"
 
 # The attribute-count fix, against the toolchain that lost the attributes: a
 # header that declares no attributes makes h5repack copy the object without


### PR DESCRIPTION
Pre-release check for 0.34.0. `scripts/check-hdf5-18.sh` is the only thing that can see the 1.8 format boundary — every dev-dependency and every third-party MAT reader links a modern libhdf5, so the suite is blind to it by construction — and its fixtures wrote no committed datatype. This cycle both introduces the 1.8 output format (#247) and adds a named type object (#254), so that was a gap.

The fixture now commits `reading_t`, names it from a dataset and from an attribute, and the script reads through it rather than past it. A named type is not something an old library can skip: its users store a reference to an object header in place of an encoding, and a library that cannot follow one reads the reference bytes as a datatype and reports the wrong element type, or drops the attribute list the reference hangs off.

Measured against 1.8.23, all fourteen checks green:

| check | result |
| --- | --- |
| `/reading_t` listed as a named datatype | yes |
| `/typed` read through the reference | `3 1 4` |
| attribute typed through it | `9` |
| `h5repack` attribute round trip | 4 in, 4 out (was 3) |

## What the mutations showed

Four ways of breaking the committed type. Three of them — dropping the shared flag, shifting the reference address by eight, giving the committed object a dataspace so it stops being a named type — make 1.8's `h5dump` abort on the *whole file*, so the pre-existing `/values` and attribute checks fail alongside the new ones. Those three do not prove the new assertions independently; what does is the fixture itself, since before this there was no named type in the file to get wrong.

The fourth is selective. A type written and referenced but never linked fails exactly one check of fourteen, and 1.8 lists it as `datatype /#324` — its address standing in for the name it lost — while every dataset and attribute still reads correctly. A file that opens, lists everything, and has quietly stopped having a named type is exactly what an exit-status check calls passing.

## The script defect that found

Under `set -e` with `pipefail`, a failing `h5dump` inside a command substitution took the script with it. The first mutation run died at check 5 of 14 and never reached the other nine. `dump_values` had this latent from the start and the new `check_named_type` reproduced it; both are fixed, so failing dump output fails its own check and nothing else. For a script that builds a library from source and runs by hand before a release, stopping at the first failure wastes the run.

No library code changes, so nothing here affects the crate's published surface.
