### PR TITLE
Read a run of adjacent chunks in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `FileBuilder::with_create_properties` resets the properties its argument does not carry, so a bound set before the call no longer decides the format of a file whose property list names no version ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `FileBuilder::write` creates the destination only once the writer has bytes for it, so a refused build leaves an existing file at that path untouched ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - An edit session writes a contiguous dataset's data-layout message in the format of the file it opened, so a `.mat` file edited through `File::open_rw` stays readable by MATLAB ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
-- `File::open_streaming` fetches a dataset's adjacent chunks in one read instead of one read each, which is what makes a file written a row at a time — thousands of chunks of a few dozen bytes — read at a sensible speed. A read still fetches only the chunks it needs, and holds at most 256 KiB of them at a time ([#257](https://github.com/stephenberry/hdf5-pure/pull/257)).
+- `File::open_streaming` fetches a dataset's adjacent chunks in one read instead of one read each, which is what makes a file written a row at a time — thousands of chunks of a few dozen bytes — read at a sensible speed. A read still fetches only the chunks it needs, and holds at most 256 KiB of them at a time ([#250](https://github.com/stephenberry/hdf5-pure/pull/250)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `FileBuilder::with_create_properties` resets the properties its argument does not carry, so a bound set before the call no longer decides the format of a file whose property list names no version ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - `FileBuilder::write` creates the destination only once the writer has bytes for it, so a refused build leaves an existing file at that path untouched ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
 - An edit session writes a contiguous dataset's data-layout message in the format of the file it opened, so a `.mat` file edited through `File::open_rw` stays readable by MATLAB ([#247](https://github.com/stephenberry/hdf5-pure/pull/247)).
+- `File::open_streaming` fetches a dataset's adjacent chunks in one read instead of one read each, which is what makes a file written a row at a time — thousands of chunks of a few dozen bytes — read at a sensible speed. A read still fetches only the chunks it needs, and holds at most 256 KiB of them at a time ([#257](https://github.com/stephenberry/hdf5-pure/pull/257)).
 
 ### Fixed
 

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -8,6 +8,8 @@ This page covers working with HDF5 files that are too large to buffer in memory,
 
 `File::open_streaming(path)` opens the same file with a lazy backing store. It fetches metadata and dataset chunks from the file as they are needed instead of buffering it whole, so it never holds the entire file in memory at once. Peak memory tracks what you actually read: one dataset, decompressed, with its chunks fetched on demand, plus the metadata being parsed.
 
+Chunks that lie next to each other on disk are fetched together, in reads of at most 256 KiB. This is what makes a file written a row at a time readable at a sensible speed: such a file carries one small chunk per row, so fetching them one at a time costs thousands of reads where a handful would do. A recording of 73 datasets over 280 rows holds 20,440 chunks of 32 bytes, which the streaming reader fetches in 73 reads. A read never fetches bytes outside the chunks it needs, so what this trades is read count, not read volume. A chunk larger than 256 KiB is read on its own, as it was before.
+
 ```rust
 use hdf5_pure::File;
 
@@ -67,7 +69,7 @@ The window is clamped to the dataset, so the final short window needs no special
 
 `File::open_streaming_with_options(path, FileAccessProperties)` bounds the memory the streaming backend retains. `FileAccessProperties::new()` returns the crate's default access behavior; you layer on two independent caches with its builder methods.
 
-`MetadataCacheConfig` mirrors the memory-budget role of HDF5's `H5Pset_mdc_config`: it caps the bytes retained for parsed metadata reads. `MetadataCacheConfig::new(max_bytes)` sets the total byte budget, and `.with_max_entry_bytes(...)` caps the size of any single cached metadata read so one large heap or index block cannot monopolize the cache.
+`MetadataCacheConfig` mirrors the memory-budget role of HDF5's `H5Pset_mdc_config`: it caps the bytes retained for parsed metadata reads. `MetadataCacheConfig::new(max_bytes)` sets the total byte budget, and `.with_max_entry_bytes(...)` caps the size of any single cached metadata read so one large heap or index block cannot monopolize the cache. It is disabled unless you ask for it, and worth asking for on a file holding many datasets: opening one walks the root group's link storage, and every dataset repeats that walk.
 
 `ChunkCacheConfig` mirrors the raw-data chunk-cache settings from `H5Pset_cache`. `ChunkCacheConfig::from_h5p_cache(rdcc_nslots, rdcc_nbytes)` builds one directly from the familiar HDF5 slot count and byte budget. It controls decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
 

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -365,6 +365,24 @@ impl ChunkCache {
         });
     }
 
+    /// The coordinates of every chunk whose decompressed bytes this cache
+    /// currently holds, in no particular order.
+    ///
+    /// A reader planning coalesced reads (see [`crate::chunk_span`]) uses this
+    /// to leave the chunks it already has out of the plan: a span covering a
+    /// chunk the read will skip fetches those bytes for nothing. It answers in
+    /// one lock over at most [`ChunkCacheConfig::max_slots`] entries, where
+    /// probing per chunk would take a lock apiece.
+    ///
+    /// The answer is a snapshot. A chunk named here can be evicted before the
+    /// read reaches it — by this very read, admitting later chunks — which
+    /// costs the coalescing for that chunk and nothing else: a chunk in no span
+    /// is read directly.
+    pub fn decompressed_coords(&self) -> Vec<ChunkCoord> {
+        let inner = self.inner.lock().unwrap();
+        inner.slots.iter().map(|s| s.coord.clone()).collect()
+    }
+
     /// Insert a copy of `data` into the LRU cache, but only if it would actually
     /// be admitted. This lets the unfiltered read path scatter directly from the
     /// file buffer and copy into the cache only when caching is enabled and the

--- a/src/chunk_span.rs
+++ b/src/chunk_span.rs
@@ -1,0 +1,427 @@
+//! Reading a run of adjacent chunks in one call, for the streaming readers.
+//!
+//! # Why this exists
+//!
+//! The streaming chunked readers fetch one chunk per [`Source::read_exact_at`],
+//! which is one `seek` plus one `read` each. That is right for the
+//! megabyte-sized chunks a file written in one pass carries, and wrong for a
+//! file written as the data arrived: a recorder that appends a row at a time
+//! produces one chunk per row, so a recording of 73 datasets over 280 rows
+//! holds 20,440 chunks of a few dozen bytes. Reading one chunk at a time cost
+//! about four times what the same read costs from a buffered
+//! [`crate::File::open`], and the whole difference was read *granularity* — the
+//! file was read exactly once, in 32-byte pieces.
+//!
+//! Those chunks are adjacent on disk. libhdf5 allocates a chunk when its chunk
+//! cache flushes rather than when the write is issued, so even a writer filling
+//! 73 datasets a row at a time lays each dataset's chunks down in one run, and
+//! this crate's writer does the same. A reader that asks for the run in one
+//! call gets the same bytes in 73 reads instead of 20,440, which brings the
+//! streaming read within about 15% of the buffered one.
+//!
+//! # What it does not spend
+//!
+//! **Memory.** A span stops at [`MAX_SPAN_BYTES`], so what a reader holds
+//! beyond the caller's own buffers is bounded by that however large the dataset
+//! is. `open_streaming` exists so that a file larger than memory still opens,
+//! and this must not spend that. The one span that may exceed the cap is a
+//! single chunk larger than it, which is read alone — exactly the read the
+//! direct path would have issued.
+//!
+//! **Read volume.** Only chunks that are exactly adjacent merge, so a span
+//! covers nothing but the chunks it was planned over. Bridging a gap between
+//! two nearby chunks would trade read count for read volume; on the layouts
+//! this targets there is no gap to bridge. It follows that the caller must plan
+//! over the chunks it will actually fetch, not over every chunk of the dataset:
+//! a chunk the caller will skip — outside a row window, or already in the chunk
+//! cache — leaves a hole that a span would cover and read for nothing.
+//!
+//! # What the caller owes it
+//!
+//! Chunks must be *asked for* in address order. A reader holds one span, so a
+//! walk that alternates between two spans re-reads a whole span at each
+//! alternation; the chunk index yields index order and a cached index yields no
+//! order at all, so neither is safe to walk unsorted. Serving out of order
+//! stays correct — [`chunk_bytes`](ChunkSpanReader::chunk_bytes) re-reads
+//! whatever span it needs — but it gives up the read count that is the point.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::convert::TryToUsize;
+use crate::error::FormatError;
+use crate::source::Source;
+
+/// Largest span read in one call, and so the most a [`ChunkSpanReader`] holds.
+///
+/// The value is a ceiling, not a target. A chunk-per-row recording's run is one
+/// dataset long — 8,960 bytes on the file above — so any cap past a few tens of
+/// kilobytes captures the same win there; what the cap decides is the layouts
+/// where a run really is long, a dataset of 4 KiB chunks written in one pass,
+/// and there it is the whole memory bound.
+pub(crate) const MAX_SPAN_BYTES: u64 = 256 * 1024;
+
+/// One contiguous byte range of the file, covering one or more chunks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Span {
+    start: u64,
+    /// Exclusive.
+    end: u64,
+}
+
+impl Span {
+    fn covers(&self, start: u64, end: u64) -> bool {
+        start >= self.start && end <= self.end
+    }
+
+    fn len(&self) -> u64 {
+        self.end - self.start
+    }
+}
+
+/// Serves a planned set of chunks out of coalesced reads.
+///
+/// Build it with the chunks one read will fetch (see the module docs on why
+/// that is not the same as the dataset's chunk list), then ask for each chunk's
+/// bytes with [`chunk_bytes`](Self::chunk_bytes) in address order. A chunk in
+/// the span already held is served from the buffer; otherwise its whole span is
+/// read first.
+pub(crate) struct ChunkSpanReader {
+    /// Sorted by `start`, and non-overlapping by construction.
+    spans: Vec<Span>,
+    /// The span `buf` currently holds, or `None` when `buf` is stale.
+    held: Option<Span>,
+    buf: Vec<u8>,
+    /// Holds a chunk that belongs to no span, so serving one does not evict the
+    /// span its neighbours are being served from.
+    scratch: Vec<u8>,
+}
+
+impl ChunkSpanReader {
+    /// Plan spans over `chunks`, given as `(address, size)`, or `None` when
+    /// coalescing them would not pay.
+    ///
+    /// `None` means the caller should read each chunk directly, which is the
+    /// answer whenever no two chunks are adjacent: every span would be a single
+    /// chunk, and serving it through the buffer would only add a copy. A file
+    /// whose writer had its chunk cache disabled scatters its chunks that way
+    /// and pays nothing for this.
+    pub(crate) fn new(chunks: impl IntoIterator<Item = (u64, u32)>) -> Option<Self> {
+        let mut ranges: Vec<Span> = chunks
+            .into_iter()
+            .map(|(address, size)| Span {
+                start: address,
+                // A crafted address near `u64::MAX` saturates rather than
+                // wrapping; the read itself is bounds-checked by the source.
+                end: address.saturating_add(u64::from(size)),
+            })
+            .collect();
+        if ranges.len() < 2 {
+            return None;
+        }
+        ranges.sort_unstable_by_key(|s| s.start);
+
+        let mut spans: Vec<Span> = Vec::new();
+        for range in ranges.iter().copied() {
+            match spans.last_mut() {
+                // Adjacent to the span being built (`start == last.end`), or
+                // overlapping it in a file whose chunks overlap, and still
+                // within the budget measured from that span's start. The bound
+                // is exactly `last.end`: one byte more would bridge a
+                // single-byte gap, and fetch a byte belonging to no chunk.
+                Some(last)
+                    if range.start <= last.end
+                        && range.end.saturating_sub(last.start) <= MAX_SPAN_BYTES =>
+                {
+                    last.end = last.end.max(range.end);
+                }
+                _ => spans.push(range),
+            }
+        }
+
+        // Nothing merged, so every span is one chunk and there is nothing here
+        // the direct path does not already do.
+        if spans.len() == ranges.len() {
+            return None;
+        }
+        Some(Self {
+            spans,
+            held: None,
+            buf: Vec::new(),
+            scratch: Vec::new(),
+        })
+    }
+
+    /// The `len` bytes of the chunk at `address`, reading its span first if
+    /// that is not the span already held.
+    pub(crate) fn chunk_bytes<S: Source + ?Sized>(
+        &mut self,
+        source: &S,
+        address: u64,
+        len: usize,
+    ) -> Result<&[u8], FormatError> {
+        let end = address.saturating_add(len as u64);
+
+        if !matches!(self.held, Some(span) if span.covers(address, end)) {
+            let Some(span) = self.span_containing(address, end) else {
+                // Not a chunk this reader was planned over. Serve it directly
+                // and leave the held span alone.
+                self.scratch = source.read_exact_at(address, len)?;
+                return Ok(&self.scratch);
+            };
+            // Reuse the buffer rather than replacing it, so peak stays one span
+            // rather than the two a fresh allocation would briefly hold. The
+            // held span is cleared first: a failed read leaves `buf` holding
+            // bytes that belong to no span, and nothing may serve out of it.
+            self.held = None;
+            self.buf.resize(span.len().to_usize()?, 0);
+            source.read_at(span.start, &mut self.buf)?;
+            self.held = Some(span);
+        }
+
+        let span = self.held.expect("held above, or set just above");
+        let lo = (address - span.start).to_usize()?;
+        lo.checked_add(len)
+            .and_then(|hi| self.buf.get(lo..hi))
+            .ok_or(FormatError::UnexpectedEof {
+                expected: lo.saturating_add(len),
+                available: self.buf.len(),
+            })
+    }
+
+    /// The span covering `[start, end)`, if this reader was planned over a
+    /// chunk there.
+    fn span_containing(&self, start: u64, end: u64) -> Option<Span> {
+        let idx = match self.spans.binary_search_by_key(&start, |s| s.start) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        self.spans
+            .get(idx)
+            .copied()
+            .filter(|s| s.covers(start, end))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::BytesSource;
+    use core::cell::Cell;
+
+    /// A source that records every read it serves.
+    struct CountingSource {
+        bytes: Vec<u8>,
+        reads: Cell<usize>,
+        bytes_read: Cell<usize>,
+        largest: Cell<usize>,
+    }
+
+    impl CountingSource {
+        fn new(len: usize) -> Self {
+            Self {
+                bytes: (0..len).map(|i| i as u8).collect(),
+                reads: Cell::new(0),
+                bytes_read: Cell::new(0),
+                largest: Cell::new(0),
+            }
+        }
+    }
+
+    impl Source for CountingSource {
+        fn len(&self) -> u64 {
+            self.bytes.len() as u64
+        }
+
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.reads.set(self.reads.get() + 1);
+            self.bytes_read.set(self.bytes_read.get() + buf.len());
+            self.largest.set(self.largest.get().max(buf.len()));
+            BytesSource::new(&self.bytes).read_at(offset, buf)
+        }
+    }
+
+    /// `count` chunks of `size` bytes laid end to end from `start`.
+    fn run(start: u64, size: u32, count: usize) -> Vec<(u64, u32)> {
+        (0..count)
+            .map(|i| (start + i as u64 * u64::from(size), size))
+            .collect()
+    }
+
+    #[test]
+    fn one_read_serves_a_whole_run_of_chunks() {
+        let chunks = run(16, 8, 100);
+        let source = CountingSource::new(4096);
+        let mut reader = ChunkSpanReader::new(chunks.clone()).expect("a run of chunks coalesces");
+
+        for &(address, _) in &chunks {
+            let bytes = reader.chunk_bytes(&source, address, 8).unwrap();
+            let expected: Vec<u8> = (address..address + 8).map(|b| b as u8).collect();
+            assert_eq!(bytes, &expected[..], "chunk at {address}");
+        }
+
+        // One read for the whole run, and not a byte beyond it.
+        assert_eq!(source.reads.get(), 1);
+        assert_eq!(source.bytes_read.get(), 800);
+    }
+
+    /// The budget is what keeps a long run from being read whole, so the test
+    /// that guards it asserts the span count the budget implies rather than
+    /// comparing against the constant — an assertion written in terms of
+    /// `MAX_SPAN_BYTES` holds for every value of it, including the ones that
+    /// give up the bound.
+    #[test]
+    fn a_long_run_is_split_at_the_budget() {
+        // 40 chunks of 8 KiB is 320 KiB, so a 256 KiB budget takes the first
+        // 32 and leaves 8 for a second span.
+        let chunks = run(0, 8192, 40);
+        let source = CountingSource::new(40 * 8192);
+        let mut reader = ChunkSpanReader::new(chunks.clone()).expect("adjacent chunks coalesce");
+
+        for &(address, size) in &chunks {
+            let bytes = reader.chunk_bytes(&source, address, size as usize).unwrap();
+            assert_eq!(bytes.len(), 8192);
+            assert_eq!(bytes[0], address as u8);
+        }
+
+        assert_eq!(source.reads.get(), 2, "320 KiB of chunks is two spans");
+        assert_eq!(source.largest.get(), 32 * 8192, "the first span is full");
+        // Still exactly the chunks' bytes, spread over the two spans.
+        assert_eq!(source.bytes_read.get(), 40 * 8192);
+    }
+
+    #[test]
+    fn chunks_that_are_not_adjacent_are_left_to_the_direct_path() {
+        let scattered: Vec<(u64, u32)> = (0..16).map(|i| (i * 4096, 8)).collect();
+        assert!(ChunkSpanReader::new(scattered).is_none());
+    }
+
+    /// The gap that separates a span from the next one is one byte, and a
+    /// reader that bridged it would fetch a byte belonging to no chunk — the
+    /// one thing this is not allowed to do. A wider gap does not test the
+    /// boundary; an off-by-one in the adjacency test survives it.
+    #[test]
+    fn a_one_byte_gap_is_not_bridged() {
+        let gapped: Vec<(u64, u32)> = (0..16).map(|i| (i * 33, 32)).collect();
+        assert!(
+            ChunkSpanReader::new(gapped).is_none(),
+            "chunks one byte apart are not adjacent"
+        );
+
+        // And in a layout that does coalesce, the gap still bounds the span:
+        // four adjacent chunks, one byte, four more.
+        let mut mixed = run(0, 32, 4);
+        mixed.extend(run(4 * 32 + 1, 32, 4));
+        let source = CountingSource::new(1024);
+        let mut reader = ChunkSpanReader::new(mixed.clone()).expect("the runs coalesce");
+        for &(address, size) in &mixed {
+            reader.chunk_bytes(&source, address, size as usize).unwrap();
+        }
+        assert_eq!(source.reads.get(), 2, "the gap splits the run");
+        assert_eq!(
+            source.bytes_read.get(),
+            8 * 32,
+            "the byte between the runs was not read"
+        );
+    }
+
+    #[test]
+    fn a_single_chunk_is_left_to_the_direct_path() {
+        assert!(ChunkSpanReader::new(run(0, 64, 1)).is_none());
+    }
+
+    #[test]
+    fn a_partly_adjacent_layout_still_coalesces_its_runs() {
+        // Two runs of four, far apart: two spans, so two reads for eight chunks.
+        let mut chunks = run(0, 32, 4);
+        chunks.extend(run(100_000, 32, 4));
+        let source = CountingSource::new(200_000);
+        let mut reader = ChunkSpanReader::new(chunks.clone()).expect("two runs coalesce");
+
+        for &(address, _) in &chunks {
+            reader.chunk_bytes(&source, address, 32).unwrap();
+        }
+        assert_eq!(source.reads.get(), 2);
+        assert_eq!(source.bytes_read.get(), 8 * 32);
+    }
+
+    #[test]
+    fn a_chunk_outside_every_span_is_read_directly() {
+        let chunks = run(0, 32, 8);
+        let source = CountingSource::new(200_000);
+        let mut reader = ChunkSpanReader::new(chunks).expect("adjacent chunks coalesce");
+
+        reader.chunk_bytes(&source, 0, 32).unwrap();
+        assert_eq!(source.reads.get(), 1);
+
+        // A chunk this reader was not planned over still reads correctly...
+        let stray = reader.chunk_bytes(&source, 100_000, 4).unwrap().to_vec();
+        assert_eq!(stray, vec![160u8, 161, 162, 163]);
+        assert_eq!(source.reads.get(), 2);
+
+        // ...and does not cost the held span, which still serves its chunks.
+        reader.chunk_bytes(&source, 224, 32).unwrap();
+        assert_eq!(source.reads.get(), 2);
+    }
+
+    #[test]
+    fn a_chunk_larger_than_the_budget_is_read_on_its_own() {
+        // One over-budget chunk, then a run of small ones. The big chunk cannot
+        // join a span, so it is read alone — the same read it would have been
+        // without coalescing — and does not drag its neighbours over budget.
+        let big = MAX_SPAN_BYTES + 40 * 1024;
+        let big_usize = big.to_usize().unwrap();
+        let mut chunks = vec![(0u64, u32::try_from(big).unwrap())];
+        chunks.extend(run(big, 64, 8));
+
+        let source = CountingSource::new(big_usize + 8 * 64);
+        let mut reader = ChunkSpanReader::new(chunks.clone()).expect("the small chunks coalesce");
+
+        assert_eq!(
+            reader.chunk_bytes(&source, 0, big_usize).unwrap().len(),
+            big_usize
+        );
+        assert_eq!(source.largest.get(), big_usize, "the big chunk read alone");
+
+        for &(address, _) in &chunks[1..] {
+            reader.chunk_bytes(&source, address, 64).unwrap();
+        }
+        // The big chunk, then one span over the eight small ones.
+        assert_eq!(source.reads.get(), 2);
+        assert_eq!(source.bytes_read.get(), big_usize + 8 * 64);
+    }
+
+    /// Out-of-order requests must still return the right bytes. They cost
+    /// reads, which is why the callers sort; correctness must not depend on
+    /// their having done so.
+    #[test]
+    fn chunks_are_served_whatever_order_they_are_asked_for() {
+        let chunks = run(64, 16, 8);
+        let source = CountingSource::new(1024);
+        let mut reader = ChunkSpanReader::new(chunks.clone()).expect("adjacent chunks coalesce");
+
+        for &(address, _) in chunks.iter().rev() {
+            let bytes = reader.chunk_bytes(&source, address, 16).unwrap();
+            assert_eq!(bytes[0], address as u8);
+        }
+        assert_eq!(source.reads.get(), 1, "one span serves both directions");
+    }
+
+    /// The span buffer is reused, so it must be cut to each span's own length:
+    /// a buffer only ever grown would make a short span read the length of the
+    /// longest one before it, which is bytes belonging to no chunk.
+    #[test]
+    fn a_short_span_reads_its_own_length_after_a_longer_one() {
+        let mut chunks = run(0, 64, 8); // 512 bytes
+        chunks.extend(run(100_000, 8, 2)); // 16 bytes, far away
+        let source = CountingSource::new(200_000);
+        let mut reader = ChunkSpanReader::new(chunks).expect("two runs coalesce");
+
+        reader.chunk_bytes(&source, 0, 64).unwrap();
+        let before = source.bytes_read.get();
+        let short = reader.chunk_bytes(&source, 100_000, 8).unwrap();
+        assert_eq!(short, &[160u8, 161, 162, 163, 164, 165, 166, 167]);
+        assert_eq!(source.bytes_read.get() - before, 16, "the short span's own");
+    }
+}

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -4,10 +4,13 @@
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec, vec::Vec};
+use alloc::{borrow::Cow, format, vec, vec::Vec};
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 use crate::btree_v1::btree_v1_node_header_size;
 use crate::chunk_cache::ChunkCache;
+use crate::chunk_span::ChunkSpanReader;
 use crate::convert::{TryToUsize, slice_range, u32_from};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
@@ -850,6 +853,50 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
     ))
 }
 
+/// Put a dataset's chunks in address order, which is the order a coalescing
+/// reader has to be asked for them in (see [`crate::chunk_span`]).
+///
+/// Neither source of a chunk list supplies it: walking the index yields index
+/// order, and a cached index yields no order at all. A reader holds one span,
+/// so a walk that alternates between two of them re-reads a whole span at every
+/// alternation — the read stays correct and the read *volume* multiplies. The
+/// sort is free to do here because every chunk of a read scatters into a
+/// disjoint part of the output, so their order was never load-bearing.
+fn sort_chunks_by_address(chunks: &mut [ChunkInfo]) {
+    chunks.sort_unstable_by_key(|c| c.address);
+}
+
+/// Plan coalesced reads over the chunks a read will actually fetch, or `None`
+/// when the layout has nothing to coalesce.
+///
+/// `wanted` picks the chunks the caller will visit — all of them for a whole
+/// read, the overlapping ones for a row window. Chunks the cache already holds
+/// are dropped on top of that: the caller skips them, so a span covering one
+/// would fetch bytes this read has no use for, which is the guarantee
+/// [`ChunkSpanReader`] is built around.
+///
+/// Planning over a chunk the read then skips anyway is only a missed
+/// opportunity, never a wrong answer, so `wanted` may be approximate where the
+/// caller's own test is fallible.
+fn plan_chunk_spans(
+    chunks: &[ChunkInfo],
+    rank: usize,
+    cache: &ChunkCache,
+    wanted: impl Fn(&ChunkInfo) -> bool,
+) -> Option<ChunkSpanReader> {
+    let cached = cache.decompressed_coords();
+    ChunkSpanReader::new(
+        chunks
+            .iter()
+            .filter(|c| wanted(c))
+            .filter(|c| {
+                let coord = &c.offsets[..rank.min(c.offsets.len())];
+                !cached.iter().any(|held| held.as_slice() == coord)
+            })
+            .map(|c| (c.address, c.chunk_size)),
+    )
+}
+
 /// Read the raw element bytes of the row window `[row_start, row_start + num_rows)`
 /// — a range along the leading dimension — decoding only the chunks it overlaps.
 ///
@@ -960,7 +1007,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     };
 
     // Walk the index once, then reuse it for later windows on this handle.
-    let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
+    let mut chunks = if let Some(chunks) = cache.all_indexed_chunks() {
         chunks
     } else {
         let chunks = collect_chunks_for_layout_from_source(
@@ -979,6 +1026,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         cache.populate_index(&chunks, rank);
         chunks
     };
+    sort_chunks_by_address(&mut chunks);
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
@@ -986,6 +1034,25 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     let row_lo = row_start.to_usize()?;
     let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
     let cd0 = chunk_dims[0];
+
+    // A chunk contributes to the window when its rows meet `[row_lo, row_hi)`.
+    // The span plan and the walk below have to agree on which chunks those are,
+    // so the test is written once.
+    let overlaps = |c0: usize| c0 < row_hi && c0.saturating_add(cd0) > row_lo;
+
+    // Coalesce over the window's own chunks. A plan built over the dataset's
+    // whole chunk list would put the rows on either side of the window inside a
+    // span and read them for nothing — an eight-row window measured 32 KB where
+    // it needed 64 bytes.
+    let mut spans = plan_chunk_spans(&chunks, rank, cache, |chunk| {
+        chunk
+            .offsets
+            .first()
+            .copied()
+            .unwrap_or(0)
+            .to_usize()
+            .is_ok_and(&overlaps)
+    });
 
     for chunk in &chunks {
         let c0 = chunk.offsets.first().copied().unwrap_or(0).to_usize()?;
@@ -997,7 +1064,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         // `band` need no guard — both are bounded by the already-checked
         // `total_bytes` allocation.
         let c_end = c0.saturating_add(cd0);
-        if c0 >= row_hi || c_end <= row_lo {
+        if !overlaps(c0) {
             continue; // no overlap with the window
         }
 
@@ -1056,16 +1123,20 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             continue;
         }
 
-        let raw = source.read_exact_at(chunk.address, chunk.chunk_size as usize)?;
+        let len = chunk.chunk_size as usize;
+        let stored = match spans.as_mut() {
+            Some(sp) => Cow::Borrowed(sp.chunk_bytes(source, chunk.address, len)?),
+            None => Cow::Owned(source.read_exact_at(chunk.address, len)?),
+        };
         match pipeline {
             Some(pl) => {
-                let dec = decompress_chunk(&raw, pl, ctx, chunk.filter_mask)?;
+                let dec = decompress_chunk(&stored, pl, ctx, chunk.filter_mask)?;
                 copy(&mut output, &dec);
                 cache.put_decompressed(coord, dec);
             }
             None => {
-                copy(&mut output, &raw);
-                cache.put_decompressed_slice(coord, &raw);
+                copy(&mut output, &stored);
+                cache.put_decompressed_slice(coord, &stored);
             }
         }
     }
@@ -1162,7 +1233,7 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
 
-    let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
+    let mut chunks = if let Some(chunks) = cache.all_indexed_chunks() {
         chunks
     } else {
         let chunks = collect_chunks_for_layout_from_source(
@@ -1181,6 +1252,7 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
         cache.populate_index(&chunks, rank);
         chunks
     };
+    sort_chunks_by_address(&mut chunks);
 
     let total_elements = dataspace.num_elements().to_usize()?;
     let total_bytes = total_elements
@@ -1203,6 +1275,10 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+
+    // Every chunk of the dataset is wanted here; what the plan leaves out is
+    // whatever the chunk cache already holds from an earlier read.
+    let mut spans = plan_chunk_spans(&chunks, rank, cache, |_| true);
 
     for chunk_info in &chunks {
         let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
@@ -1231,13 +1307,17 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
             continue;
         }
 
-        // Cache miss: fetch the chunk's bytes from the source (already owned).
-        let raw_chunk =
-            source.read_exact_at(chunk_info.address, chunk_info.chunk_size.to_usize()?)?;
-        let dec = if let Some(pl) = pipeline {
-            decompress_chunk(&raw_chunk, pl, ctx, chunk_info.filter_mask)?
-        } else {
-            raw_chunk
+        // Cache miss: fetch the chunk's stored bytes from the source.
+        let len = chunk_info.chunk_size.to_usize()?;
+        let stored = match spans.as_mut() {
+            Some(sp) => Cow::Borrowed(sp.chunk_bytes(source, chunk_info.address, len)?),
+            None => Cow::Owned(source.read_exact_at(chunk_info.address, len)?),
+        };
+        let dec = match pipeline {
+            Some(pl) => Cow::Owned(decompress_chunk(&stored, pl, ctx, chunk_info.filter_mask)?),
+            // Unfiltered: a chunk's stored bytes are its data, so they are
+            // copied out of the span only if the cache admits them.
+            None => stored,
         };
         place_chunk(
             &dec,
@@ -1250,7 +1330,11 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
             elem_size,
             rank,
         );
-        cache.put_decompressed(coord, dec); // move; dropped if not admitted
+        // Dropped either way if the cache does not admit it.
+        match dec {
+            Cow::Owned(bytes) => cache.put_decompressed(coord, bytes), // move
+            Cow::Borrowed(bytes) => cache.put_decompressed_slice(coord, bytes),
+        }
     }
 
     Ok(output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub(crate) mod btree_v2;
 pub(crate) mod btree_v2_write;
 pub(crate) mod checksum;
 pub(crate) mod chunk_cache;
+pub(crate) mod chunk_span;
 pub(crate) mod chunked_read;
 pub(crate) mod chunked_write;
 pub(crate) mod compound;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -472,7 +472,11 @@ impl FileInner {
     /// This lets a host read a file larger than its address space — the original
     /// motivation being 32-bit targets reading multi-gigabyte files (issue #27).
     /// Metadata and dataset chunks are read through a `ReadSeekSource`, so peak
-    /// memory stays close to one chunk plus the metadata being parsed.
+    /// memory stays close to one chunk plus the metadata being parsed. Chunks
+    /// that sit next to each other on disk are fetched together, in reads of at
+    /// most 256 KiB (a larger chunk is read on its own), which is what makes a
+    /// file written a row at a time — thousands of chunks of a few dozen bytes
+    /// — read at a sensible speed. See [`crate::chunk_span`].
     ///
     /// Reads match the buffered [`File::open`]: every storage layout and chunk
     /// index type, both group forms (v2 and v1 symbol-table), and compact,
@@ -1639,8 +1643,10 @@ impl File {
     ///
     /// This lets a host read a file larger than its address space. Metadata and
     /// dataset chunks are read through a `ReadSeekSource`, so peak memory stays
-    /// close to one chunk plus the metadata being parsed. Attribute reading and
-    /// v1 symbol-table groups on the resolved path are not yet supported on this
+    /// close to one chunk plus the metadata being parsed; chunks adjacent on
+    /// disk are fetched together, in reads of at most 256 KiB, and a chunk
+    /// larger than that is read on its own. Attribute reading and v1
+    /// symbol-table groups on the resolved path are not yet supported on this
     /// backend.
     ///
     /// Like [`open`](Self::open), this refuses a file whose superblock marks it
@@ -4333,6 +4339,7 @@ fn is_group(header: &ObjectHeader) -> bool {
 mod tests {
     use super::*;
     use crate::FileBuilder;
+    use std::sync::atomic::AtomicUsize;
 
     /// Read everything a read-write file can serve through the paired read
     /// paths, as comparable text.
@@ -4872,5 +4879,235 @@ mod tests {
                 );
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Coalesced chunk reads (see `crate::chunk_span`)
+    // -----------------------------------------------------------------------
+
+    /// A [`Source`] over a file image that counts what the reader asks the file
+    /// for, so a test can assert read *volume* and not only the values returned.
+    struct CountingSource {
+        bytes: Vec<u8>,
+        reads: Arc<AtomicUsize>,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Source for CountingSource {
+        fn len(&self) -> u64 {
+            self.bytes.len() as u64
+        }
+
+        fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            self.bytes_read.fetch_add(buf.len(), Ordering::Relaxed);
+            BytesSource::new(&self.bytes).read_at(offset, buf)
+        }
+    }
+
+    /// Counters for one measured read.
+    #[derive(Default)]
+    struct ReadCounts {
+        reads: Arc<AtomicUsize>,
+        bytes: Arc<AtomicUsize>,
+    }
+
+    impl ReadCounts {
+        /// Run `f` and report `(reads, bytes)` it cost.
+        fn measure<R>(&self, f: impl FnOnce() -> R) -> (usize, usize) {
+            let r0 = self.reads.load(Ordering::Relaxed);
+            let b0 = self.bytes.load(Ordering::Relaxed);
+            f();
+            (
+                self.reads.load(Ordering::Relaxed) - r0,
+                self.bytes.load(Ordering::Relaxed) - b0,
+            )
+        }
+    }
+
+    /// A streaming [`File`] over `bytes` whose reads are counted, built the way
+    /// [`File::open_streaming_with_options`] builds one over a file handle.
+    fn counting_streaming_file(
+        bytes: Vec<u8>,
+        counts: &ReadCounts,
+        access: FileAccessProperties,
+    ) -> File {
+        let source: Box<dyn Source + Send + Sync> = Box::new(CountingSource {
+            bytes,
+            reads: Arc::clone(&counts.reads),
+            bytes_read: Arc::clone(&counts.bytes),
+        });
+        let (superblock, addr_offset) =
+            FileInner::parse_superblock_source(source.as_ref()).expect("parse superblock");
+        File {
+            inner: Arc::new(FileInner::from_parts(
+                Backend::Streaming(source),
+                superblock,
+                addr_offset,
+                None,
+                access,
+            )),
+        }
+    }
+
+    /// An `n`-element f64 dataset in chunks of `chunk` elements.
+    fn chunked_f64_file(n: usize, chunk: u64) -> (Vec<u8>, Vec<f64>) {
+        let data: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let mut builder = FileBuilder::new();
+        builder
+            .create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[n as u64])
+            .with_chunks(&[chunk]);
+        (builder.finish().expect("write file"), data)
+    }
+
+    /// One chunk per row is what a writer that appends as data arrives
+    /// produces; the rows land next to each other, so the streaming reader must
+    /// fetch them in a few spans rather than one read each.
+    #[test]
+    fn a_streaming_read_coalesces_a_run_of_small_chunks() {
+        let n = 1024usize;
+        let (bytes, data) = chunked_f64_file(n, 1);
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes, &counts, FileAccessProperties::new());
+
+        let mut got = Vec::new();
+        let (reads, _) = counts.measure(|| got = file.dataset("d").unwrap().read_f64().unwrap());
+        assert_eq!(got, data, "the coalesced read must return the same values");
+
+        // Reading each of the 1024 chunks on its own would cost at least that
+        // many reads; the whole run plus its metadata fits in far fewer.
+        assert!(
+            reads < n / 8,
+            "expected the {n} chunks to be coalesced into few reads, got {reads}"
+        );
+    }
+
+    /// A windowed read must coalesce only the chunks its window overlaps: a
+    /// plan built over the dataset's whole chunk list would put the rows on
+    /// either side of the window inside a span and read them for nothing.
+    #[test]
+    fn a_windowed_streaming_read_fetches_only_its_own_window() {
+        let rows = 4096usize;
+        let (bytes, data) = chunked_f64_file(rows, 4);
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes, &counts, FileAccessProperties::new());
+        let ds = file.dataset("d").unwrap();
+
+        // The first window walks (and caches on this handle) the chunk index,
+        // so measure the second: what it reads is the window's own chunks.
+        assert_eq!(ds.read_f64_rows(0, 8).unwrap(), data[0..8]);
+        let (_, window_bytes) =
+            counts.measure(|| assert_eq!(ds.read_f64_rows(2048, 8).unwrap(), data[2048..2056]));
+
+        // Eight rows are two 32-byte chunks.
+        assert!(
+            window_bytes < 256,
+            "an 8-row window read {window_bytes} bytes; it needs 64"
+        );
+    }
+
+    /// The read volume of a whole-dataset read must not depend on which read it
+    /// is. The chunk list comes from the handle's cached index on every read
+    /// after the first, and that index is a map: it yields no address order at
+    /// all. A reader holding one coalesced span re-reads a whole span each time
+    /// an unordered walk crosses back, so the second read of a dataset spanning
+    /// more than one span cost two orders of magnitude more than the first.
+    ///
+    /// A regression here is probabilistic rather than certain — the map's order
+    /// is seeded per process, and a run that happened to be sorted would pass —
+    /// but with hundreds of chunks over two spans the chance of that is nil.
+    /// Correct code passes deterministically.
+    #[test]
+    fn a_second_whole_read_costs_what_the_first_did() {
+        // 512 KiB of f64 in 1 KiB chunks: more than one 256 KiB span, so an
+        // unordered walk has somewhere to thrash between.
+        let n = 64 * 1024usize;
+        let dataset_bytes = n * 8;
+        let (bytes, data) = chunked_f64_file(n, 128);
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes, &counts, FileAccessProperties::new());
+        let ds = file.dataset("d").unwrap();
+
+        counts.measure(|| assert_eq!(ds.read_f64().unwrap(), data));
+        let (_, second) = counts.measure(|| assert_eq!(ds.read_f64().unwrap(), data));
+
+        assert!(
+            second <= dataset_bytes,
+            "the second read fetched {second} bytes of a {dataset_bytes}-byte dataset"
+        );
+    }
+
+    /// The same, for row windows: `docs/guide/streaming.md` walks a dataset in
+    /// windows on one handle, so every window but the first takes its chunk
+    /// list from the cached index.
+    ///
+    /// Each window here covers more than one span, which is what it takes to
+    /// see the defect: a window whose chunks all fit a single span is served
+    /// out of that one buffer whatever order it walks them in.
+    #[test]
+    fn a_window_loop_costs_the_dataset_once() {
+        // 2 MiB of f64 in 1 KiB chunks, read in 512 KiB windows — two spans
+        // each.
+        let rows = 256 * 1024usize;
+        let dataset_bytes = rows * 8;
+        let (bytes, data) = chunked_f64_file(rows, 128);
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes, &counts, FileAccessProperties::new());
+        let ds = file.dataset("d").unwrap();
+
+        let window = 64 * 1024;
+        let (_, total) = counts.measure(|| {
+            for lo in (0..rows).step_by(window) {
+                let got = ds.read_f64_rows(lo as u64, window as u64).unwrap();
+                assert_eq!(got, data[lo..lo + window]);
+            }
+        });
+
+        assert!(
+            total <= 2 * dataset_bytes,
+            "a window loop over a {dataset_bytes}-byte dataset read {total} bytes"
+        );
+    }
+
+    /// A span must not cover a chunk the chunk cache already holds: the read
+    /// skips that chunk, so those bytes would be fetched for nothing.
+    ///
+    /// The cache here is given room for the whole dataset. At the default
+    /// sixteen slots a dataset this size evicts its own warm chunks as it
+    /// walks, so every chunk misses on the second read and the plan has nothing
+    /// to leave out — a config that cannot show the difference either way.
+    #[test]
+    fn a_warm_chunk_cache_is_not_re_fetched() {
+        // 32 KiB of f64 in 32 chunks of 1 KiB, laid end to end.
+        let n = 4096usize;
+        let chunk_bytes = 1024usize;
+        let (bytes, data) = chunked_f64_file(n, 128);
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(
+            bytes,
+            &counts,
+            FileAccessProperties::new()
+                .with_chunk_cache(ChunkCacheConfig::new().with_max_slots(64)),
+        );
+        let ds = file.dataset("d").unwrap();
+
+        // Warm the second half of the dataset: chunks 16..31.
+        assert_eq!(ds.read_f64_rows(2048, 2048).unwrap(), data[2048..]);
+        assert_eq!(
+            ds.chunk_cache_stats().cached_chunks(),
+            16,
+            "the window's own chunks stay cached"
+        );
+
+        let (_, second) = counts.measure(|| assert_eq!(ds.read_f64().unwrap(), data));
+        assert_eq!(
+            second,
+            16 * chunk_bytes,
+            "only the cold half was needed; a span over the whole dataset would \
+             have fetched {} bytes",
+            32 * chunk_bytes
+        );
     }
 }

--- a/tests/windowed_read_memory.rs
+++ b/tests/windowed_read_memory.rs
@@ -177,3 +177,62 @@ fn vlen_string_window_read_is_memory_bounded() {
         .collect();
     assert_eq!(window, expected);
 }
+
+/// A dataset whose chunks lie end to end for its whole length is what the
+/// coalescing reader (`src/chunk_span.rs`) exists for, and the worst case for
+/// its memory bound: a coalescer with no budget would merge all 2,048 chunks
+/// into a single 8 MiB span and hold the dataset a second time to serve them.
+/// The 256 KiB budget is what keeps the span a constant beside the read rather
+/// than a second copy of it.
+///
+/// The read here is [`Dataset::read_raw`] rather than a typed one on purpose:
+/// a typed read allocates its own copy of the dataset, and a term that large
+/// hides the one being measured.
+#[test]
+fn whole_read_of_an_all_adjacent_chunk_layout_is_memory_bounded() {
+    let _guard = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    // 8 MiB of f64 in 4 KiB chunks: 2,048 of them, unfiltered so a chunk's
+    // stored bytes are its data and a span holds no less than the file does.
+    const N0: usize = 1024 * 1024;
+    const DATASET_BYTES: usize = N0 * 8;
+
+    let data: Vec<f64> = (0..N0).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64])
+        .with_chunks(&[512]);
+    builder.write(&path).unwrap();
+    drop(data);
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+
+    let base = LIVE.load(Ordering::Relaxed);
+    PEAK.store(base, Ordering::Relaxed);
+
+    let all = ds.read_raw().unwrap();
+
+    let peak = PEAK.load(Ordering::Relaxed) - base;
+    eprintln!("peak allocation during the whole read: {peak} bytes (dataset: {DATASET_BYTES})");
+
+    // The read's own output is the dataset, and the parsed chunk index is most
+    // of what is left; an unbudgeted span would add the dataset again.
+    assert!(
+        peak < DATASET_BYTES + DATASET_BYTES / 2,
+        "peak allocation during the whole read must not grow with the run of \
+         adjacent chunks; measured {peak} bytes against a {DATASET_BYTES}-byte dataset"
+    );
+
+    assert_eq!(all.len(), DATASET_BYTES);
+    assert_eq!(
+        &all[DATASET_BYTES - 8..],
+        &((N0 - 1) as f64).to_le_bytes()[..]
+    );
+}


### PR DESCRIPTION
Takes over #250 by @ntjohnson1, whose measurement and design this is. That PR was opened by accident against a branch rather than as a draft; this is the same idea with the three defects the review found fixed, and its own regression tests.

The streaming readers fetched one chunk per read. That is right for the megabyte chunks a file written in one pass carries, and wrong for a file written as the data arrived: a recorder appending a row at a time produces one chunk per row, so a recording of 73 datasets over 280 rows holds 20,440 chunks of 32 bytes. Those chunks are adjacent, so `ChunkSpanReader` merges each read's chunks into runs and fetches a run in one call.

| whole-file read of the 20,440-chunk recording | median of 11 |
| --- | --- |
| buffered `File::open` (the control) | 5.7 ms |
| `File::open_streaming` before | 20.7 ms (3.6x the control) |
| `File::open_streaming` after | 6.6 ms (1.2x the control) |

20,440 reads become 73. The buffered arm read 5.70 ms and 5.69 ms in the two runs, so the machine was not the variable.

## What differs from #250

**Chunks are walked in address order.** This was the blocking finding. `ChunkCache::all_indexed_chunks` returns `HashMap::values()`, and both readers take their chunk list from it on every read after the first, so the walk had no address order at all. A reader holds one span and re-reads a whole span whenever the walk crosses back, so a read after the first cost two orders of magnitude more than it should. Both readers now sort before walking, which is free: every chunk of a read scatters into a disjoint part of the output, so their order was never load-bearing.

This reached buffered handles too, since every backend's windowed read goes through the same function. Measured on a window loop over a 4 MiB dataset through a plain `File::open`:

| | median of 11 |
| --- | --- |
| coalescing off | 3.19 ms |
| coalescing on, unsorted (#250 as submitted) | 11.3 ms |
| coalescing on, sorted (this PR) | 3.18 ms |

**Spans are planned over the chunks a read will actually fetch.** #250 planned over the whole chunk list before consulting the chunk cache, so a cached chunk left a hole the span still covered and re-fetched. Planning now drops both the chunks outside a row window and the ones the cache holds, which makes "a read fetches no byte outside the chunks it needs" true rather than nearly true. `ChunkCache::decompressed_coords` answers the second in one lock over at most `max_slots` entries.

**The budget is what the tests pin.** #250 credited `windowed_read_memory` with pinning `MAX_SPAN_BYTES`; raising the constant to 64 MiB left that test passing. `a_long_run_is_split_at_the_budget` now asserts the span count the budget implies rather than comparing against the constant, and a new peak-allocation test reads an 8 MiB dataset of 2,048 end-to-end chunks through the counting allocator that test binary already has. Both fail at 64 MiB.

Smaller ones from the same review: the one-byte adjacency boundary now has a fixture (a gap of 4088 bytes does not test it, and the off-by-one survived the whole suite); the span buffer is reused rather than replaced, so peak is one span rather than two; `ChunkSpanReader::new` takes `(address, size)` pairs instead of `&[ChunkInfo]`, which drops a clone per overlapping chunk from the windowed path; and the docs say what the code does, including that a chunk larger than the budget is read whole.

Two deliberate omissions. `decompress_all_chunks_from_source` is left uncoalesced: its only production caller is `read_raw_data_full_from_source`, whose `Chunked` arm is unreachable because `read_raw_data_cached_from_source` matches `Chunked` first, so coalescing there would carry a `to_vec` per chunk down a path no public API reaches. And the `MetadataCacheConfig` paragraph #250 added to the guide is not here: it documents a different optimization with numbers nothing in the repo reproduces. The guide keeps only the part that is checkable, that the metadata cache is off unless asked for.

## Verification

Every new test was mutation-checked, and the four aimed at a specific defect are caught by exactly the test written for them:

| mutation | fails |
| --- | --- |
| drop the address sort | `a_second_whole_read_costs_what_the_first_did`, `a_window_loop_costs_the_dataset_once` |
| plan over cached chunks too | `a_warm_chunk_cache_is_not_re_fetched` |
| bridge a one-byte gap | `a_one_byte_gap_is_not_bridged` |
| raise `MAX_SPAN_BYTES` to 64 MiB | `a_long_run_is_split_at_the_budget`, `whole_read_of_an_all_adjacent_chunk_layout_is_memory_bounded` |
| plan the window over the whole chunk list | `a_windowed_streaming_read_fetches_only_its_own_window` |
| never shrink the span buffer | four, including the read-volume ones |
| disable coalescing | nine |

`cargo test` 1,650 pass. `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo doc` with `-D warnings`, `cargo check --no-default-features`, and the `wasm32-unknown-unknown` check are all clean. No public API change.
