### PR TITLE
Write a large complex array in one bulk step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,33 @@ jobs:
           --test attr_message_size_limit --test userblock_dense_attrs
           --test c_1_8_read_compat
 
+  # Real big-endian execution under QEMU. Every integer this crate writes is
+  # little-endian on disk, so on a big-endian host every read and write has to
+  # swap; nothing else in CI can tell a missing swap from a present one, because
+  # every other target is little-endian and `from_ne_bytes` and `from_le_bytes`
+  # are the same function there. The C-crosscheck dev-dependency is excluded on
+  # this target (see `Cargo.toml`), so this is the pure-Rust suite only.
+  test-big-endian:
+    name: Test (s390x, QEMU via cross)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: cross-s390x
+      - name: cross test (pure-Rust library + byte-order suite on s390x)
+        run: >
+          cross test --locked --target s390x-unknown-linux-gnu
+          --no-default-features
+          --features "std checksum deflate zfp serde ndarray provenance"
+          --lib --test write_read_roundtrip --test serde_roundtrip
+          --test complex_bulk_array --test complex_integer
+          --test streaming_reader --test vlen_strings
+
   # Bare-metal no_std build: proves the crate links without `std` on a genuine
   # `none` target (the existing no-std-check only runs on the std-capable host).
   no-std-bare-metal:
@@ -307,7 +334,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: miri
-      - name: Miri test (mat::transpose unsafe)
+      - name: Miri test (unsafe in mat::transpose and mat::complex)
         # `--no-default-features --features std,serde` selects the smallest set
         # that compiles the code under test: `std` gates the `mat` module and
         # `serde` gates `transpose` within it. Dropping `deflate` also drops
@@ -331,19 +358,28 @@ jobs:
         #      itself has to be asserted nonzero.
         run: |
           set -o pipefail
-          if ! grep -qE '^[^/]*\bunsafe[[:space:]]*(\{|fn |impl )' src/mat/transpose.rs; then
-            echo "::error::src/mat/transpose.rs holds no unsafe code; point this job at the code that does."
-            exit 1
-          fi
-          cargo miri test --locked --no-default-features --features std,serde \
-            --lib mat::transpose 2>&1 | tee miri.log
-          if grep -q "running 0 tests" miri.log; then
-            echo "::error::Miri ran no tests: the --lib filter matched nothing."
-            exit 1
-          fi
-          if ! grep -qE '[1-9][0-9]* passed' miri.log; then
-            echo "::error::Miri passed no tests: they were selected but ignored or skipped."
-            exit 1
-          fi
+          # One entry per module holding unsafe that Miri can reach. Each is
+          # checked for still holding unsafe and for actually running tests, so
+          # the three hollowing modes above are caught per module rather than
+          # masked by whichever sibling still passes.
+          set -- "src/mat/transpose.rs:mat::transpose" "src/mat/complex.rs:mat::complex"
+          for entry in "$@"; do
+            file="${entry%%:*}"
+            filter="${entry##*:}"
+            if ! grep -qE '^[^/]*\bunsafe[[:space:]]*(\{|fn |impl )' "$file"; then
+              echo "::error::$file holds no unsafe code; point this job at the code that does."
+              exit 1
+            fi
+            cargo miri test --locked --no-default-features --features std,serde \
+              --lib "$filter" 2>&1 | tee miri.log
+            if grep -q "running 0 tests" miri.log; then
+              echo "::error::Miri ran no tests for $filter: the --lib filter matched nothing."
+              exit 1
+            fi
+            if ! grep -qE '[1-9][0-9]* passed' miri.log; then
+              echo "::error::Miri passed no tests for $filter: they were selected but ignored or skipped."
+              exit 1
+            fi
+          done
         env:
           MIRIFLAGS: -Zmiri-strict-provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- `mat::complex::i16_array`, and one helper per component class, write a large complex array in bulk from a `#[serde(serialize_with = ...)]` field, roughly twenty-five times faster than the per-element path for the same bytes; an empty slice keeps its component class, where a plain `Vec` writes an empty `double`.
-- `mat::ComplexElement`, the unsafe layout trait those helpers accept, is implemented for the `Complex*` types and — under the new `num-complex` feature — for `num_complex::Complex<T>`.
+- `mat::complex::i16_array`, and one helper per component class, write a large complex array in bulk from a `#[serde(serialize_with = ...)]` field, roughly twenty-five times faster than the per-element path for the same bytes; an empty slice keeps its component class, where a plain `Vec` writes an empty `double` ([#260](https://github.com/stephenberry/hdf5-pure/pull/260)).
+- `mat::ComplexElement`, the unsafe layout trait those helpers accept, is implemented for the `Complex*` types and — under the new `num-complex` feature — for `num_complex::Complex<T>` ([#260](https://github.com/stephenberry/hdf5-pure/pull/260)).
 
 ### Changed
 
-- Writing a complex array is about five times faster, `MatBuilder`'s writers included.
+- Writing a complex array is about five times faster, `MatBuilder`'s writers included ([#260](https://github.com/stephenberry/hdf5-pure/pull/260)).
 
 ## [0.35.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `mat::complex::i16_array`, and one helper per component class, write a large complex array in bulk from a `#[serde(serialize_with = ...)]` field, roughly twenty-five times faster than the per-element path for the same bytes; an empty slice keeps its component class, where a plain `Vec` writes an empty `double`.
+- `mat::ComplexElement`, the unsafe layout trait those helpers accept, is implemented for the `Complex*` types and — under the new `num-complex` feature — for `num_complex::Complex<T>`.
+
+### Changed
+
+- Writing a complex array is about five times faster, `MatBuilder`'s writers included.
+
 ## [0.35.0] - 2026-08-10
 
 A MAT cell array takes its shape and its metadata from the same rules as every other value this crate writes. An empty cell array is `0x0`, MATLAB's own `{}`, where it was `0x1`, and a cell array follows `mat::Options::one_dimensional_mode` like every other 1-D value, so `RowVector` writes `1xN` where a cell used to be a column whatever the option asked for; both are reachable only under non-default options, and `isempty` held under either empty shape, so a reader that only tested emptiness is unaffected. Every object a MAT write interns under `#refs#` — cell elements, struct elements, the MCOS subsystem's helpers — now carries the `H5PATH` attribute MATLAB writes on all but one of its own, which this crate wrote on none ([#258](https://github.com/stephenberry/hdf5-pure/pull/258)). Files written by earlier versions still read.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "flate2",
  "hdf5-metno",
  "ndarray",
+ "num-complex",
  "proptest",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["tests/fixtures/**", "fuzz/**"]
 # leaves their cross-references as dead links); `matio-crosscheck` is a
 # test-only feature and is deliberately excluded.
 [package.metadata.docs.rs]
-features = ["provenance", "parallel", "zfp", "ndarray", "serde"]
+features = ["provenance", "parallel", "zfp", "ndarray", "serde", "num-complex"]
 
 [features]
 default = ["std", "checksum", "deflate"]
@@ -40,6 +40,12 @@ ndarray = ["dep:ndarray", "std"]
 # Serde-based (de)serialization of MATLAB v7.3 .mat files.
 # Requires `std` (uses File/Group/Dataset reader APIs).
 serde = ["dep:serde", "std"]
+# `mat::ComplexElement` impls for `num_complex::Complex<T>`, so the bulk array
+# helpers in `mat::complex` take the de-facto standard Rust complex type
+# directly. The trait is `unsafe` and asserts a memory layout, so the orphan
+# rule puts these impls on whichever crate owns one of the two types — us, not
+# the caller.
+num-complex = ["dep:num-complex", "serde"]
 # Test-only: enable a crosscheck test that links against the system libmatio
 # (reference MATLAB MAT file library). Requires libmatio to be installed:
 # `brew install libmatio` (macOS) or `apt install libmatio-dev` (Debian).
@@ -57,6 +63,9 @@ serde = { version = "1", optional = true, default-features = false, features = [
 # user's existing `ndarray` unifies with ours instead of compiling a second
 # copy. Only APIs stable across 0.16/0.17 are used.
 ndarray = { version = ">=0.16, <0.18", optional = true }
+# Carries only `ComplexElement` impls. No API of ours names a `Complex<T>`, so
+# nothing here appears in a public signature.
+num-complex = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
@@ -72,12 +81,14 @@ criterion = { version = "0.5", default-features = false }
 
 # The reference HDF5 C library, used only by the byte-level crosscheck tests.
 # Its `static` feature compiles libhdf5 from source via CMake, which does not
-# cross-compile to 32-bit targets cleanly and is unnecessary there anyway (a
-# 32-bit host cannot allocate the multi-GiB fixtures these tests build). Gate it
-# to 64-bit-pointer targets so `cross test --target i686-...` can run the
-# pure-Rust suite on a 32-bit pointer width without building any C code. The
-# crosscheck test files carry
-# the matching `#![cfg(not(target_pointer_width = "32"))]` gate.
+# cross-compile cleanly and is unnecessary on the targets excluded here anyway.
+# Gate it to 64-bit little-endian so `cross test` can run the pure-Rust suite on
+# a 32-bit pointer width (`i686`) and on a big-endian host (`s390x`) without
+# building any C code: a 32-bit host cannot allocate the multi-GiB fixtures
+# these tests build, and the point of the big-endian run is this crate's own
+# byte-order handling, not the C library's. The crosscheck test files carry the
+# matching `#![cfg(all(not(target_pointer_width = "32"), target_endian =
+# "little"))]` gate.
 #
 # The suite validates against the current *released* libhdf5, not a development
 # snapshot. Which one that is comes from the `hdf5-metno-src` pin in
@@ -87,7 +98,7 @@ criterion = { version = "0.5", default-features = false }
 # derived from libhdf5 internals that a version change could move, and
 # `tests/c_absence_predicate.rs` guards the assertion most sensitive to one by
 # re-measuring the C library's error codes against deliberately damaged files.
-[target.'cfg(not(target_pointer_width = "32"))'.dev-dependencies]
+[target.'cfg(all(not(target_pointer_width = "32"), target_endian = "little"))'.dev-dependencies]
 hdf5 = { package = "hdf5-metno", version = "0.14", features = ["static", "zlib"] }
 
 [[example]]

--- a/docs/interop/matlab.md
+++ b/docs/interop/matlab.md
@@ -148,9 +148,38 @@ Components are never converted between widths, in either direction. An `int16` c
 
 The same rule is enforced against the file itself: `MATLAB_class` names the component width, the `{real, imag}` compound carries the bytes, and a file where those two disagree is refused rather than decoded. This matters because the disagreement is not always visible — a complex `int64` array with no class attribute at all falls back to `double`, whose element size is identical, so the payload length alone cannot tell them apart.
 
+### Large complex arrays
+
+Serde has no bulk channel for a sequence, so a `Vec<ComplexI16>` costs one serializer dispatch per sample — around 26 ns, which for a capture-sized array is essentially the whole cost of writing the file. `mat::complex` carries a `serialize_with` helper per component class that hands the slice over whole instead:
+
+```rust
+use hdf5_pure::mat::{self, ComplexI16};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Capture {
+    #[serde(serialize_with = "mat::complex::i16_array")]
+    samples: Vec<ComplexI16>,
+}
+```
+
+Measured on 64 Mi samples (256 MiB), one write per process: 1.78 s element-wise against 0.06 s. Repeat writes in a warm process reach 0.03 s, so quote the cold figure for a capture tool that writes once and exits. The bytes are identical either way — this changes how long a write takes, not what it produces.
+
+The element type is any `mat::ComplexElement`: this module's `Complex*` types, `num_complex::Complex<T>` with the `num-complex` feature enabled, or your own. Implementing it is `unsafe` and asserts a layout — `#[repr(C)]`, two components, real first, every byte initialized data — because the helpers read the slice as raw bytes. The component type is part of the bound, so a same-width class cannot slip through: `i32` parts will not compile as `f32_array`.
+
+Three things to know before annotating an existing field:
+
+- **The output is MAT-specific.** The slice crosses serde as a byte string, so the same struct serialized to JSON or another format emits raw bytes rather than a sequence, and its own `Deserialize` will not read that back. Annotate a field only on a type written to `.mat` alone.
+- **An empty slice keeps its component class.** See [empty complex arrays](#empty-complex-arrays) below; it is the only case where the annotation changes the file.
+- **One-dimensional only.** A `Matrix<ComplexI16>` or `Vec<Vec<ComplexI16>>` has no bulk path and still pays per element.
+
+Reading is untouched, which after this change makes it the slower half of a round trip: a `.mat` deserializes through the same per-element path it always did. If peak memory rather than speed is the constraint, [`write_blocks`](#writing-more-data-than-fits-in-memory) is the tool — these helpers still build the array in full.
+
 ### Empty complex arrays
 
 An empty complex array is written here as a zero-element `{real, imag}` compound that keeps its component class, and it round-trips through this crate. MATLAB writes empties differently: `Mat_VarWriteEmpty` stores the dimensions *as data* under `MATLAB_empty = 1`, keeping the plain class name, and the `EmptyMarkerEncoding` option selects that form for real arrays. Complex arrays do not currently follow the option. libmatio reads both forms; if you need the MATLAB-native shape for an empty complex array specifically, write it as an empty real array of the component class instead.
+
+An empty `Vec<ComplexI16>` is the one case where the plain and [bulk](#large-complex-arrays) paths differ. An empty sequence reveals no element, so the plain path cannot recover the component class and falls back on `empty_sequence_policy` — an empty `double` by default, an empty cell under `EmptySequencePolicy::Cell`. The helper was told the class by name and keeps it, matching `MatBuilder::write_complex_i16` and the `Matrix<Complex*>` sentinels. Both read back as an empty array; the shape is `0x0` either way.
 
 ## Cell arrays
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -14,6 +14,7 @@ For how to declare these in `Cargo.toml`, see [Installation](../getting-started/
 | `serde` | no | `serde` | `std` | Serialize/deserialize MATLAB v7.3 `.mat` files via serde |
 | `fast-deflate` | no | `flate2/zlib-ng` | — | zlib-ng backend for deflate |
 | `ndarray` | no | `ndarray` crate | `std` | N-dimensional array I/O via the [`ndarray`](https://docs.rs/ndarray) crate |
+| `num-complex` | no | `num-complex` | `serde` | `mat::ComplexElement` for `num_complex::Complex<T>`, for the bulk complex-array helpers |
 | `parallel` | no | `rayon` | — | Parallel chunk processing via `rayon` |
 | `provenance` | no | `sha2` | — | SHA-256 data provenance tracking |
 | `zfp` | no | — | — | ZFP fixed-rate compression (HDF5 filter 32013), `f32`/`f64`/`i32`/`i64` x 1D-4D |
@@ -59,6 +60,13 @@ Adds ergonomic N-dimensional array I/O via the [`ndarray`](https://docs.rs/ndarr
 
 !!! tip
     The `ndarray_io` example requires this feature and can be run with `cargo run --example ndarray_io --features ndarray`.
+
+### `num-complex`
+
+Implements `mat::ComplexElement` for `num_complex::Complex<T>`, so a slice of the de-facto standard Rust complex type can be handed to the bulk array helpers (`mat::complex::i16_array` and friends) without a conversion pass. It implies `serde`. See [large complex arrays](../interop/matlab.md#large-complex-arrays).
+
+!!! note
+    The impls have to ship here rather than in your crate: `ComplexElement` is `unsafe` and asserts a memory layout, and the orphan rule allows the impl only from a crate that owns one of the two types. Your *own* complex type needs no feature — implement the trait for it directly.
 
 ### `parallel`
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -8416,8 +8416,9 @@ mod tests {
     /// (issue #202).
     #[test]
     // Reads back with the reference HDF5 C library (`hdf5-metno`), a
-    // 64-bit-only dev-dependency; skip on 32-bit so the lib tests run there.
-    #[cfg(not(target_pointer_width = "32"))]
+    // 64-bit little-endian-only dev-dependency; skip elsewhere so the lib
+    // tests still run there.
+    #[cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
     fn append_inplace_crash_consistency_c_library_reads_prefix() {
         use tempfile::tempdir;
 
@@ -8473,8 +8474,9 @@ mod tests {
     /// case.
     #[test]
     // Reads back with the reference HDF5 C library (`hdf5-metno`), a
-    // 64-bit-only dev-dependency; skip on 32-bit so the lib tests run there.
-    #[cfg(not(target_pointer_width = "32"))]
+    // 64-bit little-endian-only dev-dependency; skip elsewhere so the lib
+    // tests still run there.
+    #[cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
     fn append_inplace_recover_and_reappend_after_phase3_crash() {
         use crate::reader::File as PureFile;
         use tempfile::tempdir;

--- a/src/group_v2.rs
+++ b/src/group_v2.rs
@@ -595,7 +595,7 @@ mod tests {
 /// which is the only writer that produces a huge *link*: this crate's writer
 /// stores even a 60,000-byte link name as a managed heap object, so the huge
 /// path these tests cover is unreachable from a file it wrote.
-#[cfg(all(test, not(target_pointer_width = "32")))]
+#[cfg(all(test, not(target_pointer_width = "32"), target_endian = "little"))]
 mod huge_link_tests {
     use super::*;
     use crate::fractal_heap::{huge_index_decodes, reset_huge_index_decodes};

--- a/src/mat/complex.rs
+++ b/src/mat/complex.rs
@@ -14,6 +14,10 @@
 //! Nothing is ever widened on the way in or out — a value written as
 //! [`ComplexI16`] reads back only as [`ComplexI16`], so the file always says
 //! what it holds.
+//!
+//! For a large array, reach for the [`i16_array`]-style helpers below rather
+//! than letting serde walk the elements: a sentinel struct per sample costs
+//! about 26 ns, which is most of what writing a capture takes.
 
 use core::fmt;
 
@@ -24,7 +28,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::mat::value::ComplexTag;
 
 macro_rules! complex_types {
-    ($($name:ident => $scalar:ty, $sentinel:ident, $tag:ident, $matlab:literal),* $(,)?) => {
+    ($($name:ident => $scalar:ty, $sentinel:ident, $array_sentinel:ident,
+       $array_fn:ident, $tag:ident, $matlab:literal),* $(,)?) => {
         $(
             #[doc = concat!(
                 "Sentinel struct name for [`", stringify!($name), "`]."
@@ -33,11 +38,22 @@ macro_rules! complex_types {
                 concat!("__hdf5_pure_mat_", stringify!($name), "__");
 
             #[doc = concat!(
+                "Sentinel newtype name for a whole slice of [`", stringify!($name),
+                "`], written by [`", stringify!($array_fn), "`]."
+            )]
+            pub(crate) const $array_sentinel: &str =
+                concat!("__hdf5_pure_mat_", stringify!($name), "_array__");
+
+            #[doc = concat!(
                 "A complex number with `", stringify!($scalar),
                 "` components, stored as a MATLAB `", $matlab,
                 "` complex array."
             )]
+            ///
+            /// `#[repr(C)]` so a slice of these is a valid input to the
+            /// matching array helper, which reads the slice as raw bytes.
             #[derive(Debug, Clone, Copy, PartialEq)]
+            #[repr(C)]
             pub struct $name {
                 /// Real part.
                 pub re: $scalar,
@@ -102,6 +118,103 @@ macro_rules! complex_types {
                     )
                 }
             }
+
+            #[doc = concat!(
+                "Serialize a slice of complex `", stringify!($scalar),
+                "` as one MATLAB `", $matlab, "` complex array."
+            )]
+            ///
+            /// A `serialize_with` helper. Serde has no bulk channel for a
+            /// sequence, so the default `Vec<T>` path pays a serializer
+            /// dispatch per sample; this hands the slice over whole and is the
+            /// difference between a 0.15 GB/s write and a multi-GB/s one.
+            ///
+            #[doc = concat!(
+                "Takes any [`ComplexElement`] whose `Component` is `",
+                stringify!($scalar), "` — this module's [`", stringify!($name),
+                "`], `num_complex::Complex<", stringify!($scalar),
+                ">` under the `num-complex` feature, or your own type. The \
+                 component is part of the bound, so a same-width class cannot \
+                 slip through: `i32` parts will not compile here."
+            )]
+            ///
+            /// Two things to know before annotating an existing field:
+            ///
+            /// - **The output is MAT-specific.** The slice crosses serde as a
+            ///   byte string, so serializing the same struct to JSON or another
+            ///   format yields raw bytes rather than a sequence, and its own
+            ///   `Deserialize` will not read that back. Annotate a field only
+            ///   on a type written to `.mat` alone.
+            #[doc = concat!(
+                "- **An empty slice keeps its component class**, writing an \
+                 empty `", $matlab, "` array where a plain `Vec<",
+                stringify!($name), ">` writes an empty `double`. That is the \
+                 only case where the annotation changes the file."
+            )]
+            ///
+            /// Reading is untouched: the file deserializes through the ordinary
+            /// per-element path, which is now the slower half of a round trip.
+            ///
+            /// One-dimensional only — a [`Matrix`](crate::mat::Matrix) of
+            /// complex values has no bulk path.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// # use hdf5_pure::mat;
+            /// # use serde::Serialize;
+            /// #[derive(Serialize)]
+            /// struct Capture {
+            #[doc = concat!("    #[serde(serialize_with = \"mat::complex::",
+                            stringify!($array_fn), "\")]")]
+            #[doc = concat!("    samples: Vec<mat::", stringify!($name), ">,")]
+            /// }
+            /// ```
+            pub fn $array_fn<S, T>(data: &[T], serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+                T: ComplexElement<Component = $scalar>,
+            {
+                // A backstop against a wrong `unsafe impl`, which is the only
+                // way to reach this with a `T` of the wrong shape. Everything
+                // else the byte view needs — initialized, no padding, real
+                // first — is what the impl promised and cannot be checked.
+                assert_eq!(
+                    core::mem::size_of::<T>(),
+                    2 * core::mem::size_of::<$scalar>(),
+                    concat!(
+                        "mat::complex::", stringify!($array_fn),
+                        ": ComplexElement impl has the wrong element size",
+                    ),
+                );
+                // SAFETY: `T: ComplexElement<Component = $scalar>` is an
+                // unsafe promise that every byte of `T` is initialized data
+                // laid out as two `$scalar`, so the whole slice is readable as
+                // bytes; the size assert above catches an impl that got the
+                // width wrong. Reading as `u8` needs no alignment, and the
+                // length comes from the slice itself. Empty slices are fine:
+                // `as_ptr` is non-null and aligned even when dangling.
+                let raw: &[u8] = unsafe {
+                    core::slice::from_raw_parts(
+                        data.as_ptr().cast::<u8>(),
+                        core::mem::size_of_val(data),
+                    )
+                };
+                serializer.serialize_newtype_struct($array_sentinel, &RawComplexBytes(raw))
+            }
+
+            // SAFETY: declared `#[repr(C)]` above with exactly two `$scalar`
+            // fields, real first. Two equal-width scalars leave no padding.
+            unsafe impl ComplexElement for $name {
+                type Component = $scalar;
+            }
+
+            // SAFETY: `num_complex::Complex<T>` is `#[repr(C)]` with `re`
+            // then `im`, the same shape as `$name`.
+            #[cfg(feature = "num-complex")]
+            unsafe impl ComplexElement for num_complex::Complex<$scalar> {
+                type Component = $scalar;
+            }
         )*
 
         /// The component class a complex sentinel names, or `None` for any
@@ -116,20 +229,68 @@ macro_rules! complex_types {
                 _ => None,
             }
         }
+
+        /// The component class a bulk-array sentinel names, or `None` for any
+        /// other newtype name. The slice counterpart of
+        /// [`complex_tag_for_sentinel`].
+        pub(crate) fn complex_tag_for_array_sentinel(name: &str) -> Option<ComplexTag> {
+            match name {
+                $($array_sentinel => Some(ComplexTag::$tag),)*
+                _ => None,
+            }
+        }
     };
 }
 
+/// A type the array helpers may read as raw bytes: two `Component` fields,
+/// real first, and nothing else.
+///
+/// Implemented for this module's [`ComplexI16`] and friends, and for
+/// `num_complex::Complex<T>` under the `num-complex` feature. Implement it for
+/// your own complex type to pass a slice of it to [`i16_array`] and company;
+/// the orphan rule means a type from a third crate needs an impl from one of
+/// the two crates that own it.
+///
+/// # Safety
+///
+/// `Self` must have a guaranteed layout (`#[repr(C)]` or `#[repr(transparent)]`)
+/// of exactly two `Component` fields, real first, and every byte of it must be
+/// initialized and meaningful as data. In particular no padding, no
+/// `MaybeUninit`, no pointers or references, and no interior mutability: the
+/// helpers copy `size_of::<Self>()` bytes per element straight into the file,
+/// so a padding byte is both undefined behavior and an uninitialized byte
+/// written to disk.
+///
+/// `Component` names the MATLAB class the array is stored as, which is what
+/// stops a same-width mix-up — `i32` components cannot reach [`f32_array`]
+/// even though the two elements are the same size and alignment.
+pub unsafe trait ComplexElement: Copy {
+    /// The scalar class of both parts.
+    type Component;
+}
+
+/// The caller's slice as borrowed native-endian bytes. `serialize_bytes` is
+/// serde's only bulk channel, so a serializer that does not know the sentinel
+/// sees a plain byte string — which is why these helpers are MAT-specific.
+struct RawComplexBytes<'a>(&'a [u8]);
+
+impl Serialize for RawComplexBytes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.0)
+    }
+}
+
 complex_types! {
-    Complex64 => f64, COMPLEX64_SENTINEL, F64, "double",
-    Complex32 => f32, COMPLEX32_SENTINEL, F32, "single",
-    ComplexI64 => i64, COMPLEX_I64_SENTINEL, I64, "int64",
-    ComplexI32 => i32, COMPLEX_I32_SENTINEL, I32, "int32",
-    ComplexI16 => i16, COMPLEX_I16_SENTINEL, I16, "int16",
-    ComplexI8 => i8, COMPLEX_I8_SENTINEL, I8, "int8",
-    ComplexU64 => u64, COMPLEX_U64_SENTINEL, U64, "uint64",
-    ComplexU32 => u32, COMPLEX_U32_SENTINEL, U32, "uint32",
-    ComplexU16 => u16, COMPLEX_U16_SENTINEL, U16, "uint16",
-    ComplexU8 => u8, COMPLEX_U8_SENTINEL, U8, "uint8",
+    Complex64 => f64, COMPLEX64_SENTINEL, COMPLEX64_ARRAY_SENTINEL, f64_array, F64, "double",
+    Complex32 => f32, COMPLEX32_SENTINEL, COMPLEX32_ARRAY_SENTINEL, f32_array, F32, "single",
+    ComplexI64 => i64, COMPLEX_I64_SENTINEL, COMPLEX_I64_ARRAY_SENTINEL, i64_array, I64, "int64",
+    ComplexI32 => i32, COMPLEX_I32_SENTINEL, COMPLEX_I32_ARRAY_SENTINEL, i32_array, I32, "int32",
+    ComplexI16 => i16, COMPLEX_I16_SENTINEL, COMPLEX_I16_ARRAY_SENTINEL, i16_array, I16, "int16",
+    ComplexI8 => i8, COMPLEX_I8_SENTINEL, COMPLEX_I8_ARRAY_SENTINEL, i8_array, I8, "int8",
+    ComplexU64 => u64, COMPLEX_U64_SENTINEL, COMPLEX_U64_ARRAY_SENTINEL, u64_array, U64, "uint64",
+    ComplexU32 => u32, COMPLEX_U32_SENTINEL, COMPLEX_U32_ARRAY_SENTINEL, u32_array, U32, "uint32",
+    ComplexU16 => u16, COMPLEX_U16_SENTINEL, COMPLEX_U16_ARRAY_SENTINEL, u16_array, U16, "uint16",
+    ComplexU8 => u8, COMPLEX_U8_SENTINEL, COMPLEX_U8_ARRAY_SENTINEL, u8_array, U8, "uint8",
 }
 
 #[cfg(test)]
@@ -154,6 +315,42 @@ mod tests {
             Some(ComplexTag::F64)
         );
         assert_eq!(complex_tag_for_sentinel("SomeUserStruct"), None);
+    }
+
+    /// Drive the byte view the array helpers take, small enough for Miri to
+    /// interpret — the CI Miri job runs this module, and the unsafe here is
+    /// the reason it does.
+    ///
+    /// The interesting inputs are the ones a size-and-alignment check could
+    /// not have rejected: an empty slice (whose `as_ptr` is dangling) and a
+    /// one-element slice, both of which have to produce the same value the
+    /// element-wise path would.
+    #[test]
+    fn the_array_helpers_read_their_slice_without_undefined_behavior() {
+        use crate::mat::options::Options;
+        use crate::mat::ser::value_ser::ValueSerializer;
+        use crate::mat::value::{ComplexVec, MatValue};
+
+        let opts = Options::default();
+
+        let pairs = [ComplexI16::new(1, -2), ComplexI16::new(3, -4)];
+        assert_eq!(
+            i16_array(&pairs, ValueSerializer::new(&opts)).unwrap(),
+            MatValue::ComplexVec1D(ComplexVec::I16(vec![(1, -2), (3, -4)])),
+        );
+
+        assert_eq!(
+            i16_array(&[] as &[ComplexI16], ValueSerializer::new(&opts)).unwrap(),
+            MatValue::ComplexVec1D(ComplexVec::I16(Vec::new())),
+        );
+
+        // A wider component, so a stride error shows up as a wrong value
+        // rather than as a coincidence.
+        let wide = [Complex64::new(1.5, -2.5)];
+        assert_eq!(
+            f64_array(&wide, ValueSerializer::new(&opts)).unwrap(),
+            MatValue::ComplexVec1D(ComplexVec::F64(vec![(1.5, -2.5)])),
+        );
     }
 
     /// The sentinel is the only thing distinguishing one complex type from

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -94,8 +94,8 @@ pub use producer::{Block, BlockElement, Blocking, DataProducer};
 
 #[cfg(feature = "serde")]
 pub use complex::{
-    Complex32, Complex64, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8, ComplexU16,
-    ComplexU32, ComplexU64,
+    Complex32, Complex64, ComplexElement, ComplexI8, ComplexI16, ComplexI32, ComplexI64, ComplexU8,
+    ComplexU16, ComplexU32, ComplexU64,
 };
 #[cfg(feature = "serde")]
 pub use matrix::{MatElement, Matrix};

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -217,8 +217,16 @@ fn apply_value_to_dataset(
             Ok(())
         }
         MatValue::ComplexVec1D(pairs) => {
-            let n = pairs.len() as u64;
-            apply_complex(ds, pairs, &[1, n]);
+            // `[0, 0]` when empty, the answer `dims::vector_dims` gives the
+            // options emitter — read the note there on why the two must not
+            // drift. An empty complex vector only became reachable with the
+            // `mat::complex` array helpers: before them no input produced this
+            // arm with no pairs, so the hardcoded `[1, n]` was never wrong.
+            let shape = match pairs.len() as u64 {
+                0 => [0, 0],
+                n => [1, n],
+            };
+            apply_complex(ds, pairs, &shape);
             Ok(())
         }
         MatValue::ComplexMatrix { rows, cols, pairs } => {

--- a/src/mat/ser/mod.rs
+++ b/src/mat/ser/mod.rs
@@ -3,7 +3,9 @@
 mod emit;
 mod emit_with_builder;
 mod root;
-mod value_ser;
+// `pub(crate)` so `mat::complex`'s Miri test can drive the real serializer
+// over the byte view its array helpers build. Nothing is re-exported.
+pub(crate) mod value_ser;
 
 pub use root::{
     to_bytes, to_bytes_with_options, to_path, to_path_with_options, to_writer,

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -9,7 +9,7 @@ use serde::ser::{
     SerializeTupleStruct, Serializer,
 };
 
-use crate::mat::complex::complex_tag_for_sentinel;
+use crate::mat::complex::{complex_tag_for_array_sentinel, complex_tag_for_sentinel};
 use crate::mat::error::MatError;
 use crate::mat::matrix::{MATRIX_SENTINEL, complex_tag_for_matrix_sentinel};
 use crate::mat::options::{EmptySequencePolicy, NullPolicy, Options, UnitVariantEncoding};
@@ -169,9 +169,16 @@ impl<'a> Serializer for ValueSerializer<'a> {
 
     fn serialize_newtype_struct<T: Serialize + ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         value: &T,
     ) -> Result<MatValue, MatError> {
+        // A bulk complex array: `mat::complex`'s array helpers hand the whole
+        // slice over as one byte payload rather than paying a serializer
+        // dispatch per sample. The result is the value the element-wise path
+        // would have built, so the file is unchanged either way.
+        if let Some(tag) = complex_tag_for_array_sentinel(name) {
+            return value.serialize(ComplexArraySer { tag });
+        }
         // Transparent newtype — pass through.
         value.serialize(self)
     }
@@ -242,6 +249,138 @@ impl<'a> Serializer for ValueSerializer<'a> {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, MatError> {
         Err(MatError::UnsupportedType("struct enum variant"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bulk complex array: the payload of a `mat::complex` array sentinel
+// ---------------------------------------------------------------------------
+
+/// Turns one borrowed byte payload into a whole [`MatValue::ComplexVec1D`].
+///
+/// Only `serialize_bytes` is reachable. The array sentinels are `pub(crate)`
+/// and `mat::complex`'s helpers are their only writer, so every other method
+/// here is a bug in this crate rather than something a caller can provoke —
+/// hence one shared message instead of a tailored one per type.
+struct ComplexArraySer {
+    tag: ComplexTag,
+}
+
+impl ComplexArraySer {
+    fn wrong_payload() -> MatError {
+        MatError::Custom("a complex array sentinel must carry its samples as bytes".to_owned())
+    }
+}
+
+/// The scalar entry points, all of them refusals.
+macro_rules! reject_payload {
+    ($($method:ident($ty:ty)),* $(,)?) => {
+        $(fn $method(self, _v: $ty) -> Result<MatValue, MatError> {
+            Err(Self::wrong_payload())
+        })*
+    };
+}
+
+impl Serializer for ComplexArraySer {
+    type Ok = MatValue;
+    type Error = MatError;
+
+    type SerializeSeq = Impossible<MatValue, MatError>;
+    type SerializeTuple = Impossible<MatValue, MatError>;
+    type SerializeTupleStruct = Impossible<MatValue, MatError>;
+    type SerializeTupleVariant = Impossible<MatValue, MatError>;
+    type SerializeMap = Impossible<MatValue, MatError>;
+    type SerializeStruct = Impossible<MatValue, MatError>;
+    type SerializeStructVariant = Impossible<MatValue, MatError>;
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<MatValue, MatError> {
+        Ok(MatValue::ComplexVec1D(ComplexVec::from_native_bytes(
+            self.tag, v,
+        )?))
+    }
+
+    reject_payload! {
+        serialize_bool(bool),
+        serialize_i8(i8), serialize_i16(i16), serialize_i32(i32), serialize_i64(i64),
+        serialize_u8(u8), serialize_u16(u16), serialize_u32(u32), serialize_u64(u64),
+        serialize_f32(f32), serialize_f64(f64),
+        serialize_char(char), serialize_str(&str),
+        serialize_unit_struct(&'static str),
+    }
+
+    fn serialize_none(self) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_some<T: Serialize + ?Sized>(self, _v: &T) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_unit(self) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+    ) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        _v: &T,
+    ) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+        _v: &T,
+    ) -> Result<MatValue, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, MatError> {
+        Err(Self::wrong_payload())
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, MatError> {
+        Err(Self::wrong_payload())
     }
 }
 

--- a/src/mat/value.rs
+++ b/src/mat/value.rs
@@ -352,6 +352,45 @@ macro_rules! complex_kinds {
                 }
             }
 
+            /// Rebuild a vector of `tag`'s class from interleaved `(re, im)`
+            /// components in **native**-endian order.
+            ///
+            /// Native, not little-endian, because the bytes are a live Rust
+            /// slice the caller handed over whole (see `mat::complex`'s array
+            /// helpers) rather than anything read from a file. The writer
+            /// re-encodes to little-endian on the way out, so a big-endian
+            /// host produces the same file a little-endian one does.
+            pub(crate) fn from_native_bytes(
+                tag: ComplexTag,
+                bytes: &[u8],
+            ) -> Result<Self, MatError> {
+                match tag {
+                    $(ComplexTag::$variant => {
+                        const W: usize = core::mem::size_of::<$ty>();
+                        if bytes.len() % (2 * W) != 0 {
+                            return Err(MatError::Custom(format!(
+                                "complex {} array payload of {} bytes is not a whole \
+                                 number of {}-byte pairs",
+                                ComplexTag::$variant.class().as_str(),
+                                bytes.len(),
+                                2 * W,
+                            )));
+                        }
+                        let v: Vec<($ty, $ty)> = bytes
+                            .chunks_exact(2 * W)
+                            .map(|pair| {
+                                let (re, im) = pair.split_at(W);
+                                (
+                                    <$ty>::from_ne_bytes(re.try_into().expect("half of a pair")),
+                                    <$ty>::from_ne_bytes(im.try_into().expect("half of a pair")),
+                                )
+                            })
+                            .collect();
+                        Ok(ComplexVec::$variant(v))
+                    })*
+                }
+            }
+
             /// Consume the vector as a stream of pairs. For a caller that is
             /// unpacking the whole thing, unlike [`get`](Self::get)'s cursor
             /// walk.
@@ -537,5 +576,48 @@ impl MatValue {
             MatValue::StructArray { .. } => "struct array",
             MatValue::Opaque { .. } => "opaque object",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Native rather than little-endian is the whole reason a big-endian host
+    /// writes the same file: the components come out of live memory, and the
+    /// writer swaps them on the way to disk.
+    ///
+    /// Written with `to_ne_bytes` on both sides, so it holds either way — but
+    /// that also means it cannot catch `from_ne_bytes` being changed to
+    /// `from_le_bytes`, and no CI target is big-endian. Reason about this one
+    /// rather than trusting it to fail.
+    #[test]
+    fn native_bytes_decode_at_the_host_order() {
+        let pair = [1i16.to_ne_bytes(), (-2i16).to_ne_bytes()].concat();
+        assert_eq!(
+            ComplexVec::from_native_bytes(ComplexTag::I16, &pair).unwrap(),
+            ComplexVec::I16(vec![(1, -2)]),
+        );
+    }
+
+    /// A payload that does not divide into whole pairs would otherwise lose
+    /// its tail silently, since `chunks_exact` ignores a short remainder.
+    #[test]
+    fn a_partial_pair_is_refused_rather_than_truncated() {
+        let err = ComplexVec::from_native_bytes(ComplexTag::I16, &[0, 1, 2, 3, 4]).unwrap_err();
+        assert!(
+            format!("{err}").contains("whole number of 4-byte pairs"),
+            "unexpected message: {err}"
+        );
+    }
+
+    /// The tag is the only thing an empty payload carries, and losing it is
+    /// what makes an empty array write as an untyped `double`.
+    #[test]
+    fn an_empty_payload_keeps_its_class() {
+        assert_eq!(
+            ComplexVec::from_native_bytes(ComplexTag::U8, &[]).unwrap(),
+            ComplexVec::U8(Vec::new()),
+        );
     }
 }

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -2101,7 +2101,7 @@ mod attribute_fidelity_tests {
     /// itself, which a message it encodes wrongly and parses back just as wrongly
     /// would satisfy. These encodings reach the file through an internal seam
     /// with no public spelling, so nothing else in the suite would catch that.
-    #[cfg(not(target_pointer_width = "32"))]
+    #[cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
     fn c_library_reads_every_attribute(file: &Path, expected: usize) {
         let c = hdf5::File::open(file).expect("the C library must open the repacked file");
         for names in [
@@ -2125,9 +2125,10 @@ mod attribute_fidelity_tests {
         }
     }
 
-    /// The C library is a 64-bit-only dev-dependency, so the check compiles out
-    /// on 32-bit and the pure-Rust half of the test still runs there.
-    #[cfg(target_pointer_width = "32")]
+    /// The C library is a 64-bit little-endian-only dev-dependency, so the
+    /// check compiles out elsewhere and the pure-Rust half of the test still
+    /// runs there.
+    #[cfg(not(all(not(target_pointer_width = "32"), target_endian = "little")))]
     fn c_library_reads_every_attribute(_file: &Path, _expected: usize) {}
 
     /// The other half of the rule: an attribute whose bytes are a *location* must

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -264,8 +264,12 @@ pub(crate) trait ComplexComponent: complex_component::Sealed + Copy {
     /// `with_*_data` writer emits for a real dataset of the same class.
     fn datatype() -> Datatype;
 
-    /// Append `self` to `out` in little-endian byte order.
-    fn encode_le(self, out: &mut Vec<u8>);
+    /// Write `self` to `dst`, exactly `size_of::<Self>()` bytes, little-endian.
+    ///
+    /// A pre-sized buffer rather than a `Vec` to push onto: this runs twice per
+    /// complex element, and the bounds check dominated the write — about 5x on
+    /// a large array.
+    fn encode_le_into(self, dst: &mut [u8]);
 
     /// Decode one component from exactly `size_of::<Self>()` little-endian
     /// bytes. Callers slice the element out of the raw buffer first, so a
@@ -285,8 +289,8 @@ macro_rules! impl_complex_component {
                 fn datatype() -> Datatype {
                     $make()
                 }
-                fn encode_le(self, out: &mut Vec<u8>) {
-                    out.extend_from_slice(&self.to_le_bytes());
+                fn encode_le_into(self, dst: &mut [u8]) {
+                    dst.copy_from_slice(&self.to_le_bytes());
                 }
                 #[cfg(feature = "serde")]
                 fn decode_le(bytes: &[u8]) -> Self {
@@ -1858,10 +1862,12 @@ impl DatasetBuilder {
             .field("real", T::datatype())
             .field("imag", T::datatype())
             .build();
-        let mut raw = Vec::with_capacity(data.len() * 2 * size_of::<T>());
-        for &(re, im) in data {
-            re.encode_le(&mut raw);
-            im.encode_le(&mut raw);
+        let width = size_of::<T>();
+        let mut raw = vec![0u8; data.len() * 2 * width];
+        for (slot, &(re, im)) in raw.chunks_exact_mut(2 * width).zip(data) {
+            let (real, imag) = slot.split_at_mut(width);
+            re.encode_le_into(real);
+            im.encode_le_into(imag);
         }
         self.with_compound_data(ct, raw, data.len() as u64)
     }

--- a/tests/append_crosscheck.rs
+++ b/tests/append_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// gated to 64-bit little-endian targets; skip elsewhere so the pure-Rust suite still
 // runs under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Interop tests for `Dataset::append_staged`: append to a filtered,
 //! unlimited, Extensible-Array-indexed dataset and confirm the reference C
 //! library (`hdf5-metno`) reads the grown dataset back exactly — including

--- a/tests/append_writer_crosscheck.rs
+++ b/tests/append_writer_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// gated to 64-bit little-endian targets; skip elsewhere so the pure-Rust suite still
 // runs under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Interop tests for in-place appends through an owned handle: append to a
 //! filtered, unlimited,
 //! Extensible-Array-indexed dataset and confirm the reference C library

--- a/tests/attr_count_crosscheck.rs
+++ b/tests/attr_count_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the object header's *attribute count*.
 //!
 //! On a version 2 object header the C library does not count attribute messages

--- a/tests/attr_message_size_crosscheck.rs
+++ b/tests/attr_message_size_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the compact-attribute message-size limit
 //! (issue #190).
 //!

--- a/tests/bounded_append_crosscheck.rs
+++ b/tests/bounded_append_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the bounded read-write backend (issue #147):
 //! files grown through the bounded engine read back byte-correct in the
 //! reference C library, both when the C library wrote the original file and

--- a/tests/c_1_8_read_compat.rs
+++ b/tests/c_1_8_read_compat.rs
@@ -4,7 +4,7 @@
 //! to be. `tests/owned_swmr_crosscheck.rs` already asks libhdf5 for a version 1
 //! superblock and checks the parsed K values and status flags against it, and
 //! `tests/edit_crosscheck.rs` does the same for a version 2 one. What both cost
-//! is the `hdf5-metno` dev-dependency, which requires 64-bit pointers — so every
+//! is the `hdf5-metno` dev-dependency, which requires 64-bit little-endian — so every
 //! file using it opens with `#![cfg(not(target_pointer_width = "32"))]` and
 //! compiles out on the i686 target, which is where address arithmetic is most
 //! likely to be wrong. Reading committed bytes needs no dev-dependency, so this

--- a/tests/c_absence_predicate.rs
+++ b/tests/c_absence_predicate.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Guards the discriminating power of [`common::assert_c_absent`], which the
 //! delete crosschecks use to prove a removed object is *absent* rather than
 //! merely unreachable.

--- a/tests/c_write_compat.rs
+++ b/tests/c_write_compat.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! The reference HDF5 C library must be able to *modify* a file hdf5-pure wrote,
 //! not just read it. Inserting a link into a group makes the C library read the
 //! group's Group Info message (`H5G_obj_insert` -> `H5O_msg_read(H5O_GINFO_ID)`);

--- a/tests/cell_array.rs
+++ b/tests/cell_array.rs
@@ -1,7 +1,11 @@
 // Crosschecks against the reference HDF5 C library (`hdf5-metno`), gated to
-// 64-bit-pointer targets; skip on 32-bit so `cross test --target i686-...`
-// stays pure-Rust.
-#![cfg(all(feature = "serde", not(target_pointer_width = "32")))]
+// 64-bit little-endian targets; skip elsewhere so `cross test` on `i686` and
+// `s390x` stays pure-Rust.
+#![cfg(all(
+    feature = "serde",
+    not(target_pointer_width = "32"),
+    target_endian = "little"
+))]
 //! Cell-array serialization for sequences that don't fit a numeric matrix.
 //!
 //! `Vec<MyStruct>`, `Vec<Option<T>>` with `None` interspersed, and

--- a/tests/committed_datatype_crosscheck.rs
+++ b/tests/committed_datatype_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Committed (`H5Tcommit`) datatypes, written by the reference C library and read
 //! back by hdf5-pure (issue #254).
 //!

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,16 +4,16 @@
 //!
 //! Items in [`heap`] are pure Rust and available everywhere. Everything at this
 //! level touches the reference C library, which is a dev-dependency gated to
-//! 64-bit-pointer targets, so it compiles out on 32-bit rather than forcing every
-//! including file to carry the gate.
+//! 64-bit little-endian targets, so it compiles out on `i686` and `s390x`
+//! rather than forcing every including file to carry the gate.
 #![allow(dead_code)]
 
 pub mod heap;
 
-#[cfg(not(target_pointer_width = "32"))]
+#[cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 mod c_library;
 // Not every including binary uses the C helpers — some want only `heap` — and an
 // unused re-export is a warning that `allow(dead_code)` does not cover.
-#[cfg(not(target_pointer_width = "32"))]
+#[cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 #[allow(unused_imports)]
 pub use c_library::*;

--- a/tests/complex_bulk_array.rs
+++ b/tests/complex_bulk_array.rs
@@ -1,0 +1,516 @@
+#![cfg(feature = "serde")]
+//! The bulk complex-array helpers in [`mat::complex`].
+//!
+//! Serde has no bulk channel for a sequence, so a `Vec<ComplexI16>` pays a
+//! serializer dispatch per sample — about 26 ns, which for a capture-sized
+//! array is the whole cost of writing the file. The helpers hand the slice
+//! over whole instead.
+//!
+//! That makes byte-for-byte equivalence with the element-wise path the
+//! property worth pinning: the helpers exist to change how long a write takes,
+//! not what it produces. The one deliberate exception is the empty slice, and
+//! it has its own test below.
+
+use hdf5_pure::mat::options::OneDimensionalMode;
+use hdf5_pure::mat::{
+    self, Complex32, Complex64, ComplexElement, ComplexI8, ComplexI16, ComplexI32, ComplexI64,
+    ComplexU8, ComplexU16, ComplexU32, ComplexU64, Compression, Options,
+};
+use hdf5_pure::{AttrValue, File, LibVer};
+use serde::{Deserialize, Serialize, Serializer};
+
+/// A single pair, odd and even counts, and an element count past `u16::MAX`.
+/// The empty slice is deliberately absent — it is the one length where the two
+/// paths differ, so it has tests of its own below.
+const LENGTHS: &[usize] = &[1, 2, 3, 7, 64, 1000, 65537];
+
+/// One equivalence test per component class: the same values written both
+/// ways, compared as whole files.
+///
+/// Per class rather than once generically, because the class is what the
+/// helper selects — a helper wired to the wrong width or the wrong sentinel
+/// would still round-trip through this crate and still be wrong in MATLAB.
+macro_rules! equivalence_per_class {
+    ($($test:ident => $elem:ident, $scalar:ty, $helper:path),* $(,)?) => {
+        $(
+            #[test]
+            fn $test() {
+                #[derive(Serialize)]
+                struct Elementwise {
+                    data: Vec<$elem>,
+                }
+
+                struct Slice<'a>(&'a [$elem]);
+
+                impl Serialize for Slice<'_> {
+                    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                        $helper(self.0, s)
+                    }
+                }
+
+                #[derive(Serialize)]
+                struct Bulk<'a> {
+                    data: Slice<'a>,
+                }
+
+                for &n in LENGTHS {
+                    let data: Vec<$elem> = (0..n)
+                        .map(|i| <$elem>::new(i as $scalar, (n - i) as $scalar))
+                        .collect();
+                    let element_wise = mat::to_bytes(&Elementwise { data: data.clone() })
+                        .expect("element-wise write");
+                    let bulk = mat::to_bytes(&Bulk { data: Slice(&data) }).expect("bulk write");
+                    assert_eq!(
+                        element_wise,
+                        bulk,
+                        concat!(stringify!($elem), ": bulk and element-wise files differ at {} samples"),
+                        n,
+                    );
+                }
+            }
+        )*
+    };
+}
+
+equivalence_per_class! {
+    f64_array_matches_element_wise => Complex64, f64, mat::complex::f64_array,
+    f32_array_matches_element_wise => Complex32, f32, mat::complex::f32_array,
+    i64_array_matches_element_wise => ComplexI64, i64, mat::complex::i64_array,
+    i32_array_matches_element_wise => ComplexI32, i32, mat::complex::i32_array,
+    i16_array_matches_element_wise => ComplexI16, i16, mat::complex::i16_array,
+    i8_array_matches_element_wise => ComplexI8, i8, mat::complex::i8_array,
+    u64_array_matches_element_wise => ComplexU64, u64, mat::complex::u64_array,
+    u32_array_matches_element_wise => ComplexU32, u32, mat::complex::u32_array,
+    u16_array_matches_element_wise => ComplexU16, u16, mat::complex::u16_array,
+    u8_array_matches_element_wise => ComplexU8, u8, mat::complex::u8_array,
+}
+
+// ---------------------------------------------------------------------------
+// The documented usage: a `serialize_with` attribute on a struct field
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Capture {
+    label: String,
+    #[serde(serialize_with = "mat::complex::i16_array")]
+    samples: Vec<ComplexI16>,
+}
+
+/// The bulk path is a write-side optimization only, so the file it produces
+/// has to deserialize through the ordinary `Vec<ComplexI16>` reader.
+#[test]
+fn a_bulk_written_array_reads_back_element_wise() {
+    let capture = Capture {
+        label: "sweep".to_owned(),
+        samples: (0..1000).map(|i| ComplexI16::new(i, -i)).collect(),
+    };
+    let bytes = mat::to_bytes(&capture).expect("write");
+    let back: Capture = mat::from_bytes(&bytes).expect("read");
+    assert_eq!(back, capture);
+}
+
+/// The helper produces a `MatValue`, so every option still reaches the writer
+/// that emits it. The equivalence tests above run under the defaults only,
+/// which would not notice a bulk path that had grown a writer of its own and
+/// quietly stopped compressing or reorienting.
+#[test]
+fn options_reach_a_bulk_array_the_same_way() {
+    #[derive(Serialize)]
+    struct Elementwise {
+        samples: Vec<ComplexI16>,
+    }
+
+    // A repeating ramp, so a working deflate has something to find.
+    let samples: Vec<ComplexI16> = (0..4096)
+        .map(|i| ComplexI16::new(i % 8, -(i % 8)))
+        .collect();
+
+    // Compression needs chunked storage, whose chunk indices need the 1.10
+    // format; the MAT default is 1.8, which refuses compression by name.
+    let mut options = Options::default();
+    options.libver = LibVer::V110;
+    options.compression = Compression::Deflate {
+        level: 6,
+        shuffle: false,
+    };
+    options.one_dimensional_mode = OneDimensionalMode::RowVector;
+
+    let element_wise = mat::to_bytes_with_options(
+        &Elementwise {
+            samples: samples.clone(),
+        },
+        &options,
+    )
+    .expect("element-wise");
+    let bulk = mat::to_bytes_with_options(
+        &Capture {
+            label: "ramp".to_owned(),
+            samples: samples.clone(),
+        },
+        &options,
+    )
+    .expect("bulk");
+
+    // The bulk file carries an extra `label` variable, so compare the sample
+    // dataset rather than the whole file. Shape and class as well as payload:
+    // the payload alone is blind to orientation, so a bulk path that built a
+    // `ComplexMatrix` instead of a `ComplexVec1D` would pass every other test
+    // here and silently transpose the field under `RowVector`.
+    assert_eq!(
+        payload_of(&element_wise, "samples"),
+        payload_of(&bulk, "samples"),
+    );
+    assert_eq!(dims_of(&element_wise, "samples"), dims_of(&bulk, "samples"));
+    assert_eq!(
+        class_of(&element_wise, "samples"),
+        class_of(&bulk, "samples")
+    );
+
+    // And the options really were in force, rather than both paths having
+    // ignored them identically.
+    let mut plain_opts = options.clone();
+    plain_opts.compression = Compression::None;
+    plain_opts.one_dimensional_mode = OneDimensionalMode::ColumnVector;
+    let plain = mat::to_bytes_with_options(
+        &Capture {
+            label: "ramp".to_owned(),
+            samples,
+        },
+        &plain_opts,
+    )
+    .expect("uncompressed bulk");
+    assert!(
+        bulk.len() < plain.len(),
+        "deflate should shrink a repeating ramp: {} vs {}",
+        bulk.len(),
+        plain.len()
+    );
+    assert_ne!(
+        dims_of(&bulk, "samples"),
+        dims_of(&plain, "samples"),
+        "the orientation option has to move the shape, or the shape check above proves nothing"
+    );
+}
+
+/// Every float bit pattern MATLAB distinguishes has to survive the byte view.
+///
+/// The equivalence tests above generate their samples with `i as f64`, so they
+/// are all finite, non-negative and integral — a decode that normalized `-0.0`
+/// to `0.0`, or quieted a signaling NaN, would pass every one of them. MATLAB
+/// tells `-0` from `0` (`1/x` is `-Inf`), so it is a real distinction to lose.
+#[test]
+fn float_specials_survive_the_bulk_path() {
+    #[derive(Serialize)]
+    struct Elementwise {
+        data: Vec<Complex64>,
+    }
+
+    struct Slice<'a>(&'a [Complex64]);
+
+    impl Serialize for Slice<'_> {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            mat::complex::f64_array(self.0, s)
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Bulk<'a> {
+        data: Slice<'a>,
+    }
+
+    let values = vec![
+        Complex64::new(f64::NAN, -f64::NAN),
+        Complex64::new(f64::INFINITY, f64::NEG_INFINITY),
+        Complex64::new(-0.0, 0.0),
+        Complex64::new(f64::MIN_POSITIVE / 2.0, -1.5),
+    ];
+
+    assert_eq!(
+        mat::to_bytes(&Elementwise {
+            data: values.clone()
+        })
+        .expect("element-wise"),
+        mat::to_bytes(&Bulk {
+            data: Slice(&values)
+        })
+        .expect("bulk"),
+    );
+}
+
+/// A dataset's element bytes, filters already undone by the reader.
+fn payload_of(bytes: &[u8], name: &str) -> Vec<u8> {
+    let file = File::from_bytes(bytes.to_vec()).expect("open");
+    file.dataset(name)
+        .expect("dataset")
+        .read_u8()
+        .expect("payload")
+}
+
+/// The helper reads its payload out of live memory, so the bytes it starts
+/// from are the *host's* order — and HDF5 stores little-endian. This asserts
+/// the components as they land on disk, which holds on either kind of host and
+/// is the assertion a big-endian one would fail if the swap were ever dropped.
+///
+/// The equivalence tests above compare two paths against each other, so they
+/// would agree about a wrong byte order; this one names it.
+///
+/// It still cannot fail on a little-endian host, where the native and
+/// little-endian decoders are the same function, and CI has no big-endian
+/// target. What it does pin is the LE encode on the way out.
+#[test]
+fn a_bulk_array_stores_its_components_little_endian() {
+    struct Slice<'a>(&'a [ComplexI32]);
+
+    impl Serialize for Slice<'_> {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            mat::complex::i32_array(self.0, s)
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Root<'a> {
+        data: Slice<'a>,
+    }
+
+    let bytes = mat::to_bytes(&Root {
+        data: Slice(&[ComplexI32::new(1, 2)]),
+    })
+    .expect("write");
+
+    assert_eq!(payload_of(&bytes, "data"), vec![1, 0, 0, 0, 2, 0, 0, 0]);
+}
+
+// ---------------------------------------------------------------------------
+// The empty slice: the one place the two paths deliberately differ
+// ---------------------------------------------------------------------------
+
+/// An empty `Vec<ComplexI16>` reveals no element, so the element-wise path
+/// cannot recover the component class and falls back to an empty `double`.
+/// The helper was told the class by name, so it keeps it — matching
+/// `MatBuilder::write_complex_i16`, which documents the same answer for an
+/// empty input, and the `Matrix<Complex*>` sentinels, which exist for exactly
+/// this problem.
+///
+/// This is the only case where switching a field to a helper changes the file.
+#[test]
+fn an_empty_bulk_array_keeps_its_component_class_where_the_element_wise_path_cannot() {
+    #[derive(Serialize, Deserialize)]
+    struct Elementwise {
+        data: Vec<ComplexI16>,
+    }
+
+    let bulk = mat::to_bytes(&Capture {
+        label: "none".to_owned(),
+        samples: Vec::new(),
+    })
+    .expect("bulk write");
+    let element_wise = mat::to_bytes(&Elementwise { data: Vec::new() }).expect("element-wise");
+
+    assert_ne!(
+        class_of(&bulk, "samples"),
+        class_of(&element_wise, "data"),
+        "the empty-slice difference this test documents has gone away"
+    );
+    assert_eq!(class_of(&bulk, "samples"), "int16");
+    assert_eq!(class_of(&element_wise, "data"), "double");
+
+    // Both read back as an empty array, which is what makes the difference a
+    // matter of what the file says it holds rather than of what it holds.
+    let from_bulk: Capture = mat::from_bytes(&bulk).expect("read bulk");
+    assert!(from_bulk.samples.is_empty());
+    let from_element_wise: Elementwise = mat::from_bytes(&element_wise).expect("read element-wise");
+    assert!(from_element_wise.data.is_empty());
+}
+
+/// The two MAT emitters have to describe an empty bulk array with the same
+/// MATLAB dimensions.
+///
+/// They already drifted once over an empty `Vec` (`0x0` against `0x1`, see the
+/// note on `mat::dims::vector_dims`), and this feature reopened the same hole:
+/// an empty `ComplexVec1D` was unreachable from the serializer until these
+/// helpers existed, so the default emitter's hardcoded `[1, n]` had never been
+/// asked for `n == 0`. `serde_roundtrip::both_emit_paths_produce_the_same_bytes`
+/// carries the general parity check; this one also pins the shape, because a
+/// comparison passes just as well when both sides are wrong.
+#[test]
+fn an_empty_bulk_array_has_the_same_dims_from_either_emitter() {
+    let empty = Capture {
+        label: "none".to_owned(),
+        samples: Vec::new(),
+    };
+    let default_path = mat::to_bytes(&empty).expect("to_bytes");
+    let options_path =
+        mat::to_bytes_with_options(&empty, &Options::default()).expect("to_bytes_with_options");
+
+    assert_eq!(
+        dims_of(&default_path, "samples"),
+        dims_of(&options_path, "samples"),
+        "the two emitters disagree about an empty complex array's shape"
+    );
+    // MATLAB's own `[]`, which is the shape every other empty here uses.
+    assert_eq!(dims_of(&default_path, "samples"), vec![0, 0]);
+    assert_eq!(default_path, options_path);
+}
+
+/// The whole point of the `num-complex` feature: a slice of the de-facto
+/// standard Rust complex type reaches the helper directly.
+///
+/// The orphan rule means this impl can only ship from here, so nothing outside
+/// this crate can test it — and without a test, a `num-complex` major that
+/// changed `Complex`'s layout or field order would go unnoticed until it
+/// silently swapped every sample's parts.
+#[cfg(feature = "num-complex")]
+#[test]
+fn a_num_complex_slice_writes_the_same_file() {
+    #[derive(Serialize)]
+    struct Elementwise {
+        data: Vec<ComplexI16>,
+    }
+
+    struct Foreign<'a>(&'a [num_complex::Complex<i16>]);
+
+    impl Serialize for Foreign<'_> {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            mat::complex::i16_array(self.0, s)
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Bulk<'a> {
+        data: Foreign<'a>,
+    }
+
+    // Distinct, sign-varying parts, so a swap or a reinterpretation shows.
+    let foreign: Vec<num_complex::Complex<i16>> = (0..500)
+        .map(|i| num_complex::Complex::new(i, -i - 1))
+        .collect();
+    let native: Vec<ComplexI16> = foreign
+        .iter()
+        .map(|c| ComplexI16::new(c.re, c.im))
+        .collect();
+
+    assert_eq!(
+        mat::to_bytes(&Elementwise { data: native }).expect("element-wise"),
+        mat::to_bytes(&Bulk {
+            data: Foreign(&foreign)
+        })
+        .expect("bulk"),
+    );
+}
+
+/// A dataset's HDF5 shape.
+fn dims_of(bytes: &[u8], name: &str) -> Vec<u64> {
+    let file = File::from_bytes(bytes.to_vec()).expect("open");
+    file.dataset(name)
+        .expect("dataset")
+        .shape()
+        .expect("shape")
+        .to_vec()
+}
+
+/// The `MATLAB_class` attribute of a top-level variable.
+fn class_of(bytes: &[u8], name: &str) -> String {
+    let file = File::from_bytes(bytes.to_vec()).expect("open");
+    let ds = file.dataset(name).expect("dataset");
+    ds.attrs()
+        .expect("attrs")
+        .get("MATLAB_class")
+        .and_then(AttrValue::as_str)
+        .unwrap_or_else(|| panic!("{name} has no MATLAB_class"))
+        .to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Foreign element types
+// ---------------------------------------------------------------------------
+
+/// A complex type this crate does not own — `num_complex::Complex<i16>`, an
+/// FFI `struct { re, im }` — is why the helpers take a [`ComplexElement`]
+/// rather than `&[ComplexI16]`. Requiring a conversion pass would reintroduce
+/// the per-sample cost they exist to remove.
+#[test]
+fn a_foreign_element_writes_the_same_file() {
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct ForeignIq {
+        re: i16,
+        im: i16,
+    }
+
+    // SAFETY: `#[repr(C)]` with exactly two `i16`, real first, so no padding
+    // and every byte is data.
+    unsafe impl ComplexElement for ForeignIq {
+        type Component = i16;
+    }
+
+    #[derive(Serialize)]
+    struct Elementwise {
+        data: Vec<ComplexI16>,
+    }
+
+    struct Foreign<'a>(&'a [ForeignIq]);
+
+    impl Serialize for Foreign<'_> {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            mat::complex::i16_array(self.0, s)
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Bulk<'a> {
+        data: Foreign<'a>,
+    }
+
+    let foreign: Vec<ForeignIq> = (0..500).map(|i| ForeignIq { re: i, im: !i }).collect();
+    let native: Vec<ComplexI16> = foreign
+        .iter()
+        .map(|p| ComplexI16::new(p.re, p.im))
+        .collect();
+
+    assert_eq!(
+        mat::to_bytes(&Elementwise { data: native }).expect("element-wise"),
+        mat::to_bytes(&Bulk {
+            data: Foreign(&foreign)
+        })
+        .expect("bulk"),
+    );
+}
+
+/// The helpers read `2 * size_of::<Component>()` bytes per element, so an
+/// `unsafe impl` that named a wider type would read past the slice. Nothing
+/// safe can reach this — a plain `&[i16]` or `&[u32]` is now a compile error,
+/// and so is `i32` components handed to `f32_array` — but a wrong impl still
+/// gets a diagnostic rather than a buffer overrun.
+#[test]
+#[should_panic(expected = "ComplexElement impl has the wrong element size")]
+fn an_impl_that_lies_about_its_width_is_caught() {
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct TooWide {
+        re: i32,
+        im: i32,
+    }
+
+    // SAFETY: deliberately wrong, to exercise the backstop. `Component = i16`
+    // claims a 4-byte element where this one is 8.
+    unsafe impl ComplexElement for TooWide {
+        type Component = i16;
+    }
+
+    struct Wrong<'a>(&'a [TooWide]);
+
+    impl Serialize for Wrong<'_> {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            mat::complex::i16_array(self.0, s)
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Root<'a> {
+        data: Wrong<'a>,
+    }
+
+    let _ = mat::to_bytes(&Root {
+        data: Wrong(&[TooWide { re: 1, im: 2 }]),
+    });
+}

--- a/tests/dense_attr_limits_crosscheck.rs
+++ b/tests/dense_attr_limits_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the dense (fractal-heap) attribute bounds
 //! (issue #191).
 //!

--- a/tests/dense_huge_objects.rs
+++ b/tests/dense_huge_objects.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reading dense group-link and dense-attribute storage whose messages are too
 //! large for the fractal heap to "manage" and are instead stored as "huge"
 //! objects, resolved through the heap's huge-objects v2 B-tree.

--- a/tests/edit_append_inplace_crosscheck.rs
+++ b/tests/edit_append_inplace_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for issue #146: the unified append + edit session.
 //!
 //! Covers the fast, immediate `Dataset::append` and the staged

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation for in-place editing against the reference C library
 //! (issue #32): files the C library *writes* are edited in place by
 //! `File::open_rw`, and the result is read back by both `hdf5-pure` and the C

--- a/tests/edit_dense_attr_copy.rs
+++ b/tests/edit_dense_attr_copy.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Object copy reproduces dense (fractal-heap) attribute storage (issue #87,
 //! follow-up to PR #78).
 //!

--- a/tests/edit_userblock_crosscheck.rs
+++ b/tests/edit_userblock_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation for editing files with a userblock (the userblock slice of
 //! issue #104) against the reference C library. A single off-by-base address in
 //! an edited file makes the C library error or read garbage, so reading the

--- a/tests/enum_attr_crosscheck.rs
+++ b/tests/enum_attr_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! An enumeration *attribute* written by the reference C library must reach the
 //! caller, decoded through the enum's integer base type (#248).
 //!

--- a/tests/enum_base_crosscheck.rs
+++ b/tests/enum_base_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! The reference C library must agree about an enumeration this crate wrote over
 //! a base type other than `i32`/`u8` (issue #208).
 //!

--- a/tests/extensible_array_crosscheck.rs
+++ b/tests/extensible_array_crosscheck.rs
@@ -1,6 +1,6 @@
-// Links the reference HDF5 C library (`hdf5-metno`), gated to 64-bit-pointer
+// Links the reference HDF5 C library (`hdf5-metno`), gated to 64-bit little-endian
 // targets; skip on 32-bit so `cross test --target i686-...` stays pure-Rust.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation for Extensible-Array-indexed chunked datasets (one unlimited
 //! dimension), in both directions against the reference C HDF5 library.
 //!

--- a/tests/file_space_crosscheck.rs
+++ b/tests/file_space_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation of the file-space strategy (`H5Pset_file_space_strategy`)
 //! against the reference HDF5 C library: a strategy hdf5-pure writes is read back
 //! by the C library, and a strategy the C library writes is read back by

--- a/tests/file_space_fuzz_crosscheck.rs
+++ b/tests/file_space_fuzz_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Property-based cross-validation of the file-space (`fcpl`) and bounded-mutation
 //! (`fapl`) surface against the reference HDF5 C library (issue #178).
 //!

--- a/tests/fill_value_crosscheck.rs
+++ b/tests/fill_value_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for configurable fill values (issue #151).
 //!
 //! Two directions, both make-or-break:

--- a/tests/fractal_heap_dense_links.rs
+++ b/tests/fractal_heap_dense_links.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reading dense (fractal-heap) group link storage that the reference C library
 //! writes, across group sizes that grow the heap's root indirect block past a
 //! single direct block.

--- a/tests/hdf5_crosscheck.rs
+++ b/tests/hdf5_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation tests: write with hdf5-pure, read with the official C HDF5 library.
 //!
 //! These tests verify that files produced by hdf5-pure are valid HDF5 files

--- a/tests/layout_introspection_crosscheck.rs
+++ b/tests/layout_introspection_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the layout / filter introspection API
 //! (issue #149). The reference library *writes* datasets in every storage class
 //! and chunk-index kind; this crate must classify them identically and — the

--- a/tests/libver_output_crosscheck.rs
+++ b/tests/libver_output_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for the HDF5 1.8 output format
 //! (`FileBuilder::with_libver_bounds` with an upper bound of `LibVer::V18`).
 //!

--- a/tests/mat_streaming_crosscheck.rs
+++ b/tests/mat_streaming_crosscheck.rs
@@ -1,6 +1,6 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets.
-#![cfg(not(target_pointer_width = "32"))]
+// gated to 64-bit little-endian targets.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! The reference C library must read a `.mat` written by the streaming path.
 //!
 //! This exercises the combination nothing else does: a userblock-offset file

--- a/tests/ndarray_roundtrip.rs
+++ b/tests/ndarray_roundtrip.rs
@@ -2,9 +2,13 @@
 //! and byte-level cross-validation against the reference HDF5 library
 //! (`hdf5-metno`). Only built with the `ndarray` feature.
 // Byte-level crosscheck links the reference HDF5 C library (`hdf5-metno`), gated
-// to 64-bit-pointer targets; skip on 32-bit so `cross test --target i686-...`
-// stays pure-Rust.
-#![cfg(all(feature = "ndarray", not(target_pointer_width = "32")))]
+// to 64-bit little-endian targets; skip elsewhere so `cross test` on `i686` and
+// `s390x` stays pure-Rust.
+#![cfg(all(
+    feature = "ndarray",
+    not(target_pointer_width = "32"),
+    target_endian = "little"
+))]
 
 use hdf5_pure::{Error, File, FileBuilder};
 use ndarray::{Array1, Array2, Array3, ArrayD, ShapeBuilder, array};

--- a/tests/owned_append_crosscheck.rs
+++ b/tests/owned_append_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// gated to 64-bit little-endian targets; skip elsewhere so the pure-Rust suite still
 // runs under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Interop for owned-handle in-place append (issue #148, phase 2): append through
 //! a `File::open_rw` `Dataset` handle and confirm the reference C library
 //! (`hdf5-metno`) reads the grown dataset back exactly — for unfiltered and

--- a/tests/owned_swmr_crosscheck.rs
+++ b/tests/owned_swmr_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// gated to 64-bit little-endian targets; skip elsewhere so the pure-Rust suite still
 // runs under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Interop for the owned SWMR writer (issue #148, PR B): after a clean
 //! `File::close`, the SWMR-write flag is cleared and the reference C library
 //! reads the streamed appends back exactly.

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Cross-validation for whole-file repack (issue #21) against the reference
 //! HDF5 C library: a file the C library *writes* is repacked by `hdf5_pure`,
 //! and the result is read back by both readers. Also proves the fail-loud

--- a/tests/serde_crosscheck.rs
+++ b/tests/serde_crosscheck.rs
@@ -1,7 +1,11 @@
 // Crosschecks against the reference HDF5 C library (`hdf5-metno`), gated to
-// 64-bit-pointer targets; skip on 32-bit so `cross test --target i686-...`
-// stays pure-Rust.
-#![cfg(all(feature = "serde", not(target_pointer_width = "32")))]
+// 64-bit little-endian targets; skip elsewhere so `cross test` on `i686` and
+// `s390x` stays pure-Rust.
+#![cfg(all(
+    feature = "serde",
+    not(target_pointer_width = "32"),
+    target_endian = "little"
+))]
 //! Crosscheck: files produced by our serde layer are readable by the C HDF5
 //! library (via `hdf5-metno`). This gives us confidence that the `.mat` v7.3
 //! files we produce are valid HDF5 and follow MATLAB conventions that other

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -1763,6 +1763,13 @@ fn both_emit_paths_produce_the_same_bytes() {
         // collapsed every empty matrix to `0x0`.
         empty_matrix: Matrix<f64>,
         empty_matrix_cols: Matrix<f64>,
+        // An empty complex array reaches its own emit arm, and only the
+        // options emitter routed it through `vector_dims`; the other described
+        // it `0x1`. Unreachable until `mat::complex`'s array helpers made an
+        // empty `ComplexVec1D` constructible, which is exactly the shape this
+        // test warns about above.
+        #[serde(serialize_with = "mat::complex::f64_array")]
+        empty_complex: Vec<Complex64>,
         absent: Option<f64>,
         nothing: (),
     }
@@ -1790,6 +1797,7 @@ fn both_emit_paths_produce_the_same_bytes() {
         empty_cells: Vec::new(),
         empty_matrix: Matrix::from_row_major(0, 0, Vec::new()),
         empty_matrix_cols: Matrix::from_row_major(0, 3, Vec::new()),
+        empty_complex: Vec::new(),
         absent: None,
         nothing: (),
     };

--- a/tests/swmr_append.rs
+++ b/tests/swmr_append.rs
@@ -1,7 +1,7 @@
 // Reads back with the reference HDF5 C library (`hdf5-metno`), gated to
-// 64-bit-pointer targets; skip on 32-bit so `cross test --target i686-...`
-// stays pure-Rust.
-#![cfg(not(target_pointer_width = "32"))]
+// 64-bit little-endian targets; skip elsewhere so `cross test` on `i686` and
+// `s390x` stays pure-Rust.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! SWMR append-writer tests: hdf5-pure appends in place to an unlimited
 //! Extensible-Array dataset, and the result is read back by hdf5-pure and by the
 //! reference C library. Appends cross the inline -> direct-block -> super-block

--- a/tests/swmr_refresh.rs
+++ b/tests/swmr_refresh.rs
@@ -1,6 +1,6 @@
-// Uses the reference HDF5 C library (`hdf5-metno`), gated to 64-bit-pointer
+// Uses the reference HDF5 C library (`hdf5-metno`), gated to 64-bit little-endian
 // targets; skip on 32-bit so `cross test --target i686-...` stays pure-Rust.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! SWMR-reader (refresh) tests: hdf5-pure follows an Extensible-Array dataset
 //! that an external HDF5 writer appends to.
 //!

--- a/tests/userblock_base_address_crosscheck.rs
+++ b/tests/userblock_base_address_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// which is gated to 64-bit-pointer targets; skip them on 32-bit so the pure-Rust
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
 // suite can run under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reading the structures the C library places in a file that has a userblock.
 //!
 //! The format specification says of the superblock's base address that "unless

--- a/tests/vlen_chunked_crosscheck.rs
+++ b/tests/vlen_chunked_crosscheck.rs
@@ -1,7 +1,7 @@
 // Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
-// gated to 64-bit-pointer targets; skip on 32-bit so the pure-Rust suite still
+// gated to 64-bit little-endian targets; skip elsewhere so the pure-Rust suite still
 // runs under `cross test --target i686-...`.
-#![cfg(not(target_pointer_width = "32"))]
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
 //! Reference-C-library interop for chunked, filtered, and resizable
 //! variable-length string datasets (issue #109).
 //!


### PR DESCRIPTION
Writing a large complex array to a `.mat` was CPU-bound in serde, not in the file layer. Profiling a 256 MiB complex `i16` array put **97% of the write in the value-tree build** — one sentinel struct per sample, about 26 ns each — with the emitter and the file assembly accounting for the rest.

| 256 MiB of complex `i16`, one write per process | before | after |
| --- | --- | --- |
| `mat::to_writer` | 1.78 s | **0.06 s** |
| `MatBuilder::write_complex_i16` | 0.062 s | **0.013 s** |

(A repeat write in a warm process reaches 0.03 s, but the cold figure is the honest one for a tool that writes a capture and exits. The element-wise path is CPU-bound and does not vary.)

## The bulk path

`serialize_bytes` is serde's only bulk channel, so `mat::complex::i16_array` — and one helper per component class — passes the slice across as a byte payload under a per-class sentinel newtype, which `ValueSerializer` recognizes and routes to a collector that accepts nothing else.

```rust
#[derive(Serialize)]
struct Capture {
    #[serde(serialize_with = "mat::complex::i16_array")]
    samples: Vec<ComplexI16>,
}
```

## `ComplexElement`, and why the obvious version was unsound

The first cut took a generic `T` and checked `size_of` and `align_of`. That is not enough, and not in a subtle way:

- Size and alignment cannot express *"no padding, every byte initialized"*. `#[repr(C)] struct { a: i16, b: u8 }` is size 4, align 2, passes both checks, and its uninitialized padding byte was read and copied into the file. Miri reports it as UB through plain `mat::to_bytes` — and it is also an uninitialized-memory disclosure into a file a user may ship.
- They cannot separate same-width classes either. `f32`/`i32`/`u32` are all 4 bytes with 4-byte alignment, so `f32_array` accepted `i32` components and wrote them under `MATLAB_class = "single"`, where MATLAB reads `1` as `1.4e-45`. That is the exact failure the crate refuses everywhere else — a class and a width that disagree is [documented as refused rather than decoded](docs/interop/matlab.md).

So the helpers now take `mat::ComplexElement`, an `unsafe` trait carrying the component class as an associated type. The layout promise is made once, in an `unsafe impl`, instead of being re-derived from two checks that cannot carry it, and the component is part of the bound — `i32` parts reaching `f32_array` is a compile error.

The orphan rule means an impl for a third crate's type has to ship from one of the two crates involved, hence the optional **`num-complex`** feature. Your own complex type needs no feature: implement the trait for it directly.

## Endianness

Decoding uses `from_ne_bytes` rather than `from_le_bytes`, because the bytes come from live memory rather than from a file, and the writer re-encodes little-endian on the way out. A big-endian host therefore produces a byte-identical file. This was previously untestable — see the CI commit.

## Behavior

Output is byte-for-byte what the per-element path produced, pinned per component class across seven lengths, plus float specials (NaN, ±inf, `-0.0`, subnormal), a foreign element type, and non-default options.

**One deliberate difference:** an empty slice keeps its component class, writing an empty `int16` array where a plain `Vec<ComplexI16>` cannot recover the class and falls back on `empty_sequence_policy`. This matches `MatBuilder::write_complex_i16` and the `Matrix<Complex*>` sentinels, which exist for exactly this problem.

That empty case also exposed a live divergence: `to_bytes` described an empty complex array as `0x1` while `to_bytes_with_options` used `0x0` — the same drift `dims::vector_dims` was written to prevent. It was unreachable before, because nothing could construct an empty complex vector. Fixed, and the emitter-parity test grew an empty complex field so it cannot reopen.

## CI (second commit)

- **Miri** named `mat::transpose` specifically, so the new unsafe was outside it. It now iterates a list of modules, repeating the anti-hollowing checks the job already documents for each. Verified against the padded-element case above.
- **No CI target was big-endian**, so `from_ne_bytes` and `from_le_bytes` were indistinguishable and every byte-order guard in the crate was untestable by construction. `s390x-unknown-linux-gnu` under QEMU closes that. It needs the `hdf5-metno` dev-dependency gated off the way `i686` already does — that dependency compiles libhdf5 from C source, and the run is about this crate's byte-order handling, not the C library's — so the gate moves from 64-bit-pointer to 64-bit little-endian, and the crosscheck files carrying the matching cfg move with it. **This job has not run before; CI here is its first execution.**

## Verification

1913 tests pass across `serde`, `num-complex`, and default feature sets; clippy and fmt clean. `cargo-semver-checks` against 0.35.0 reports no required bump — the change is additive, so the manifest version is untouched.

Both new guards were mutation-checked rather than assumed: reverting the emitter fix fails the empty-dims test, and returning a `ComplexMatrix` instead of a `ComplexVec1D` — byte-identical under the default orientation, and previously survivable by the whole suite — now fails two.
