### PR TITLE
Open a group's members in one walk, not one per name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Group::iter_datasets` and `Group::iter_groups` yield a group's members as opened handles paired with their names, walking the group once where opening each name from `datasets()` re-walks it per member ([#259](https://github.com/stephenberry/hdf5-pure/pull/259)).
+
 ## [0.35.0] - 2026-08-10
 
 A MAT cell array takes its shape and its metadata from the same rules as every other value this crate writes. An empty cell array is `0x0`, MATLAB's own `{}`, where it was `0x1`, and a cell array follows `mat::Options::one_dimensional_mode` like every other 1-D value, so `RowVector` writes `1xN` where a cell used to be a column whatever the option asked for; both are reachable only under non-default options, and `isempty` held under either empty shape, so a reader that only tested emptiness is unaffected. Every object a MAT write interns under `#refs#` — cell elements, struct elements, the MCOS subsystem's helpers — now carries the `H5PATH` attribute MATLAB writes on all but one of its own, which this crate wrote on none ([#258](https://github.com/stephenberry/hdf5-pure/pull/258)). Files written by earlier versions still read.

--- a/docs/guide/groups-attributes.md
+++ b/docs/guide/groups-attributes.md
@@ -87,6 +87,7 @@ Open the file and start from `File::root()`, which returns a `Group` for the roo
 
 - `groups()` returns the names of child groups (`Vec<String>`).
 - `datasets()` returns the names of child datasets (`Vec<String>`).
+- `iter_groups()` and `iter_datasets()` return those same children as opened handles paired with their names, walking the group once where opening each name separately re-walks it per member. Use them when the members themselves are what you want; use the name lists when a listing is.
 - `attrs()` returns the attributes as a `HashMap<String, AttrValue>`.
 - `attr_datatypes()` returns their on-disk datatypes as a `HashMap<String, Datatype>`.
 

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -170,6 +170,8 @@ Combined with a [streaming open](streaming.md#reading-a-large-dataset-a-window-a
 
 `File::root()` returns the root `Group`, and `File::group(path)` resolves a subgroup by path. A `Group` lists its children with `groups()` and `datasets()` (each returning `Vec<String>` of names), opens a child dataset with `dataset(name)`, and opens a child subgroup with `group(name)`.
 
+To walk the members rather than list them, `iter_groups()` and `iter_datasets()` yield `(String, Group)` and `(String, Dataset)` pairs, enumerating the group once instead of once per member. They are for taking every member: reaching one you can already name stays cheaper through `dataset(name)`.
+
 ```rust
 use hdf5_pure::File;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2470,6 +2470,11 @@ impl Group {
     }
 
     /// List the names of datasets in this group.
+    ///
+    /// To read from the datasets themselves, prefer
+    /// [`iter_datasets`](Self::iter_datasets): it hands back opened handles for
+    /// the cost of this call, where opening each name separately re-walks the
+    /// group once per member.
     pub fn datasets(&self) -> Result<Vec<String>, Error> {
         let entries = self.children()?;
         let mut names = Vec::new();
@@ -2480,6 +2485,63 @@ impl Group {
             }
         }
         Ok(names)
+    }
+
+    /// Open every dataset in this group, each paired with its name.
+    ///
+    /// This is the walk to reach for when the members themselves are what you
+    /// want — their attributes, shapes or data — rather than a list of names.
+    /// [`datasets`](Self::datasets) already parses every child's object header to
+    /// tell a dataset from a group, and then keeps only the name, so following it
+    /// with a [`dataset`](Self::dataset) call per entry re-walks the group's link
+    /// structure and re-parses that same header. This keeps what it read, and
+    /// costs one enumeration of the group rather than one per member.
+    ///
+    /// Handles are built as the iterator is advanced, so a walk that stops early
+    /// pays for only the members it took. Each dataset gets the file-wide
+    /// chunk-cache default; to override the cache for one, open it by name with
+    /// [`dataset_with_options`](Self::dataset_with_options).
+    ///
+    /// Members arrive in the order the group's link structure yields them — the
+    /// same order [`datasets`](Self::datasets) reports, which is not necessarily
+    /// sorted.
+    ///
+    /// ```no_run
+    /// # use hdf5_pure::File;
+    /// # fn main() -> Result<(), hdf5_pure::Error> {
+    /// let file = File::open("runs.h5")?;
+    /// for (name, dataset) in file.root().iter_datasets()? {
+    ///     println!("{name}: {:?}", dataset.shape());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn iter_datasets(
+        &self,
+    ) -> Result<impl ExactSizeIterator<Item = (String, Dataset)> + use<>, Error> {
+        let mut members = Vec::new();
+        for entry in self.children()? {
+            let hdr = self.file.parse_header(entry.object_header_address)?;
+            if has_message(&hdr, MessageType::DataLayout) {
+                members.push((entry, hdr));
+            }
+        }
+        let file = Arc::clone(&self.file);
+        let parent = self.path.clone();
+        let chunk_cache = DatasetAccessProperties::new()
+            .resolved_chunk_cache(self.file.access_properties.chunk_cache);
+        Ok(members.into_iter().map(move |(entry, header)| {
+            let path = child_path_of(parent.as_deref(), &entry.name);
+            let dataset = Dataset {
+                file: Arc::clone(&file),
+                address: entry.object_header_address,
+                header,
+                chunk_cache: ChunkCache::with_config(chunk_cache),
+                chunk_cache_config: chunk_cache,
+                path,
+            };
+            (entry.name, dataset)
+        }))
     }
 
     /// The names of children that are committed (`H5Tcommit`) datatype objects:
@@ -2560,6 +2622,10 @@ impl Group {
     }
 
     /// List the names of subgroups in this group.
+    ///
+    /// To descend into the subgroups themselves, prefer
+    /// [`iter_groups`](Self::iter_groups), which hands back opened handles for
+    /// the cost of this call.
     pub fn groups(&self) -> Result<Vec<String>, Error> {
         let entries = self.children()?;
         let mut names = Vec::new();
@@ -2570,6 +2636,52 @@ impl Group {
             }
         }
         Ok(names)
+    }
+
+    /// Open every subgroup of this group, each paired with its name.
+    ///
+    /// The counterpart to [`iter_datasets`](Self::iter_datasets), and the way to
+    /// recurse without paying a [`group`](Self::group) lookup per child: that
+    /// lookup re-walks this group's link structure, which a walk of the whole
+    /// tree would otherwise repeat once per subgroup.
+    ///
+    /// Members arrive in the order the group's link structure yields them — the
+    /// same order [`groups`](Self::groups) reports, which is not necessarily
+    /// sorted.
+    ///
+    /// ```no_run
+    /// # use hdf5_pure::{Error, Group};
+    /// fn total_datasets(group: &Group) -> Result<usize, Error> {
+    ///     let mut n = group.datasets()?.len();
+    ///     for (_, child) in group.iter_groups()? {
+    ///         n += total_datasets(&child)?;
+    ///     }
+    ///     Ok(n)
+    /// }
+    /// ```
+    pub fn iter_groups(
+        &self,
+    ) -> Result<impl ExactSizeIterator<Item = (String, Group)> + use<>, Error> {
+        let mut members = Vec::new();
+        for entry in self.children()? {
+            // A `Group` handle carries no parsed header, so the header that
+            // classified this child is dropped here rather than held for the
+            // length of the walk.
+            if is_group(&self.file.parse_header(entry.object_header_address)?) {
+                members.push(entry);
+            }
+        }
+        let file = Arc::clone(&self.file);
+        let parent = self.path.clone();
+        Ok(members.into_iter().map(move |entry| {
+            let path = child_path_of(parent.as_deref(), &entry.name);
+            let group = Group {
+                file: Arc::clone(&file),
+                address: entry.object_header_address,
+                path,
+            };
+            (entry.name, group)
+        }))
     }
 
     /// Read all attributes of this group.
@@ -2696,13 +2808,7 @@ impl Group {
     /// The root-relative path of a child named `name`, or `None` if this group
     /// itself has no resolvable path (reached by object reference).
     fn child_path(&self, name: &str) -> Option<String> {
-        self.path.as_ref().map(|p| {
-            if p.is_empty() {
-                name.to_string()
-            } else {
-                format!("{p}/{name}")
-            }
-        })
+        child_path_of(self.path.as_deref(), name)
     }
 
     /// Create an empty subgroup `name` within this group, staged until
@@ -4335,6 +4441,22 @@ fn is_group(header: &ObjectHeader) -> bool {
     })
 }
 
+/// The root-relative path of a child named `name` under `parent`, or `None` if
+/// the parent has no resolvable path (reached by object reference).
+///
+/// Free-standing rather than a method on [`Group`] so the member iterators can
+/// build child paths from a closure that outlives the borrow of the group they
+/// came from.
+fn child_path_of(parent: Option<&str>, name: &str) -> Option<String> {
+    parent.map(|p| {
+        if p.is_empty() {
+            name.to_string()
+        } else {
+            format!("{p}/{name}")
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5108,6 +5230,223 @@ mod tests {
             "only the cold half was needed; a span over the whole dataset would \
              have fetched {} bytes",
             32 * chunk_bytes
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Group member iterators (`iter_datasets` / `iter_groups`)
+    // -----------------------------------------------------------------------
+
+    /// A root holding `datasets` datasets, `groups` subgroups (each with one
+    /// dataset of its own) and one committed datatype, so a member walk has all
+    /// three child kinds to sort apart.
+    ///
+    /// Names are not zero-padded, so lexical order and insertion order disagree
+    /// past the tenth member: a walk that silently sorted would show up here.
+    fn mixed_member_file(datasets: usize, groups: usize) -> Vec<u8> {
+        let mut b = FileBuilder::new();
+        b.commit_datatype("a_type", crate::make_i32_type());
+        for i in 0..datasets {
+            b.create_dataset(&format!("ds{i}"))
+                .with_i32_data(&[i as i32, -(i as i32)]);
+        }
+        for i in 0..groups {
+            let mut g = b.create_group(&format!("g{i}"));
+            g.create_dataset("inner").with_i32_data(&[i as i32]);
+            g.create_dataset("other").with_i32_data(&[-1]);
+            b.add_group(g.finish());
+        }
+        b.finish().expect("write the fixture")
+    }
+
+    /// The iterator must report exactly what opening each name reports: the same
+    /// members, in the same order, resolving to the same objects. Anything the
+    /// two disagree on is a member a caller would see differently for having
+    /// chosen the cheaper walk.
+    #[test]
+    fn iter_datasets_agrees_with_opening_each_name() {
+        let file = File::from_bytes(mixed_member_file(12, 3)).unwrap();
+
+        for group in [file.root(), file.group("g1").unwrap()] {
+            let names = group.datasets().unwrap();
+            assert!(
+                !names.is_empty(),
+                "the fixture must have members to compare"
+            );
+
+            let iterated: Vec<(String, Dataset)> = group.iter_datasets().unwrap().collect();
+            assert_eq!(
+                iterated.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>(),
+                names,
+                "the iterator must yield the members `datasets` lists, in that order"
+            );
+
+            for (name, ds) in &iterated {
+                let opened = group.dataset(name).unwrap();
+                assert_eq!(ds.header_address(), opened.header_address(), "{name}");
+                assert_eq!(ds.shape().unwrap(), opened.shape().unwrap(), "{name}");
+                assert_eq!(ds.read_i32().unwrap(), opened.read_i32().unwrap(), "{name}");
+            }
+        }
+    }
+
+    /// The subgroup counterpart, including that a handle it yields can be walked
+    /// again — recursion through `iter_groups` is the shape it exists for.
+    #[test]
+    fn iter_groups_agrees_with_opening_each_name() {
+        let file = File::from_bytes(mixed_member_file(4, 5)).unwrap();
+        let root = file.root();
+
+        let names = root.groups().unwrap();
+        let iterated: Vec<(String, Group)> = root.iter_groups().unwrap().collect();
+        assert_eq!(
+            iterated.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>(),
+            names,
+            "the iterator must yield the subgroups `groups` lists, in that order"
+        );
+        assert_eq!(names.len(), 5);
+
+        for (name, group) in &iterated {
+            assert_eq!(
+                group.header_address(),
+                root.group(name).unwrap().header_address(),
+                "{name}"
+            );
+            let mut inner = group
+                .iter_datasets()
+                .unwrap()
+                .map(|(n, _)| n)
+                .collect::<Vec<_>>();
+            inner.sort();
+            assert_eq!(inner, ["inner", "other"], "{name} must be walkable in turn");
+        }
+    }
+
+    /// Each iterator must claim only its own kind of child. A committed datatype
+    /// is the child that belongs to neither, and the one a walk asking only for
+    /// datasets and groups would otherwise be free to mis-sort into either.
+    #[test]
+    fn the_member_iterators_sort_the_child_kinds_apart() {
+        let file = File::from_bytes(mixed_member_file(3, 2)).unwrap();
+        let root = file.root();
+
+        let datasets: Vec<String> = root.iter_datasets().unwrap().map(|(n, _)| n).collect();
+        let groups: Vec<String> = root.iter_groups().unwrap().map(|(n, _)| n).collect();
+
+        assert_eq!(datasets, ["ds0", "ds1", "ds2"]);
+        assert_eq!(groups, ["g0", "g1"]);
+        assert_eq!(root.named_datatypes().unwrap(), ["a_type"]);
+        assert!(
+            !datasets.contains(&"a_type".to_string()) && !groups.contains(&"a_type".to_string()),
+            "a committed datatype is neither a dataset nor a group"
+        );
+    }
+
+    /// The bytes a walk of `n` members reads, by each route: opening every name,
+    /// and iterating handles.
+    fn member_walk_bytes(n: usize) -> (usize, usize) {
+        let mut b = FileBuilder::new();
+        for i in 0..n {
+            b.create_dataset(&format!("ds{i}"))
+                .with_i32_data(&[i as i32]);
+        }
+        let bytes = b.finish().expect("write the fixture");
+
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes.clone(), &counts, FileAccessProperties::new());
+        let (_, by_name) = counts.measure(|| {
+            let root = file.root();
+            for name in root.datasets().unwrap() {
+                root.dataset(&name).unwrap();
+            }
+        });
+
+        let counts = ReadCounts::default();
+        let file = counting_streaming_file(bytes, &counts, FileAccessProperties::new());
+        let (_, iterated) =
+            counts.measure(|| for (_, _ds) in file.root().iter_datasets().unwrap() {});
+
+        (by_name, iterated)
+    }
+
+    /// Opening members by name re-walks the group's link structure once per
+    /// member; iterating handles walks it once. Bytes is the metric that
+    /// separates them: a group this size keeps its links inline in the object
+    /// header, so that header grows with the member count and re-reading it per
+    /// member is quadratic, while the *number* of reads stays linear either way
+    /// and would show almost nothing.
+    ///
+    /// Asserted as how the cost scales rather than as one fixture's byte count,
+    /// since a fixed number would pass just as well on a walk that stayed
+    /// quadratic with a smaller constant.
+    #[test]
+    fn iterating_members_enumerates_the_group_once() {
+        let (by_name_16, iterated_16) = member_walk_bytes(16);
+        let (by_name_64, iterated_64) = member_walk_bytes(64);
+
+        assert!(
+            iterated_64 <= 5 * iterated_16,
+            "one enumeration plus one header per member is linear, so four times \
+             the members must cost about four times the bytes: {iterated_16} -> \
+             {iterated_64}"
+        );
+        assert!(
+            by_name_64 >= 8 * by_name_16,
+            "re-reading the link-bearing header once per member is quadratic, so \
+             four times the members must cost far more than four times the bytes: \
+             {by_name_16} -> {by_name_64}"
+        );
+        assert!(
+            iterated_64 * 8 < by_name_64,
+            "at 64 members the one-enumeration walk must be the cheaper by a wide \
+             margin: {iterated_64} bytes against {by_name_64}"
+        );
+    }
+
+    /// A yielded handle must carry the same root-relative path as one opened by
+    /// name, or a write through it would address the wrong object — or no object
+    /// at all. A member of a *subgroup* is the case that separates them, since
+    /// its path has a prefix to get right.
+    #[test]
+    fn a_member_handle_resolves_to_its_own_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("members.h5");
+        std::fs::write(&path, mixed_member_file(2, 2)).unwrap();
+
+        let file = File::open_rw(&path).unwrap();
+        let group = file.group("g1").unwrap();
+        let (name, mut ds) = group
+            .iter_datasets()
+            .unwrap()
+            .find(|(n, _)| n == "inner")
+            .expect("g1/inner");
+        assert_eq!(name, "inner");
+        ds.set_attr("tag", AttrValue::I64(7)).unwrap();
+        file.commit().unwrap();
+        // Windows holds the write lock until the session is dropped.
+        drop(ds);
+        drop(group);
+        drop(file);
+
+        let file = File::open(&path).unwrap();
+        assert_eq!(
+            file.dataset("g1/inner")
+                .unwrap()
+                .attrs()
+                .unwrap()
+                .get("tag")
+                .and_then(AttrValue::as_i64),
+            Some(7),
+            "the attribute must land on the member the handle came from"
+        );
+        assert!(
+            !file
+                .dataset("g0/inner")
+                .unwrap()
+                .attrs()
+                .unwrap()
+                .contains_key("tag"),
+            "and on no other group's member of the same name"
         );
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2497,14 +2497,29 @@ impl Group {
     /// structure and re-parses that same header. This keeps what it read, and
     /// costs one enumeration of the group rather than one per member.
     ///
-    /// Handles are built as the iterator is advanced, so a walk that stops early
-    /// pays for only the members it took. Each dataset gets the file-wide
-    /// chunk-cache default; to override the cache for one, open it by name with
+    /// **This walk is for taking every member, or nearly every one.** Telling a
+    /// dataset from a group means parsing its header, so the whole group is
+    /// enumerated and every child's header parsed before the iterator is
+    /// returned — breaking out early saves nothing, and reaching one known member
+    /// this way costs far more than [`dataset`](Self::dataset) does. Only the
+    /// handle construction is deferred to each step, and that is not where the
+    /// cost is.
+    ///
+    /// The headers of the members are held for the length of the walk, since each
+    /// one is what its handle is built from. That is bounded by the group being
+    /// walked rather than by the file, but it is proportional to the group: a
+    /// header carries a compact dataset's data and its compact attributes inline,
+    /// so a large group of such datasets is a large allocation.
+    ///
+    /// Each dataset gets the file-wide chunk-cache default; to override the cache
+    /// for one, open it by name with
     /// [`dataset_with_options`](Self::dataset_with_options).
     ///
     /// Members arrive in the order the group's link structure yields them — the
     /// same order [`datasets`](Self::datasets) reports, which is not necessarily
-    /// sorted.
+    /// sorted. Each handle is a snapshot taken when the iterator was built, so a
+    /// [`File::commit`] that runs mid-walk is not reflected in the members still
+    /// to come; re-open the group to see past it.
     ///
     /// ```no_run
     /// # use hdf5_pure::File;
@@ -2644,6 +2659,12 @@ impl Group {
     /// recurse without paying a [`group`](Self::group) lookup per child: that
     /// lookup re-walks this group's link structure, which a walk of the whole
     /// tree would otherwise repeat once per subgroup.
+    ///
+    /// As with [`iter_datasets`](Self::iter_datasets), the whole group is
+    /// enumerated and classified before the iterator is returned, so this is the
+    /// walk for taking every subgroup rather than for reaching one — breaking out
+    /// early saves nothing. A [`Group`] handle carries no parsed header, so
+    /// unlike `iter_datasets` this holds none of them.
     ///
     /// Members arrive in the order the group's link structure yields them — the
     /// same order [`groups`](Self::groups) reports, which is not necessarily
@@ -5381,25 +5402,26 @@ mod tests {
     /// quadratic with a smaller constant.
     #[test]
     fn iterating_members_enumerates_the_group_once() {
-        let (by_name_16, iterated_16) = member_walk_bytes(16);
+        let (_, iterated_16) = member_walk_bytes(16);
         let (by_name_64, iterated_64) = member_walk_bytes(64);
 
+        // The rule this test exists for, and the only assertion here that is
+        // about `iter_datasets` itself.
         assert!(
             iterated_64 <= 5 * iterated_16,
             "one enumeration plus one header per member is linear, so four times \
              the members must cost about four times the bytes: {iterated_16} -> \
              {iterated_64}"
         );
+
+        // Contrast, not a property of this code: it holds because `Group::dataset`
+        // re-enumerates. If a future change makes that route cheap enough to turn
+        // this red, nothing here has regressed — confirm the scaling assertion
+        // above still holds and then drop this one.
         assert!(
-            by_name_64 >= 8 * by_name_16,
-            "re-reading the link-bearing header once per member is quadratic, so \
-             four times the members must cost far more than four times the bytes: \
-             {by_name_16} -> {by_name_64}"
-        );
-        assert!(
-            iterated_64 * 8 < by_name_64,
-            "at 64 members the one-enumeration walk must be the cheaper by a wide \
-             margin: {iterated_64} bytes against {by_name_64}"
+            iterated_64 < by_name_64,
+            "at 64 members the one-enumeration walk should still be the cheaper: \
+             {iterated_64} bytes against {by_name_64}"
         );
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5403,6 +5403,106 @@ mod tests {
         );
     }
 
+    /// A yielded handle must carry the chunk-cache configuration the file was
+    /// opened with, the same one `dataset` resolves for it.
+    ///
+    /// Nothing about the values read would show a handle that quietly ignored
+    /// it: the cache decides how often the chunk index is re-parsed and how much
+    /// decompressed data is retained, not what comes back. So the configuration
+    /// has to be asserted directly, or dropping it here is a silent regression.
+    #[test]
+    fn a_member_handle_carries_the_files_chunk_cache_config() {
+        let configured = ChunkCacheConfig::new()
+            .with_max_slots(17)
+            .with_max_bytes(4096)
+            .with_index_cache(false);
+        let file = File::from_bytes_with_options(
+            mixed_member_file(3, 0),
+            FileAccessProperties::new().with_chunk_cache(configured),
+        )
+        .unwrap();
+        let root = file.root();
+
+        let members: Vec<(String, Dataset)> = root.iter_datasets().unwrap().collect();
+        assert_eq!(members.len(), 3);
+        for (name, ds) in &members {
+            assert_eq!(
+                ds.chunk_cache_config(),
+                root.dataset(name).unwrap().chunk_cache_config(),
+                "{name} must resolve its cache the way `dataset` does"
+            );
+            assert_eq!(
+                ds.chunk_cache_config(),
+                configured,
+                "{name} must carry the configuration the file was opened with"
+            );
+        }
+    }
+
+    /// A file whose root holds `inner` and `sub`, and a group `g0` holding
+    /// children of those same names, plus a `refs` dataset pointing at `g0`.
+    ///
+    /// The duplicated names are the trap: a member handle that wrongly took a
+    /// root-relative path would address a real object rather than fail, so the
+    /// mistake would look like a successful write.
+    fn dereferenced_group_file() -> Vec<u8> {
+        let mut b = FileBuilder::new();
+        b.create_dataset("inner").with_i32_data(&[0]);
+        let mut root_sub = b.create_group("sub");
+        root_sub.create_dataset("x").with_i32_data(&[0]);
+        b.add_group(root_sub.finish());
+
+        let mut g = b.create_group("g0");
+        g.create_dataset("inner").with_i32_data(&[1]);
+        let mut nested = g.create_group("sub");
+        nested.create_dataset("x").with_i32_data(&[1]);
+        g.add_group(nested.finish());
+        b.add_group(g.finish());
+
+        b.create_dataset("refs").with_path_references(&["g0"]);
+        b.finish().expect("write the fixture")
+    }
+
+    /// A group reached by object reference has no resolvable path, so neither can
+    /// its members: there is nothing for a write through one to address. The
+    /// iterators must carry that `None` across rather than fall back to a
+    /// root-relative path, which here would reach a different, real object.
+    #[test]
+    fn members_of_a_dereferenced_group_have_no_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("refs.h5");
+        std::fs::write(&path, dereferenced_group_file()).unwrap();
+
+        let file = File::open_rw(&path).unwrap();
+        let mut objects = file.dataset("refs").unwrap().dereference().unwrap();
+        let group = match objects.remove(0) {
+            Object::Group(g) => g,
+            other => panic!("expected a group, got {other:?}"),
+        };
+
+        // The file is writable and both names exist at the root, so a refusal
+        // here can only come from the handle having no path to address.
+        let (name, mut member) = group.iter_datasets().unwrap().next().unwrap();
+        assert_eq!(name, "inner");
+        assert!(
+            matches!(
+                member.set_attr("tag", AttrValue::I64(1)),
+                Err(Error::ReadOnly)
+            ),
+            "a member of a path-less group must refuse a write, not address `/inner`"
+        );
+
+        let (name, subgroup) = group.iter_groups().unwrap().next().unwrap();
+        assert_eq!(name, "sub");
+        assert!(
+            matches!(
+                subgroup.set_attr("tag", AttrValue::I64(1)),
+                Err(Error::ReadOnly)
+            ),
+            "and so must a subgroup of one, not address `/sub`"
+        );
+    }
+
     /// A yielded handle must carry the same root-relative path as one opened by
     /// name, or a write through it would address the wrong object — or no object
     /// at all. A member of a *subgroup* is the case that separates them, since

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -1391,8 +1391,7 @@ fn collect_addresses(
     prefix: &str,
     map: &mut HashMap<u64, String>,
 ) -> Result<(), Error> {
-    for name in group.datasets()? {
-        let ds = group.dataset(&name)?;
+    for (name, ds) in group.iter_datasets()? {
         map.insert(ds.header_address(), join(prefix, &name));
     }
     // A committed datatype is an object with an address like any other: a dataset
@@ -1402,8 +1401,7 @@ fn collect_addresses(
         let (_, address) = group.named_datatype_at(&name)?;
         map.insert(address, join(prefix, &name));
     }
-    for name in group.groups()? {
-        let child = group.group(&name)?;
+    for (name, child) in group.iter_groups()? {
         let child_path = join(prefix, &name);
         map.insert(child.header_address(), child_path.clone());
         collect_addresses(&child, &child_path, map)?;


### PR DESCRIPTION
`Group::datasets()` returns `Vec<String>`, so walking a group's members meant a `group.dataset(&name)` call per entry and a second `Result` to handle. Iterating members to inspect their attributes is a common shape, and the round trip is not only ergonomic overhead.

`datasets()` already parses every child's object header to tell a dataset from a group, then keeps only `entry.name` and discards the header. `dataset(&name)` then re-walks the group's link structure, linear-scans it for the name, and re-parses that same header. There is no header cache, so on the streaming backend each of those is I/O.

`Group::iter_datasets()` and `Group::iter_groups()` keep what the classification pass read:

```rust
for (name, dataset) in group.iter_datasets()? {
    count += dataset.attrs()?.contains_key("H5PATH") as usize;
}
```

- **One enumeration** of the group, not one per member. `iter_datasets` also reuses the header it parsed to classify the child, so each header is read once instead of twice.
- **Name paired with the handle.** No handle exposes its own name, so yielding a bare `Dataset` would send callers back to `datasets()` for the thing they were walking by. The enumeration already produced the name, so returning it costs nothing.
- `iter_groups` drops the classification header rather than holding it, since a `Group` handle carries none.

`datasets()` and `groups()` are unchanged. Names-only stays a legitimate need, ~30 call sites in `tests/` want it, and constructing n handles is not free.

### What this is *not*

Telling a dataset from a group requires parsing its header, so the enumeration and every member's header parse happen before the iterator is returned. **Breaking out early saves nothing, and reaching one known member this way is much more expensive than `dataset(name)`** — at 64 members, `find()` for one costs 8,260 bytes against 1,393. Only handle construction is deferred, and that is not where the cost is. The docs say so plainly; an earlier draft of them did not.

The consequence of keeping the headers is that they are held for the length of the walk, bounded by the group being walked rather than by the file, but proportional to it. That is the accepted trade for `Item = (String, Dataset)` with no per-item `Result`. Lazy classification would bound it at one header and make an early break cheap, at the price of `Item = Result<(String, Dataset)>` — the second `Result` this change exists to remove.

## Cost

`repack::collect_addresses` was this exact walk inside the crate and now uses the new methods.

Measured with the existing `CountingSource` harness, on a root group of n datasets:

| members | by name (bytes) | iterating (bytes) |
| --- | --- | --- |
| 16 | 9,812 | 2,116 |
| 32 | 29,284 | 4,164 |
| 64 | 97,412 | 8,260 |
| 128 | 354,016 | 16,480 |

Bytes is the metric that separates them. A group this size keeps its links inline in the object header, so that header grows with the member count and re-reading it per member is quadratic; the *number* of reads is linear either way (1,155 against 387 at 128 members) and would show almost nothing.

`iterating_members_enumerates_the_group_once` asserts the scaling rather than a fixed byte count, since a fixed number would pass just as well on a walk that stayed quadratic with a smaller constant. Only its first assertion is about this code; the contrast against the by-name route is labelled as such, with a note telling a future maintainer to drop it rather than chase it if `Group::dataset` ever gets cheaper.

## Tests

Seven, in `src/reader.rs`, each mutation-verified and selective:

| mutation | caught by |
| --- | --- |
| drop `iter_datasets`' is-a-dataset filter | `iter_datasets_agrees_with_opening_each_name`, `the_member_iterators_sort_the_child_kinds_apart` |
| drop the parent path prefix | `a_member_handle_resolves_to_its_own_path` only |
| classify `iter_groups` with `DataLayout` instead of `is_group` | `iter_groups_agrees_with_opening_each_name`, `the_member_iterators_sort_the_child_kinds_apart` |
| reimplement `iter_datasets` by re-opening each name (same results, quadratic) | `iterating_members_enumerates_the_group_once` only |
| discard the file's chunk-cache config | `a_member_handle_carries_the_files_chunk_cache_config` only |
| make `child_path_of` treat a path-less parent as the root | `members_of_a_dereferenced_group_have_no_path` only |

The fourth is the point: a behaviorally identical but quadratic implementation passes every correctness test and is caught only by the scaling test.

The last two came out of review — both mutations left all 765 tests green before those tests existed. The chunk-cache one is silent (same values, only a re-parse and eviction regression). The path one is not: a group reached by `Dataset::dereference` has no resolvable path, and its members must refuse a write rather than address a same-named object at the root, so its fixture puts `inner` and `sub` at both the root and inside the referenced group.

The committed-datatype child is in the main fixture because it belongs to neither iterator, and is the child a walk asking only for datasets and groups is free to mis-sort.

Additive only, so no version bump.

Gates run locally: `cargo fmt --all -- --check`, `cargo clippy --locked --features "serde ndarray" --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo test --lib` (767), `cargo test --doc`, `cargo test --test repack`.