### PR TITLE
Carry the element size as a NonZero instead of re-checking it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Dataset::buffered_appender` returns a `BufferedAppender` that holds appended elements in memory and writes them a whole chunk at a time, so a filtered dataset takes any append length; buffered elements reach the file only on `flush`, `finish`, or `discard`, and a SWMR session is refused ([#262](https://github.com/stephenberry/hdf5-pure/issues/262)).
 - `FileAccessProperties::with_sync_policy(SyncPolicy::OnClose)` drops the `fsync` from every commit and append, leaving one at `close`, with the new `File::sync` for checkpoints in between; writes still reach the operating system as they are made, so what moves to the caller is power-loss durability within the session ([#263](https://github.com/stephenberry/hdf5-pure/issues/263)).
 - A staged edit that would stop a live `BufferedAppender` from flushing — one naming its dataset or an ancestor, any edit at all while it still owes a realignment, or a second appender on the same dataset — is refused with `Error::EditUnsupported` at the call that makes it, rather than losing the buffered elements when the appender drops ([#262](https://github.com/stephenberry/hdf5-pure/issues/262)).
+- `Datatype::element_size` returns the element width as a `NonZeroU32`, refusing a zero-width type; prefer it to `type_size` wherever the width is about to be divided by ([#272](https://github.com/stephenberry/hdf5-pure/pull/272)).
 
 ### Changed
 
 - **Breaking:** `CompoundTypeBuilder::build` returns `Result<Datatype, FormatError>`, refusing a compound of no fields and one whose fields pack to zero bytes, the way `ExplicitCompoundTypeBuilder::build` already did ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).
+- **Breaking:** `FormatError::ShapeDataMismatch`'s `element_size` field is a `NonZeroUsize`, so the element counts its message reports are well defined by type rather than by convention ([#272](https://github.com/stephenberry/hdf5-pure/pull/272)).
 - `Dataset::append` accepts a filtered append of any length, where it required a whole number of chunks; the dataset's own length must still be chunk-aligned ([#262](https://github.com/stephenberry/hdf5-pure/issues/262)).
 
 ### Fixed

--- a/src/appender.rs
+++ b/src/appender.rs
@@ -16,6 +16,8 @@
 //! elements are not in the file until [`flush`](BufferedAppender::flush) or
 //! [`finish`](BufferedAppender::finish) puts them there.
 
+use core::num::NonZeroUsize;
+
 use crate::convert::TryToUsize;
 use crate::edit::AppendBuilder;
 use crate::element::H5Element;
@@ -122,7 +124,7 @@ pub struct BufferedAppender<'a> {
     /// whenever a write is actually due, so an append through another handle
     /// cannot leave this appender writing against a stale length.
     chunk_elems: u64,
-    element_size: usize,
+    element_size: NonZeroUsize,
     filtered: bool,
     /// Elements appended but not yet written, as little-endian bytes.
     pending: AppendBuilder,
@@ -177,7 +179,7 @@ impl<'a> BufferedAppender<'a> {
         Ok(Self {
             dataset,
             chunk_elems,
-            element_size: g.element_size.max(1),
+            element_size: g.element_size,
             filtered: g.filtered,
             pending: AppendBuilder::new(),
             poisoned: false,
@@ -362,9 +364,11 @@ impl<'a> BufferedAppender<'a> {
         // Copy the prefix rather than split it out: a failed write must leave
         // the buffer holding exactly the elements that did not land, and how
         // many those are is only known afterwards.
-        let head = self
-            .pending
-            .head(take_elems.to_usize()?.saturating_mul(self.element_size));
+        let head = self.pending.head(
+            take_elems
+                .to_usize()?
+                .saturating_mul(self.element_size.get()),
+        );
 
         let result = if staged {
             self.dataset.append_staged_committed(head)
@@ -385,7 +389,7 @@ impl<'a> BufferedAppender<'a> {
             landed
                 .to_usize()
                 .unwrap_or(usize::MAX)
-                .saturating_mul(self.element_size),
+                .saturating_mul(self.element_size.get()),
         );
         // Flushing a partial tail on a filtered dataset leaves it unaligned
         // again, so the realignment debt comes back and the claim has to widen

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -26,6 +26,8 @@
 //! flag and refuses filters; the general writer takes an exclusive lock, accepts
 //! filters, and relocates a partial trailing chunk.
 
+use core::num::NonZeroUsize;
+
 use crate::checksum::jenkins_lookup3;
 use crate::chunked_write::{ea_compute_stats, split_into_chunks, write_ea_addr};
 use crate::convert::TryToUsize;
@@ -210,7 +212,7 @@ pub(crate) struct Located {
     /// Elements per chunk along axis 0 (the only varying axis for rank 1).
     pub chunk_elems: u64,
     /// Bytes per dataset element (datatype size).
-    pub elem_bytes: usize,
+    pub elem_bytes: NonZeroUsize,
     /// Bytes per chunk (uncompressed).
     pub chunk_bytes: usize,
 
@@ -349,13 +351,13 @@ impl Located {
             ));
         }
         let chunk_elems = chunk_dims[0] as u64;
-        let elem_bytes = chunk_dims[1] as usize;
-        if elem_bytes == 0 {
-            // A zero element-size pseudo-dimension is a malformed layout; refuse
-            // rather than divide by it when validating an append length.
+        // A zero element-size pseudo-dimension is a malformed layout; refuse
+        // rather than divide by it when validating an append length. The binding
+        // carries that refusal forward, so no later step re-checks it.
+        let Some(elem_bytes) = NonZeroUsize::new(chunk_dims[1] as usize) else {
             return Err(unsupported("dataset has a zero-sized element"));
-        }
-        let chunk_bytes = chunk_elems.to_usize()? * elem_bytes;
+        };
+        let chunk_bytes = chunk_elems.to_usize()? * elem_bytes.get();
 
         let ea_header = ExtensibleArrayHeader::parse_from_source(file, ea_addr, os, ls)?;
         let has_filters = filter_msg.is_some();
@@ -921,7 +923,7 @@ pub(crate) fn plan_ea_append<F: Store>(
     loc: &Located,
     datatype: &Datatype,
     spatial: &[u64],
-    element_size: usize,
+    element_size: NonZeroUsize,
     pipeline: Option<&FilterPipeline>,
     raw: &[u8],
     new_elems: u64,
@@ -973,7 +975,7 @@ pub(crate) fn plan_ea_append<F: Store>(
             usize::try_from(rec.stored_size)
                 .map_err(|_| Error::AppendUnsupported("chunk size exceeds this platform"))?
         } else {
-            chunk_elems.to_usize()? * element_size
+            chunk_elems.to_usize()? * element_size.get()
         };
         rec.addr
             .checked_add(stored_len as u64)
@@ -984,14 +986,14 @@ pub(crate) fn plan_ea_append<F: Store>(
         // One bounded read of the single trailing chunk.
         let stored = file.read_exact_at(rec.addr, stored_len)?;
         let full = if let Some(pl) = pipeline {
-            let ctx = ChunkContext::from_datatype(spatial, datatype);
+            let ctx = ChunkContext::from_datatype(spatial, datatype)?;
             decompress_chunk(&stored, pl, ctx, rec.filter_mask).map_err(Error::Format)?
         } else {
             stored
         };
         let live_elems = usize::try_from(current_dim % chunk_elems)
             .map_err(|_| Error::AppendUnsupported("chunk length exceeds this platform"))?;
-        let live_bytes = live_elems * element_size;
+        let live_bytes = live_elems * element_size.get();
         if full.len() < live_bytes {
             return Err(Error::AppendUnsupported(
                 "trailing chunk decoded shorter than its live element count",
@@ -1006,7 +1008,7 @@ pub(crate) fn plan_ea_append<F: Store>(
     let tail_len_elems = new_dim - n_full * chunk_elems;
     let split = split_into_chunks(&tail_raw, &[tail_len_elems], spatial, element_size);
     let new_chunk_bytes: Vec<Vec<u8>> = if let Some(pl) = pipeline {
-        let ctx = ChunkContext::from_datatype(spatial, datatype);
+        let ctx = ChunkContext::from_datatype(spatial, datatype)?;
         let mut out = Vec::with_capacity(split.len());
         for (_, buf) in &split {
             out.push(compress_chunk(buf, pl, ctx).map_err(Error::Format)?);

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -8,10 +8,12 @@ use alloc::{borrow::Cow, format, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 
+use core::num::NonZeroUsize;
+
 use crate::btree_v1::btree_v1_node_header_size;
 use crate::chunk_cache::ChunkCache;
 use crate::chunk_span::ChunkSpanReader;
-use crate::convert::{TryToUsize, slice_range, u32_from};
+use crate::convert::{TryToUsize, nonzero_usize_from, slice_range, u32_from};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
@@ -599,11 +601,11 @@ const MAX_CHUNK_LOGICAL_BYTES: u64 = u32::MAX as u64;
 /// normally-sized chunks, entirely readable.
 fn ensure_chunk_bytes_representable(
     chunk_dims: &[usize],
-    elem_size: usize,
+    elem_size: NonZeroUsize,
 ) -> Result<(), FormatError> {
     let logical = chunk_dims
         .iter()
-        .try_fold(elem_size as u64, |acc, &d| acc.checked_mul(d as u64));
+        .try_fold(elem_size.get() as u64, |acc, &d| acc.checked_mul(d as u64));
     match logical {
         Some(bytes) if bytes <= MAX_CHUNK_LOGICAL_BYTES => Ok(()),
         _ => Err(FormatError::InvalidChunkGeometry(
@@ -655,7 +657,11 @@ pub fn read_chunked_data(
     let addr = addr_opt
         .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
-    let elem_size = datatype.type_size() as usize;
+    // The element width, taken once as a proven-non-zero value. Everything below
+    // that divides or divides by it receives that proof rather than the bare
+    // number, so no later step re-checks it.
+    let elem_width = datatype.element_size()?;
+    let elem_size = nonzero_usize_from(elem_width)?;
 
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
@@ -663,8 +669,8 @@ pub fn read_chunked_data(
     // Collect chunks based on version and index type
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "chunk byte sizes and the datatype element size are encoded into 32-bit \
-                  chunk-info fields; both stay well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
+        reason = "chunk byte sizes are encoded into 32-bit chunk-info fields; they stay \
+                  well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
     )]
     let chunks = match (version, chunk_index_type) {
         (3, _) => {
@@ -673,7 +679,7 @@ pub fn read_chunked_data(
         }
         (4, Some(1)) => {
             // Single chunk — one chunk covering the entire dataset
-            let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size;
+            let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size.get();
             let (csize, fmask) = if let Some(fs) = single_filtered_size {
                 (fs as u32, single_filter_mask.unwrap_or(0))
             } else {
@@ -693,7 +699,7 @@ pub fn read_chunked_data(
                 addr,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                elem_size as u32,
+                elem_width.get(),
             )
         }
         (4, Some(3)) => {
@@ -706,7 +712,7 @@ pub fn read_chunked_data(
                 &header,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                elem_size as u32,
+                elem_width.get(),
                 offset_size,
                 length_size,
             )?
@@ -725,7 +731,7 @@ pub fn read_chunked_data(
                 &header,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                elem_size as u32,
+                elem_width.get(),
                 offset_size,
                 length_size,
             )?
@@ -739,18 +745,17 @@ pub fn read_chunked_data(
 
     // Decompress all chunks (parallel when beneficial, sequential otherwise)
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
-    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
     let decompressed_chunks = decompress_all_chunks(file_data, &chunks, pipeline, ctx)?;
 
     let num_elements = dataspace.num_elements();
-    let total_bytes =
-        num_elements
-            .to_usize()?
-            .checked_mul(elem_size)
-            .ok_or(FormatError::OffsetOverflow {
-                offset: num_elements,
-                length: elem_size as u64,
-            })?;
+    let total_bytes = num_elements
+        .to_usize()?
+        .checked_mul(elem_size.get())
+        .ok_or(FormatError::OffsetOverflow {
+            offset: num_elements,
+            length: elem_size.get() as u64,
+        })?;
     Ok(assemble_chunks(
         &chunks,
         &decompressed_chunks,
@@ -812,7 +817,7 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
     let addr = addr_opt
         .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
-    let elem_size = datatype.type_size() as usize;
+    let elem_size = datatype.element_size_usize()?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
 
@@ -831,17 +836,16 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
     )?;
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
-    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
     let decompressed_chunks = decompress_all_chunks_from_source(source, &chunks, pipeline, ctx)?;
     let num_elements = dataspace.num_elements();
-    let total_bytes =
-        num_elements
-            .to_usize()?
-            .checked_mul(elem_size)
-            .ok_or(FormatError::OffsetOverflow {
-                offset: num_elements,
-                length: elem_size as u64,
-            })?;
+    let total_bytes = num_elements
+        .to_usize()?
+        .checked_mul(elem_size.get())
+        .ok_or(FormatError::OffsetOverflow {
+            offset: num_elements,
+            length: elem_size.get() as u64,
+        })?;
     Ok(assemble_chunks(
         &chunks,
         &decompressed_chunks,
@@ -941,7 +945,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         ));
     };
 
-    let elem_size = datatype.type_size() as usize;
+    let elem_size = datatype.element_size_usize()?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
 
@@ -968,10 +972,10 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         })
     })?;
     let row_bytes = row_elems
-        .checked_mul(elem_size)
+        .checked_mul(elem_size.get())
         .ok_or(FormatError::OffsetOverflow {
             offset: row_elems as u64,
-            length: elem_size as u64,
+            length: elem_size.get() as u64,
         })?;
 
     let out_rows = num_rows.to_usize()?;
@@ -1029,7 +1033,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     sort_chunks_by_address(&mut chunks);
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
-    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
 
     let row_lo = row_start.to_usize()?;
     let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
@@ -1093,7 +1097,7 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             dims[0] = hi - lo;
             let advance = skip
                 .saturating_mul(chunk_strides[0])
-                .saturating_mul(elem_size);
+                .saturating_mul(elem_size.get());
             Some((offsets, dims, advance))
         };
 
@@ -1154,12 +1158,8 @@ fn row_band_copy(
     chunk: &[u8],
     src: usize,
     band: usize,
-    elem_size: usize,
+    elem_size: NonZeroUsize,
 ) {
-    debug_assert!(
-        elem_size > 0,
-        "a zero-width element type is refused at parse"
-    );
     let mut len = band
         .min(chunk.len().saturating_sub(src))
         .min(output.len().saturating_sub(dst));
@@ -1233,7 +1233,7 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     let addr = addr_opt
         .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
-    let elem_size = datatype.type_size() as usize;
+    let elem_size = datatype.element_size_usize()?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
 
@@ -1259,12 +1259,13 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     sort_chunks_by_address(&mut chunks);
 
     let total_elements = dataspace.num_elements().to_usize()?;
-    let total_bytes = total_elements
-        .checked_mul(elem_size)
-        .ok_or(FormatError::OffsetOverflow {
-            offset: total_elements as u64,
-            length: elem_size as u64,
-        })?;
+    let total_bytes =
+        total_elements
+            .checked_mul(elem_size.get())
+            .ok_or(FormatError::OffsetOverflow {
+                offset: total_elements as u64,
+                length: elem_size.get() as u64,
+            })?;
     let mut output = vec![0u8; total_bytes];
 
     let mut ds_strides = vec![1usize; rank];
@@ -1278,7 +1279,7 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     }
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
-    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
 
     // Every chunk of the dataset is wanted here; what the plan leaves out is
     // whatever the chunk cache already holds from an earlier read.
@@ -1354,7 +1355,7 @@ pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
     single_filter_mask: Option<u32>,
     chunk_dimensions: &[u32],
     dataspace: &Dataspace,
-    elem_size: usize,
+    elem_size: NonZeroUsize,
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<ChunkInfo>, FormatError> {
@@ -1369,7 +1370,7 @@ pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
                 .iter()
                 .map(|&d| d as usize)
                 .product::<usize>()
-                * elem_size;
+                * elem_size.get();
             let (csize, fmask) = if let Some(fs) = single_filtered_size {
                 (u32_from(fs)?, single_filter_mask.unwrap_or(0))
             } else {
@@ -1388,7 +1389,7 @@ pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
                 addr,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
+                u32_from(elem_size.get() as u64)?,
             ))
         }
         (4, Some(3)) => {
@@ -1400,7 +1401,7 @@ pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
                 &header,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
+                u32_from(elem_size.get() as u64)?,
                 offset_size,
                 length_size,
             )
@@ -1414,7 +1415,7 @@ pub(crate) fn collect_chunks_for_layout_from_source<S: Source + ?Sized>(
                 &header,
                 &dataspace.dimensions,
                 &spatial_chunk_dims,
-                u32_from(elem_size as u64)?,
+                u32_from(elem_size.get() as u64)?,
                 offset_size,
                 length_size,
             )
@@ -1472,12 +1473,9 @@ pub(crate) fn enumerate_chunks_from_source<S: Source + ?Sized>(
         .len()
         .checked_sub(1)
         .ok_or_else(|| FormatError::ChunkedReadError("chunked layout has no dimensions".into()))?;
-    let elem_size = chunk_dimensions[rank] as usize;
-    if elem_size == 0 {
-        return Err(FormatError::ChunkedReadError(
-            "chunked layout has a zero element size".into(),
-        ));
-    }
+    let elem_size = NonZeroUsize::new(chunk_dimensions[rank] as usize).ok_or_else(|| {
+        FormatError::ChunkedReadError("chunked layout has a zero element size".into())
+    })?;
     collect_chunks_for_layout_from_source(
         source,
         *version,
@@ -1622,12 +1620,9 @@ pub(crate) fn collect_chunked_storage_spans<S: Source + ?Sized>(
         .len()
         .checked_sub(1)
         .ok_or_else(|| FormatError::ChunkedReadError("chunked layout has no dimensions".into()))?;
-    let elem_size = chunk_dimensions[rank] as usize;
-    if elem_size == 0 {
-        return Err(FormatError::ChunkedReadError(
-            "chunked layout has a zero element size".into(),
-        ));
-    }
+    let elem_size = NonZeroUsize::new(chunk_dimensions[rank] as usize).ok_or_else(|| {
+        FormatError::ChunkedReadError("chunked layout has a zero element size".into())
+    })?;
 
     let mut data: Vec<(u64, u64)> = Vec::new();
 
@@ -1769,7 +1764,7 @@ fn assemble_chunks(
     rank: usize,
     chunk_dims: &[usize],
     ds_dims: &[usize],
-    elem_size: usize,
+    elem_size: NonZeroUsize,
     total_bytes: usize,
 ) -> Vec<u8> {
     let mut output = vec![0u8; total_bytes];
@@ -1860,15 +1855,17 @@ pub fn read_chunked_data_cached(
     let addr = addr_opt
         .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
 
-    let elem_size = datatype.type_size() as usize;
+    // Taken once as a proven-non-zero width; see the buffered reader above.
+    let elem_width = datatype.element_size()?;
+    let elem_size = nonzero_usize_from(elem_width)?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
     let ndims = rank + 1; // rank + the trailing element-size dimension
 
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "chunk byte sizes and the datatype element size are encoded into 32-bit \
-                  chunk-info fields; both stay well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
+        reason = "chunk byte sizes are encoded into 32-bit chunk-info fields; they stay \
+                  well below u32::MAX (HDF5 caps a chunk at 4 GiB)"
     )]
     let chunks = if let Some(chunks) = cache.all_indexed_chunks() {
         chunks
@@ -1876,7 +1873,7 @@ pub fn read_chunked_data_cached(
         let chunks = match (version, chunk_index_type) {
             (3, _) => collect_chunk_info(file_data, addr, ndims, offset_size, length_size)?,
             (4, Some(1)) => {
-                let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size;
+                let chunk_byte_size: usize = chunk_dims.iter().product::<usize>() * elem_size.get();
                 let (csize, fmask) = if let Some(fs) = single_filtered_size {
                     (fs as u32, single_filter_mask.unwrap_or(0))
                 } else {
@@ -1895,7 +1892,7 @@ pub fn read_chunked_data_cached(
                     addr,
                     &dataspace.dimensions,
                     &spatial_chunk_dims,
-                    elem_size as u32,
+                    elem_width.get(),
                 )
             }
             (4, Some(3)) => {
@@ -1907,7 +1904,7 @@ pub fn read_chunked_data_cached(
                     &header,
                     &dataspace.dimensions,
                     &spatial_chunk_dims,
-                    elem_size as u32,
+                    elem_width.get(),
                     offset_size,
                     length_size,
                 )?
@@ -1925,7 +1922,7 @@ pub fn read_chunked_data_cached(
                     &header,
                     &dataspace.dimensions,
                     &spatial_chunk_dims,
-                    elem_size as u32,
+                    elem_width.get(),
                     offset_size,
                     length_size,
                 )?
@@ -1942,7 +1939,7 @@ pub fn read_chunked_data_cached(
 
     // Assemble output
     let total_elements = dataspace.num_elements().to_usize()?;
-    let total_bytes = total_elements * elem_size;
+    let total_bytes = total_elements * elem_size.get();
     let mut output = vec![0u8; total_bytes];
 
     let mut ds_strides = vec![1usize; rank];
@@ -1956,7 +1953,7 @@ pub fn read_chunked_data_cached(
     }
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
-    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype);
+    let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
 
     for chunk_info in &chunks {
         let coord: Vec<u64> = chunk_info.offsets.iter().take(rank).copied().collect();
@@ -2047,7 +2044,7 @@ fn place_chunk(
     ds_dims: &[usize],
     ds_strides: &[usize],
     chunk_strides: &[usize],
-    elem_size: usize,
+    elem_size: NonZeroUsize,
     rank: usize,
 ) {
     if rank == 0 {
@@ -2091,17 +2088,10 @@ fn copy_chunk_to_output(
     ds_dims: &[usize],
     ds_strides: &[usize],
     chunk_strides: &[usize],
-    elem_size: usize,
+    elem_size: NonZeroUsize,
     rank: usize,
 ) {
     debug_assert!(rank >= 1, "rank == 0 is handled by the callers");
-    // The element-boundary clamp below divides by `elem_size`; a zero-width
-    // element type is refused when the datatype message is parsed, so one cannot
-    // reach here from a file.
-    debug_assert!(
-        elem_size > 0,
-        "a zero-width element type is refused at parse"
-    );
     // Row contiguity (the whole optimization) relies on a unit innermost stride
     // in both layouts, which the row-major stride construction guarantees.
     debug_assert_eq!(chunk_strides[rank - 1], 1);
@@ -2115,7 +2105,7 @@ fn copy_chunk_to_output(
     if inner_row_len == 0 {
         return; // the chunk lies entirely past the inner edge
     }
-    let row_bytes = inner_row_len * elem_size;
+    let row_bytes = inner_row_len * elem_size.get();
     // Destination offset contributed by the innermost dimension (stride 1).
     let inner_dst = chunk_offsets[inner] * ds_strides[inner];
 
@@ -2139,8 +2129,8 @@ fn copy_chunk_to_output(
         }
 
         if in_bounds {
-            let src = chunk_base * elem_size;
-            let dst = ds_base * elem_size;
+            let src = chunk_base * elem_size.get();
+            let dst = ds_base * elem_size.get();
             // Clamp to the bytes available on each side, on an element boundary.
             let mut avail = row_bytes
                 .min(chunk_data.len().saturating_sub(src))
@@ -2165,24 +2155,27 @@ fn copy_chunk_to_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::convert::nz;
 
     #[test]
     fn chunk_bytes_within_limit_are_accepted() {
         // A realistic chunk: 256 KiB of f64 elements.
-        assert!(ensure_chunk_bytes_representable(&[128, 256], 8).is_ok());
+        assert!(ensure_chunk_bytes_representable(&[128, 256], nz(8)).is_ok());
         // A single chunk right at the 4 GiB limit is still representable.
-        assert!(ensure_chunk_bytes_representable(&[u32::MAX as usize], 1).is_ok());
+        assert!(ensure_chunk_bytes_representable(&[u32::MAX as usize], nz(1)).is_ok());
     }
 
     #[test]
     fn chunk_bytes_over_limit_are_refused() {
         // The issue #185 shape: 10 elements of a ~2.86 GB fixed-length string
         // (0xAAAAAAAA bytes) is ~28.6 GB per chunk — impossible for the format.
-        let err = ensure_chunk_bytes_representable(&[10], 0xAAAA_AAAA).unwrap_err();
+        let err = ensure_chunk_bytes_representable(&[10], nz(0xAAAA_AAAA)).unwrap_err();
         assert!(matches!(err, FormatError::InvalidChunkGeometry(_)));
 
         // A geometry whose product overflows u64 is refused, not wrapped.
-        assert!(ensure_chunk_bytes_representable(&[usize::MAX, usize::MAX], usize::MAX).is_err());
+        assert!(
+            ensure_chunk_bytes_representable(&[usize::MAX, usize::MAX], nz(usize::MAX)).is_err()
+        );
     }
 
     fn write_offset(buf: &mut Vec<u8>, val: u64, size: u8) {

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -7,7 +7,9 @@ extern crate alloc;
 use alloc::{format, vec, vec::Vec};
 
 use crate::checksum::jenkins_lookup3;
-use crate::convert::TryToUsize;
+use core::num::NonZeroUsize;
+
+use crate::convert::{TryToUsize, nonzero_usize_from};
 use crate::error::FormatError;
 use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
 #[cfg(feature = "zfp")]
@@ -345,7 +347,7 @@ pub fn split_into_chunks(
     raw_data: &[u8],
     shape: &[u64],
     chunk_dims: &[u64],
-    element_size: usize,
+    element_size: NonZeroUsize,
 ) -> Vec<(Vec<u64>, Vec<u8>)> {
     let rank = shape.len();
     if rank == 0 {
@@ -422,13 +424,13 @@ pub fn split_into_chunks(
         )]
         let offsets_us: Vec<usize> = offsets.iter().map(|&o| o as usize).collect();
 
-        let mut chunk_bytes = vec![0u8; chunk_total_elements * element_size];
+        let mut chunk_bytes = vec![0u8; chunk_total_elements * element_size.get()];
 
         // In-bounds run length along the contiguous innermost dimension.
         let inner_row_len =
             chunk_dims_us[inner].min(shape_us[inner].saturating_sub(offsets_us[inner]));
         if inner_row_len > 0 {
-            let row_bytes = inner_row_len * element_size;
+            let row_bytes = inner_row_len * element_size.get();
             let inner_src = offsets_us[inner] * ds_strides[inner];
             let outer_total: usize = chunk_dims_us[..inner].iter().product();
             for c in coord.iter_mut() {
@@ -449,8 +451,8 @@ pub fn split_into_chunks(
                 }
 
                 if in_bounds {
-                    let src = src_base * element_size;
-                    let dst = dst_base * element_size;
+                    let src = src_base * element_size.get();
+                    let dst = dst_base * element_size.get();
                     let mut avail = row_bytes.min(raw_data.len().saturating_sub(src));
                     avail -= avail % element_size;
                     if avail > 0 {
@@ -1512,7 +1514,7 @@ pub(crate) struct CompressedChunkSet {
     /// overhang zero-filled, so these are all equal in practice).
     raw_sizes: Vec<u64>,
     chunk_dims_u32: Vec<u32>,
-    element_size: usize,
+    element_size: NonZeroUsize,
     has_filters: bool,
     use_extensible: bool,
     pipeline_message: Option<Vec<u8>>,
@@ -1530,9 +1532,9 @@ pub(crate) fn compress_chunks(
     maxshape: Option<&[u64]>,
 ) -> Result<CompressedChunkSet, FormatError> {
     let chunk_dims = ctx.chunk_dims;
-    let element_size = ctx.element_size as usize;
+    let element_size = nonzero_usize_from(ctx.element_size)?;
     let pipeline = options.build_pipeline(
-        ctx.element_size,
+        ctx.element_size.get(),
         chunk_dims,
         ctx.element_type,
         ctx.scale_offset_type,
@@ -1626,7 +1628,7 @@ fn chunk_index_bytes(
             &set.chunk_dims_u32,
             index_address,
             offset_size,
-            set.element_size as u32,
+            set.element_size.get() as u32,
         );
         (ea_bytes, layout)
     } else if written_chunks.len() == 1 {
@@ -1639,7 +1641,7 @@ fn chunk_index_bytes(
             filtered_size,
             filter_mask,
             offset_size,
-            set.element_size as u32,
+            set.element_size.get() as u32,
         );
         (Vec::new(), layout)
     } else {
@@ -1654,7 +1656,7 @@ fn chunk_index_bytes(
             &set.chunk_dims_u32,
             index_address,
             offset_size,
-            set.element_size as u32,
+            set.element_size.get() as u32,
             FIXED_ARRAY_PAGE_BITS,
         );
         (fa_bytes, layout)
@@ -1831,7 +1833,7 @@ pub(crate) struct VerbatimLayout {
 pub(crate) fn plan_chunked_data_verbatim(
     meta: &[ChunkMeta],
     chunk_dims: &[u64],
-    element_size: usize,
+    element_size: NonZeroUsize,
     raw_size: u64,
     pipeline_message: Option<&[u8]>,
     base_address: u64,
@@ -1894,7 +1896,7 @@ pub(crate) fn plan_chunked_data_verbatim(
             &chunk_dims_u32,
             ea_address,
             offset_size,
-            element_size as u32,
+            element_size.get() as u32,
         )
     } else if num_chunks == 1 {
         let chunk_addr = written_chunks[0].address;
@@ -1914,7 +1916,7 @@ pub(crate) fn plan_chunked_data_verbatim(
             filtered_size,
             filter_mask,
             offset_size,
-            element_size as u32,
+            element_size.get() as u32,
         )
     } else {
         let fa_address = base_address + cursor;
@@ -1931,7 +1933,7 @@ pub(crate) fn plan_chunked_data_verbatim(
             &chunk_dims_u32,
             fa_address,
             offset_size,
-            element_size as u32,
+            element_size.get() as u32,
             FIXED_ARRAY_PAGE_BITS,
         )
     };
@@ -1980,6 +1982,7 @@ pub(crate) fn emit_chunked_data_verbatim<S: ByteSink>(
 mod tests {
     use super::*;
     use crate::chunked_read::read_chunked_data;
+    use crate::convert::nz;
     use crate::data_layout::DataLayout;
     use crate::dataspace::{Dataspace, DataspaceType};
     use crate::datatype::{Datatype, DatatypeByteOrder};
@@ -2063,7 +2066,7 @@ mod tests {
     #[test]
     fn split_1d_single_chunk() {
         let data = f64_to_bytes(&[1.0, 2.0, 3.0]);
-        let result = split_into_chunks(&data, &[3], &[3], 8);
+        let result = split_into_chunks(&data, &[3], &[3], nz(8));
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, vec![0]);
         assert_eq!(bytes_to_f64(&result[0].1), vec![1.0, 2.0, 3.0]);
@@ -2073,7 +2076,7 @@ mod tests {
     fn split_1d_multiple_chunks() {
         let values: Vec<f64> = (0..10).map(|i| i as f64).collect();
         let data = f64_to_bytes(&values);
-        let result = split_into_chunks(&data, &[10], &[4], 8);
+        let result = split_into_chunks(&data, &[10], &[4], nz(8));
         assert_eq!(result.len(), 3); // ceil(10/4) = 3
         assert_eq!(result[0].0, vec![0]);
         assert_eq!(result[1].0, vec![4]);
@@ -2089,7 +2092,7 @@ mod tests {
         // 4x4 dataset, 2x2 chunks -> 4 chunks
         let values: Vec<f64> = (0..16).map(|i| i as f64).collect();
         let data = f64_to_bytes(&values);
-        let result = split_into_chunks(&data, &[4, 4], &[2, 2], 8);
+        let result = split_into_chunks(&data, &[4, 4], &[2, 2], nz(8));
         assert_eq!(result.len(), 4);
         assert_eq!(result[0].0, vec![0, 0]);
         assert_eq!(result[1].0, vec![0, 2]);
@@ -2221,7 +2224,7 @@ mod tests {
             })
             .collect();
         let layout =
-            plan_chunked_data_verbatim(&meta, &[7], 8, 56, Some(&[]), 0x1000, None).unwrap();
+            plan_chunked_data_verbatim(&meta, &[7], nz(8), 56, Some(&[]), 0x1000, None).unwrap();
 
         let chunk_bytes: u64 = meta.iter().map(|m| m.compressed_size).sum();
         assert_eq!(
@@ -2241,7 +2244,7 @@ mod tests {
     /// is refused rather than planned as an empty region.
     #[test]
     fn a_verbatim_plan_with_no_chunks_is_refused() {
-        let result = plan_chunked_data_verbatim(&[], &[7], 8, 56, None, 0x1000, None);
+        let result = plan_chunked_data_verbatim(&[], &[7], nz(8), 56, None, 0x1000, None);
         assert!(
             matches!(result, Err(FormatError::ChunkedReadError(_))),
             "a chunk-less plan must be refused"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -36,6 +36,8 @@
 //! explicitly accounted for this way; a leftover `#[expect]` whose cast was
 //! later removed fails the gate too, keeping the annotations honest.
 
+use core::num::{NonZeroU32, NonZeroUsize};
+
 #[cfg(not(feature = "std"))]
 use core::ops::Range;
 #[cfg(feature = "std")]
@@ -92,6 +94,33 @@ pub fn u32_from(value: u64) -> Result<u32, FormatError> {
     })
 }
 
+/// Narrow a non-zero `u32` to a non-zero `usize`, carrying the proof across.
+///
+/// The counterpart to [`TryToUsize::to_usize`] for a value whose non-zero-ness
+/// has already been established — an element size, in practice — so the code it
+/// is handed to keeps the guarantee instead of re-deriving it. The `u32` fits
+/// `usize` on every target this crate supports, and routing through the checked
+/// conversion keeps that assumption from becoming a silent truncation on a
+/// narrower one.
+#[inline]
+pub(crate) fn nonzero_usize_from(value: NonZeroU32) -> Result<NonZeroUsize, FormatError> {
+    NonZeroUsize::try_from(value).map_err(|_| FormatError::ValueTooLargeForPlatform {
+        value: u64::from(value.get()),
+        target: "usize",
+    })
+}
+
+/// Test-only shorthand for a non-zero size literal, so a fixture can pass an
+/// element width without restating the (statically obvious) proof each time.
+///
+/// # Panics
+///
+/// If `value` is zero.
+#[cfg(test)]
+pub(crate) fn nz(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("a test's element size is non-zero")
+}
+
 /// Compute `offset .. offset + len` as a `usize` range, checking both the
 /// 64-bit addition and the narrowing of each bound to `usize`.
 ///
@@ -135,6 +164,17 @@ mod tests {
         assert_eq!(1234u64.to_usize().unwrap(), 1234);
         assert_eq!(42u32.to_usize().unwrap(), 42);
         assert_eq!(u32_from(1000).unwrap(), 1000);
+    }
+
+    /// The whole point of the conversion is that the proof survives it: what
+    /// goes in non-zero comes out non-zero, at the platform's width.
+    #[test]
+    fn a_nonzero_width_survives_the_narrowing() {
+        let width = NonZeroU32::new(8).unwrap();
+        assert_eq!(nonzero_usize_from(width).unwrap().get(), 8);
+
+        let widest = NonZeroU32::new(u32::MAX).unwrap();
+        assert_eq!(nonzero_usize_from(widest).unwrap().get(), u32::MAX as usize);
     }
 
     #[test]

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -3,6 +3,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
+use core::num::NonZeroUsize;
+
 use crate::chunk_cache::ChunkCache;
 use crate::chunked_read::{
     read_chunked_data, read_chunked_data_cached, read_chunked_data_cached_from_source,
@@ -291,8 +293,8 @@ fn get_byte_order(dt: &Datatype) -> DatatypeByteOrder {
     }
 }
 
-fn get_size(dt: &Datatype) -> usize {
-    dt.type_size() as usize
+fn get_size(dt: &Datatype) -> Result<NonZeroUsize, FormatError> {
+    dt.element_size_usize()
 }
 
 /// True when a numeric element is stored in the "standard" full-width layout —
@@ -364,8 +366,8 @@ macro_rules! bulk_decode {
 pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint or FixedPoint")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -376,7 +378,7 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
     let (bit_offset, bit_precision) = int_bits(datatype);
 
     // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
                 return Ok(bulk_decode!(raw, count, order, f32, f64));
@@ -385,7 +387,7 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
                 return Ok(bulk_decode!(raw, count, order, f64, f64));
             }
             Datatype::FixedPoint { signed: true, .. } => {
-                return Ok(match elem_size {
+                return Ok(match elem_size.get() {
                     1 => bulk_decode!(raw, count, order, i8, f64),
                     2 => bulk_decode!(raw, count, order, i16, f64),
                     4 => bulk_decode!(raw, count, order, i32, f64),
@@ -394,7 +396,7 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
                 });
             }
             Datatype::FixedPoint { signed: false, .. } => {
-                return Ok(match elem_size {
+                return Ok(match elem_size.get() {
                     1 => bulk_decode!(raw, count, order, u8, f64),
                     2 => bulk_decode!(raw, count, order, u16, f64),
                     4 => bulk_decode!(raw, count, order, u32, f64),
@@ -410,7 +412,7 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
 
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
-        let chunk = &raw[i * elem_size..(i + 1) * elem_size];
+        let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         let val = convert_to_f64(chunk, datatype, &order)?;
         result.push(val);
     }
@@ -461,8 +463,8 @@ fn convert_to_f64(
 pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (signed)")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -475,8 +477,8 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
     // Fast path: standard full-width layout, bulk-decoded then sign-extended.
     // Signed storage types reproduce `read_signed_int`'s sign-extension for the
     // full-width case (and a float read as i64 bit-reinterprets identically).
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, i8, i64),
             2 => bulk_decode!(raw, count, order, i16, i64),
             4 => bulk_decode!(raw, count, order, i32, i64),
@@ -487,8 +489,8 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
 
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
-        let chunk = &raw[i * elem_size..(i + 1) * elem_size];
-        let v = read_signed_int(chunk, elem_size, &order, bit_offset, bit_precision);
+        let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
+        let v = read_signed_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
         result.push(v);
     }
     Ok(result)
@@ -498,8 +500,8 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
 pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -511,8 +513,8 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
 
     // Fast path: standard full-width layout, bulk-decoded with zero-extension
     // (unsigned storage types reproduce `read_unsigned_int`'s magnitude).
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, u8, u64),
             2 => bulk_decode!(raw, count, order, u16, u64),
             4 => bulk_decode!(raw, count, order, u32, u64),
@@ -523,8 +525,8 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
 
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
-        let chunk = &raw[i * elem_size..(i + 1) * elem_size];
-        let v = read_unsigned_int(chunk, elem_size, &order, bit_offset, bit_precision);
+        let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
+        let v = read_unsigned_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
         result.push(v);
     }
     Ok(result)
@@ -534,8 +536,8 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
 pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -546,7 +548,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
     let (bit_offset, bit_precision) = int_bits(datatype);
 
     // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
                 return Ok(bulk_decode!(raw, count, order, f32, f32));
@@ -555,7 +557,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
                 return Ok(bulk_decode!(raw, count, order, f64, f32));
             }
             Datatype::FixedPoint { signed: true, .. } => {
-                return Ok(match elem_size {
+                return Ok(match elem_size.get() {
                     1 => bulk_decode!(raw, count, order, i8, f32),
                     2 => bulk_decode!(raw, count, order, i16, f32),
                     4 => bulk_decode!(raw, count, order, i32, f32),
@@ -564,7 +566,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
                 });
             }
             Datatype::FixedPoint { signed: false, .. } => {
-                return Ok(match elem_size {
+                return Ok(match elem_size.get() {
                     1 => bulk_decode!(raw, count, order, u8, f32),
                     2 => bulk_decode!(raw, count, order, u16, f32),
                     4 => bulk_decode!(raw, count, order, u32, f32),
@@ -578,7 +580,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
 
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
-        let chunk = &raw[i * elem_size..(i + 1) * elem_size];
+        let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
                 result.push(read_f32_bytes(chunk, &order));
@@ -635,8 +637,8 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
 pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -648,8 +650,8 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
 
     // Fast path: standard full-width layout, bulk-decoded then narrowed to i32
     // (matches `read_signed_int(..) as i32` for the full-width case).
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, i8, i32),
             2 => bulk_decode!(raw, count, order, i16, i32),
             4 => bulk_decode!(raw, count, order, i32, i32),
@@ -660,8 +662,8 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
 
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
-        let chunk = &raw[i * elem_size..(i + 1) * elem_size];
-        let v = read_signed_int(chunk, elem_size, &order, bit_offset, bit_precision);
+        let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
+        let v = read_signed_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
         #[expect(
             clippy::cast_possible_truncation,
             reason = "read_as_i32 narrows each stored signed value to the requested i32"
@@ -676,8 +678,8 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
 pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -687,8 +689,8 @@ pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatEr
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
 
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, i8, i16),
             2 => bulk_decode!(raw, count, order, i16, i16),
             4 => bulk_decode!(raw, count, order, i32, i16),
@@ -714,8 +716,8 @@ pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatEr
 pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -725,8 +727,8 @@ pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatEr
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
 
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, u8, u32),
             2 => bulk_decode!(raw, count, order, u16, u32),
             4 => bulk_decode!(raw, count, order, u32, u32),
@@ -750,8 +752,8 @@ pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatEr
 pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
-    let elem_size = get_size(datatype);
-    if elem_size == 0 || !raw.len().is_multiple_of(elem_size) {
+    let elem_size = get_size(datatype)?;
+    if !raw.len().is_multiple_of(elem_size.get()) {
         return Err(FormatError::DataSizeMismatch {
             expected: 0,
             actual: raw.len(),
@@ -761,8 +763,8 @@ pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatEr
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
 
-    if is_standard_layout(elem_size, &order, bit_offset, bit_precision) {
-        return Ok(match elem_size {
+    if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
+        return Ok(match elem_size.get() {
             1 => bulk_decode!(raw, count, order, u8, u16),
             2 => bulk_decode!(raw, count, order, u16, u16),
             4 => bulk_decode!(raw, count, order, u32, u16),
@@ -785,11 +787,10 @@ pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatEr
 pub fn read_as_strings(raw: &[u8], datatype: &Datatype) -> Result<Vec<String>, FormatError> {
     match datatype {
         Datatype::String { size, padding, .. } => {
-            let elem_size = *size as usize;
-            if elem_size == 0 {
+            let Some(elem_size) = NonZeroUsize::new(*size as usize) else {
                 return Ok(Vec::new());
-            }
-            if !raw.len().is_multiple_of(elem_size) {
+            };
+            if !raw.len().is_multiple_of(elem_size.get()) {
                 return Err(FormatError::DataSizeMismatch {
                     expected: 0,
                     actual: raw.len(),
@@ -798,7 +799,7 @@ pub fn read_as_strings(raw: &[u8], datatype: &Datatype) -> Result<Vec<String>, F
             let count = raw.len() / elem_size;
             let mut result = Vec::with_capacity(count);
             for i in 0..count {
-                let chunk = &raw[i * elem_size..(i + 1) * elem_size];
+                let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
                 let s = match padding {
                     crate::datatype::StringPadding::NullTerminate => {
                         let end = chunk.iter().position(|&b| b == 0).unwrap_or(chunk.len());
@@ -877,7 +878,7 @@ fn int_bits(dt: &Datatype) -> (u16, u16) {
         _ => {
             // Full-width standard layout. `try_from` clamps the (always small,
             // <= 64) bit width without a narrowing cast.
-            let bits = u16::try_from(get_size(dt) * 8).unwrap_or(u16::MAX);
+            let bits = u16::try_from(u64::from(dt.type_size()) * 8).unwrap_or(u16::MAX);
             (0, bits)
         }
     }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -7,6 +7,7 @@
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 use core::fmt;
+use core::num::{NonZeroU32, NonZeroUsize};
 
 use byteorder::{ByteOrder, LittleEndian};
 
@@ -1089,19 +1090,46 @@ impl Datatype {
         }
     }
 
-    /// Refuse a type that occupies zero bytes per element.
+    /// The element size in bytes, proven non-zero.
     ///
-    /// The writers divide by the element size exactly as the readers do, and a
-    /// `Datatype` a caller constructs never passes through
-    /// [`parse`](Self::parse), where a file-sourced one is refused. This is the
-    /// same refusal for the other direction.
-    pub(crate) fn ensure_nonzero_size(&self) -> Result<(), FormatError> {
-        if self.type_size() == 0 {
-            return Err(FormatError::ZeroSizedDatatype {
-                class: self.class_code(),
-            });
-        }
-        Ok(())
+    /// Prefer this to [`type_size`](Self::type_size) for any element size that
+    /// is about to be divided or divided *by*: it returns the size as a
+    /// [`NonZeroU32`], so the value carries its own proof and the code it is
+    /// handed to cannot divide by zero. Every such site in this crate takes a
+    /// non-zero size rather than re-checking one.
+    ///
+    /// The refusal has to live here rather than in the type because
+    /// `type_size()` is *computed*: an [`Array`](Self::Array) reports its base
+    /// type times its dimensions, so a zero dimension yields a zero-width
+    /// element behind a header that claims otherwise, and the variants are
+    /// deliberately open for a caller to build as a literal. A type read out of
+    /// a file is already refused when its message is decoded; this is the same
+    /// refusal for a constructed one, on the way into a writer.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::ZeroSizedDatatype`] if the type occupies zero bytes per
+    /// element.
+    pub fn element_size(&self) -> Result<NonZeroU32, FormatError> {
+        NonZeroU32::new(self.type_size()).ok_or(FormatError::ZeroSizedDatatype {
+            class: self.class_code(),
+        })
+    }
+
+    /// The element size in bytes as a non-zero `usize`, for the byte arithmetic
+    /// that indexes an in-memory buffer.
+    ///
+    /// The narrowing is the one [`convert`](crate::convert) describes: a `u32`
+    /// fits `usize` on every target this crate supports, and the conversion is
+    /// routed through a checked one anyway.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::ZeroSizedDatatype`] if the type occupies zero bytes per
+    /// element, or [`FormatError::ValueTooLargeForPlatform`] if the size does
+    /// not fit this target's `usize`.
+    pub(crate) fn element_size_usize(&self) -> Result<NonZeroUsize, FormatError> {
+        crate::convert::nonzero_usize_from(self.element_size()?)
     }
 }
 
@@ -1598,6 +1626,62 @@ mod tests {
         assert_eq!(
             Datatype::parse(&buf).unwrap_err(),
             FormatError::ZeroSizedDatatype { class: 3 }
+        );
+    }
+
+    /// The accessor the rest of the crate uses agrees with `type_size` for an
+    /// ordinary type. The point of the pair is that one of them carries a proof
+    /// and the other does not — not that they report different widths.
+    #[test]
+    fn element_size_matches_type_size_for_a_type_that_has_one() {
+        let dt = Datatype::FixedPoint {
+            size: 4,
+            byte_order: DatatypeByteOrder::LittleEndian,
+            signed: true,
+            bit_offset: 0,
+            bit_precision: 32,
+        };
+        assert_eq!(dt.element_size().unwrap().get(), dt.type_size());
+    }
+
+    /// A caller-built literal never passes through `parse`, so `element_size` is
+    /// the only thing standing between a degenerate type and the writers. The
+    /// `Array` case is the one that matters: its width is *computed* from its
+    /// dimensions, so this cannot be caught by inspecting a stored size field.
+    #[test]
+    fn element_size_refuses_a_constructed_array_with_a_zero_dimension() {
+        let dt = Datatype::Array {
+            base_type: Box::new(Datatype::FixedPoint {
+                size: 4,
+                byte_order: DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 32,
+            }),
+            dimensions: vec![0, 4],
+        };
+        assert_eq!(dt.type_size(), 0);
+        assert_eq!(
+            dt.element_size().unwrap_err(),
+            FormatError::ZeroSizedDatatype { class: 10 }
+        );
+        assert_eq!(
+            dt.element_size_usize().unwrap_err(),
+            FormatError::ZeroSizedDatatype { class: 10 }
+        );
+    }
+
+    /// The class in the error names the type that was refused, not the base type
+    /// underneath it, so a report points at the message the writer was handed.
+    #[test]
+    fn element_size_reports_the_refused_types_own_class() {
+        let dt = Datatype::Compound {
+            size: 0,
+            members: vec![],
+        };
+        assert_eq!(
+            dt.element_size().unwrap_err(),
+            FormatError::ZeroSizedDatatype { class: 6 }
         );
     }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -181,6 +181,8 @@ use std::fs;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
+use core::num::NonZeroUsize;
+
 use crate::checksum::jenkins_lookup3;
 use crate::chunk_index_inplace::{Located, Store, apply_ea_append, plan_ea_append};
 use crate::chunked_read::{
@@ -1059,8 +1061,8 @@ const APPEND_BATCH_BYTES: u64 = 1 << 20;
 pub(crate) struct AppendGeometry {
     /// Elements per chunk along axis 0 (>= 1).
     pub(crate) chunk_elems: u64,
-    /// Bytes per on-disk element.
-    pub(crate) element_size: usize,
+    /// Bytes per on-disk element, proven non-zero.
+    pub(crate) element_size: NonZeroUsize,
     /// Current length along the unlimited dimension.
     pub(crate) current_dim: u64,
     /// Whether a filter pipeline applies (an in-place append then requires a
@@ -1087,8 +1089,8 @@ pub(crate) struct LocatedState {
     pub(crate) datatype: Datatype,
     /// Spatial (rank-length) chunk dimensions in elements: `[chunk_elems]`.
     pub(crate) spatial: Vec<u64>,
-    /// Bytes per element (datatype size).
-    pub(crate) element_size: usize,
+    /// Bytes per element (datatype size), proven non-zero.
+    pub(crate) element_size: NonZeroUsize,
     /// The re-encodable filter pipeline, when the dataset is filtered.
     pub(crate) pipeline: Option<FilterPipeline>,
 }
@@ -2440,7 +2442,7 @@ impl WriteEngine {
             let st = &self.located[&oh_addr];
             (
                 st.loc.chunk_elems.max(1),
-                st.element_size as u64,
+                st.element_size.get() as u64,
                 self.batch_elems(st.loc.chunk_bytes, st.loc.chunk_elems.max(1)),
                 st.pipeline.is_some(),
                 st.loc.current_dim,
@@ -4665,7 +4667,7 @@ impl WriteEngine {
                              cannot be overwritten in place yet",
                         ));
                     }
-                    let ctx = ChunkContext::from_datatype(&spatial, &fd.dt);
+                    let ctx = ChunkContext::from_datatype(&spatial, &fd.dt)?;
                     let mut encoded = Vec::with_capacity(split.len());
                     for (_, buf) in &split {
                         encoded.push(compress_chunk(buf, &pipeline, ctx)?);
@@ -4984,14 +4986,14 @@ impl WriteEngine {
                 .read_exact_at(partial.address, len)
                 .map_err(|_| Error::AppendUnsupported("trailing chunk could not be read"))?;
             let full = if let Some(pl) = &pipeline {
-                let ctx = ChunkContext::from_datatype(&spatial, &disk_dt);
+                let ctx = ChunkContext::from_datatype(&spatial, &disk_dt)?;
                 decompress_chunk(&stored, pl, ctx, partial.filter_mask).map_err(Error::Format)?
             } else {
                 stored
             };
             let live_elems = usize::try_from(current_dim0 % chunk_elems)
                 .map_err(|_| Error::AppendUnsupported("chunk length exceeds this platform"))?;
-            let live_bytes = live_elems * element_size;
+            let live_bytes = live_elems * element_size.get();
             if full.len() < live_bytes {
                 return Err(Error::AppendUnsupported(
                     "trailing chunk decoded shorter than its live element count",
@@ -5008,7 +5010,7 @@ impl WriteEngine {
         let tail_len_elems = new_dim0 - (n_full as u64) * chunk_elems;
         let split = split_into_chunks(&tail_raw, &[tail_len_elems], &spatial, element_size);
         let new_chunk_bytes: Vec<Vec<u8>> = if let Some(pl) = &pipeline {
-            let ctx = ChunkContext::from_datatype(&spatial, &disk_dt);
+            let ctx = ChunkContext::from_datatype(&spatial, &disk_dt)?;
             let mut out = Vec::with_capacity(split.len());
             for (_, buf) in &split {
                 out.push(compress_chunk(buf, pl, ctx).map_err(Error::Format)?);
@@ -5578,7 +5580,7 @@ impl WriteEngine {
         &mut self,
         region: &[u8],
         chunk_dims: &[u64],
-        element_size: usize,
+        element_size: NonZeroUsize,
         raw_size: u64,
         maxshape: Option<&[u64]>,
         pipeline_message: Option<&[u8]>,
@@ -5788,7 +5790,7 @@ impl WriteEngine {
         region: &[u8],
         new_dataspace_body: &[u8],
         chunk_dims_u32: &[u32],
-        element_size: usize,
+        element_size: NonZeroUsize,
         raw_size: u64,
         has_filters: bool,
         kept_chunks: &[WrittenChunk],
@@ -5849,7 +5851,7 @@ impl WriteEngine {
             chunk_dims_u32,
             ea_base,
             OFFSET_SIZE,
-            element_size as u32,
+            element_size.get() as u32,
         );
         let region = replace_dataspace_message(region, new_dataspace_body)?;
         let region = replace_layout_message(&region, &layout_body)?;
@@ -6186,7 +6188,7 @@ impl WriteEngine {
     /// (issue #261).
     fn build_chunked_dataset(&mut self, fd: &FlatDataset) -> Result<Vec<u8>, Error> {
         let chunk_dims = fd.chunk_options.resolve_chunk_dims(&fd.ds.dimensions);
-        let ctx = ChunkContext::from_datatype(&chunk_dims, &fd.dt);
+        let ctx = ChunkContext::from_datatype(&chunk_dims, &fd.dt)?;
         let set = compress_chunks(
             &fd.raw,
             &fd.ds.dimensions,
@@ -6722,7 +6724,7 @@ enum CopyTree {
     DatasetChunked {
         region: Vec<u8>,
         chunk_dims: Vec<u64>,
-        element_size: usize,
+        element_size: NonZeroUsize,
         raw_size: u64,
         maxshape: Option<Vec<u64>>,
         pipeline_message: Option<Vec<u8>>,
@@ -6799,7 +6801,7 @@ enum MovingWrite {
     Chunked {
         region: Vec<u8>,
         chunk_dims: Vec<u64>,
-        element_size: usize,
+        element_size: NonZeroUsize,
         raw_size: u64,
         maxshape: Option<Vec<u64>>,
         pipeline_message: Option<Vec<u8>>,
@@ -6828,7 +6830,7 @@ enum MovingWrite {
         new_dataspace_body: Vec<u8>,
         /// Rank-only spatial chunk dimensions, for the rebuilt v4 layout message.
         chunk_dims_u32: Vec<u32>,
-        element_size: usize,
+        element_size: NonZeroUsize,
         /// Full (uncompressed) chunk byte size = product(spatial) * element_size.
         raw_size: u64,
         has_filters: bool,
@@ -7237,9 +7239,11 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
     // Refused for the same reason the whole-file writer refuses it: nothing
     // occupies zero bytes per element, the writers divide by the element size,
     // and a caller-built `Datatype` never passes through `Datatype::parse`.
-    dt.ensure_nonzero_size()?;
+    // Taking it as a `NonZeroUsize` hands the proof to the staging below rather
+    // than leaving each step to re-derive it.
+    let elem_size = dt.element_size_usize()?;
 
-    let elem = dt.type_size() as u64;
+    let elem = elem_size.get() as u64;
     // Multiply with checked arithmetic: an absurd shape whose element count
     // (or byte size) overflows `u64` is refused rather than panicking in a
     // debug build or silently wrapping in release (which could let a wrapped
@@ -7293,10 +7297,10 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         // so the
         // resulting object header is byte-identical to a freshly written one.
         let chunk_dims = db.chunk_options.resolve_chunk_dims(&shape);
-        let ctx = ChunkContext::from_datatype(&chunk_dims, &dt);
+        let ctx = ChunkContext::from_datatype(&chunk_dims, &dt)?;
         db.chunk_options
             .build_pipeline(
-                ctx.element_size,
+                ctx.element_size.get(),
                 &chunk_dims,
                 ctx.element_type,
                 ctx.scale_offset_type,
@@ -7604,8 +7608,9 @@ fn parse_chunked_header(region: &[u8]) -> Result<ChunkedHeaderParts, Error> {
 struct ChunkedGeometry {
     /// Rank-only spatial chunk dimensions.
     spatial: Vec<u64>,
-    /// Element size in bytes.
-    element_size: usize,
+    /// Element size in bytes, proven non-zero: the chunk splitter divides by
+    /// it, and so does the append path's element-count arithmetic.
+    element_size: NonZeroUsize,
     /// Full (uncompressed) chunk byte size, `product(spatial) * element_size`.
     raw_size: u64,
     /// The on-disk maximum dimensions when they differ from the current shape; an
@@ -7637,17 +7642,12 @@ fn chunked_geometry(
         .iter()
         .map(|&c| u64::from(c))
         .collect();
-    let element_size = dt.type_size() as usize;
-    if element_size == 0 {
-        return Err(Error::EditUnsupported(
-            "chunked dataset has a zero element size",
-        ));
-    }
+    let element_size = dt.element_size_usize()?;
     let raw_size = spatial
         .iter()
         .copied()
         .product::<u64>()
-        .saturating_mul(element_size as u64);
+        .saturating_mul(element_size.get() as u64);
     let maxshape = ds
         .max_dimensions
         .as_ref()

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use alloc::string::String;
 use std::string::String;
 
 use core::fmt;
+use core::num::NonZeroUsize;
 
 /// Errors that can occur when parsing HDF5 binary format structures.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -284,9 +285,10 @@ pub enum FormatError {
         expected: usize,
         /// Number of data bytes actually supplied.
         actual: usize,
-        /// Size in bytes of one element (the dataset's datatype size). Always
-        /// non-zero; used to report the mismatch in elements as well as bytes.
-        element_size: usize,
+        /// Size in bytes of one element (the dataset's datatype size), used to
+        /// report the mismatch in elements as well as bytes. Non-zero by type,
+        /// so the division in the message is well defined.
+        element_size: NonZeroUsize,
     },
     /// A chunked/filtered/extensible dataset's chunk geometry is invalid — for
     /// example chunk dimensions whose rank disagrees with the shape, a zero chunk
@@ -815,14 +817,12 @@ impl fmt::Display for FormatError {
                 actual,
                 element_size,
             } => {
-                // `element_size` is guaranteed non-zero at construction, so the
-                // element counts below are well defined.
                 write!(
                     f,
                     "shape/data mismatch: shape requires {} elements ({expected} bytes), \
                      but {} elements ({actual} bytes) were supplied",
-                    expected / element_size,
-                    actual / element_size,
+                    expected / element_size.get(),
+                    actual / element_size.get(),
                 )
             }
             FormatError::InvalidChunkGeometry(reason) => {

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1480,14 +1480,18 @@ impl FileWriter {
             // refuses. A caller-built `Datatype` reaches the writer without
             // passing through `Datatype::parse`, which refuses the file-sourced
             // ones, so this is where the same invariant is held on the way out.
-            dt.ensure_nonzero_size()?;
+            //
+            // Taking the size as a `NonZeroU32` here is what holds that for the
+            // rest of the write: every later stage receives the proof rather
+            // than the bare number, so none of them re-checks it.
+            let elem_size = dt.element_size_usize()?;
             // Guard against a shape that disagrees with the supplied data. The
             // reader enforces the same `num_elements * element_size` invariant
             // (see `data_read::read_raw_data_full`), so without this check a
             // mismatch (e.g. data for 3 elements with shape `[2, 2]`) would
             // produce a file that fails to read back. `saturating_mul` keeps an
             // absurd shape from overflowing into a false match.
-            let elem_size = dt.type_size() as u64;
+            let elem_bytes = elem_size.get() as u64;
             if !is_empty && raw_chunks.is_none() {
                 // A produced region is checked against the same invariant as a
                 // materialized one — its size is declared rather than measured,
@@ -1507,7 +1511,7 @@ impl FileWriter {
                     .copied()
                     .try_fold(1u64, |acc, d| acc.checked_mul(d))
                     .unwrap_or(u64::MAX);
-                let expected = num_elements.saturating_mul(elem_size);
+                let expected = num_elements.saturating_mul(elem_bytes);
                 if declared != expected {
                     #[expect(
                         clippy::cast_possible_truncation,
@@ -1516,7 +1520,7 @@ impl FileWriter {
                     return Err(FormatError::ShapeDataMismatch {
                         expected: expected as usize,
                         actual: declared as usize,
-                        element_size: elem_size as usize,
+                        element_size: elem_size,
                     });
                 }
             }
@@ -1571,10 +1575,9 @@ impl FileWriter {
             // A user-defined fill value is one element wide, so its byte length
             // must equal the datatype's element size.
             if let Some(fill) = &db.fill {
-                let expected = elem_size.to_usize()?;
-                if fill.len() != expected {
+                if fill.len() != elem_size.get() {
                     return Err(FormatError::FillValueSizeMismatch {
-                        expected,
+                        expected: elem_size.get(),
                         actual: fill.len(),
                     });
                 }
@@ -1613,7 +1616,7 @@ impl FileWriter {
             types
                 .into_iter()
                 .map(|ct| {
-                    ct.datatype.ensure_nonzero_size()?;
+                    ct.datatype.element_size()?;
                     committed.push(CtFlat {
                         name: ct.name,
                         dt: ct.datatype,
@@ -2033,7 +2036,7 @@ impl FileWriter {
             .map(|(i, d)| {
                 if is_chunked[i] && d.raw_chunks.is_none() {
                     let chunk_dims = d.chunk_options.resolve_chunk_dims(&d.ds.dimensions);
-                    let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt);
+                    let ctx = crate::filters::ChunkContext::from_datatype(&chunk_dims, &d.dt)?;
                     Ok(Some(compress_chunks(
                         &d.raw,
                         &d.ds.dimensions,

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -64,13 +64,13 @@ impl<'a> ChunkContext<'a> {
     ///
     /// Currently only used by tests (read/write paths build the context via
     /// [`ChunkContext::from_datatype`]); gated so it is not shipped as dead code.
-    #[cfg(test)]
     ///
     /// # Panics
     ///
-    /// If `element_size` is zero. Test-only, and every caller passes a literal
-    /// width; the production constructor
+    /// If `element_size` is zero. Every caller passes a literal width, and this
+    /// is test-only; the production constructor
     /// [`from_datatype`](Self::from_datatype) returns an error instead.
+    #[cfg(test)]
     pub fn basic(chunk_dims: &'a [u64], element_size: u32) -> Self {
         Self {
             chunk_dims,

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -6,6 +6,8 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+
+use core::num::NonZeroU32;
 // `format!` is only reached by the zfp-gated code paths below.
 #[cfg(all(not(feature = "std"), feature = "zfp"))]
 use alloc::format;
@@ -32,8 +34,12 @@ use crate::zfp::ZfpElementType;
 pub struct ChunkContext<'a> {
     /// Chunk dimensions in elements (one per dataset rank).
     pub chunk_dims: &'a [u64],
-    /// Size of one element in bytes (for shuffle's interleave width).
-    pub element_size: u32,
+    /// Size of one element in bytes (for shuffle's interleave width), proven
+    /// non-zero: the chunk splitter clamps a row copy to an element boundary
+    /// with `% element_size`, and the byte-oriented filters divide a buffer
+    /// length by it. Carrying the proof here is what lets those sites skip a
+    /// check of their own.
+    pub element_size: NonZeroU32,
     /// Scalar type, required for type-aware filters like ZFP. `None` means
     /// the caller does not know or does not need it; type-aware filters
     /// will return an error.
@@ -59,27 +65,44 @@ impl<'a> ChunkContext<'a> {
     /// Currently only used by tests (read/write paths build the context via
     /// [`ChunkContext::from_datatype`]); gated so it is not shipped as dead code.
     #[cfg(test)]
+    ///
+    /// # Panics
+    ///
+    /// If `element_size` is zero. Test-only, and every caller passes a literal
+    /// width; the production constructor
+    /// [`from_datatype`](Self::from_datatype) returns an error instead.
     pub fn basic(chunk_dims: &'a [u64], element_size: u32) -> Self {
         Self {
             chunk_dims,
-            element_size,
+            element_size: NonZeroU32::new(element_size).expect("a test's element size is non-zero"),
             element_type: None,
             scale_offset_type: None,
         }
     }
 
     /// Build a full context from a dataset's `Datatype`: derives
-    /// `element_size` from `dt.type_size()` and `element_type` from
+    /// `element_size` from [`Datatype::element_size`] and `element_type` from
     /// [`zfp_element_type_from_datatype`]. This is the preferred
     /// constructor for read/write paths where a `Datatype` is in scope,
     /// so the two fields can't drift out of sync.
-    pub fn from_datatype(chunk_dims: &'a [u64], dt: &crate::datatype::Datatype) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::ZeroSizedDatatype`] if the type occupies zero bytes per
+    /// element. Refusing here is what makes the field's guarantee true; every
+    /// consumer of the context then takes the size without re-checking it.
+    ///
+    /// [`Datatype::element_size`]: crate::datatype::Datatype::element_size
+    pub fn from_datatype(
+        chunk_dims: &'a [u64],
+        dt: &crate::datatype::Datatype,
+    ) -> Result<Self, FormatError> {
+        Ok(Self {
             chunk_dims,
-            element_size: dt.type_size(),
+            element_size: dt.element_size()?,
             element_type: zfp_element_type_from_datatype(dt),
             scale_offset_type: crate::scaleoffset::scale_offset_type_from_datatype(dt),
-        }
+        })
     }
 }
 
@@ -142,7 +165,7 @@ pub fn decompress_chunk(
         }
         let input: &[u8] = owned.as_deref().unwrap_or(compressed);
         let next = match filter.filter_id {
-            FILTER_SHUFFLE => shuffle_decompress(input, ctx.element_size as usize)?,
+            FILTER_SHUFFLE => shuffle_decompress(input, ctx.element_size.get() as usize)?,
             FILTER_DEFLATE => {
                 deflate_decompress(input, inner_output_cap(expected, pipeline, filter_mask, i))?
             }
@@ -187,7 +210,7 @@ fn expected_chunk_len(ctx: &ChunkContext<'_>) -> Option<usize> {
         .chunk_dims
         .iter()
         .try_fold(1u64, |acc, &d| acc.checked_mul(d))?;
-    let bytes = elems.checked_mul(u64::from(ctx.element_size))?;
+    let bytes = elems.checked_mul(u64::from(ctx.element_size.get()))?;
     usize::try_from(bytes).ok().filter(|&n| n != 0)
 }
 
@@ -285,7 +308,7 @@ pub fn compress_chunk(
     for filter in &pipeline.filters {
         let input: &[u8] = owned.as_deref().unwrap_or(data);
         let next = match filter.filter_id {
-            FILTER_SHUFFLE => shuffle_compress(input, ctx.element_size as usize)?,
+            FILTER_SHUFFLE => shuffle_compress(input, ctx.element_size.get() as usize)?,
             FILTER_DEFLATE => {
                 let level = filter.client_data.first().copied().unwrap_or(6);
                 deflate_compress(input, level)?
@@ -615,6 +638,38 @@ fn fletcher32_append(data: &[u8]) -> Result<Vec<u8>, FormatError> {
 mod tests {
     use super::*;
     use crate::filter_pipeline::FilterDescription;
+
+    /// The context is the single place a `Datatype` becomes an element width for
+    /// the chunk splitter and the byte-oriented filters, so it is where a
+    /// degenerate type has to be turned away. Everything downstream then takes
+    /// the width without a check of its own.
+    #[test]
+    fn a_context_cannot_be_built_from_a_zero_width_datatype() {
+        let degenerate = crate::datatype::Datatype::Array {
+            base_type: Box::new(crate::datatype::Datatype::FixedPoint {
+                size: 4,
+                byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+                signed: true,
+                bit_offset: 0,
+                bit_precision: 32,
+            }),
+            dimensions: vec![0],
+        };
+        assert_eq!(
+            ChunkContext::from_datatype(&[4], &degenerate).unwrap_err(),
+            FormatError::ZeroSizedDatatype { class: 10 }
+        );
+
+        let ordinary = crate::datatype::Datatype::FixedPoint {
+            size: 4,
+            byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+            signed: true,
+            bit_offset: 0,
+            bit_precision: 32,
+        };
+        let ctx = ChunkContext::from_datatype(&[4], &ordinary).unwrap();
+        assert_eq!(ctx.element_size.get(), 4);
+    }
 
     // --- Deflate tests ---
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1399,7 +1399,7 @@ impl FileInner {
         num_rows: u64,
     ) -> Result<Vec<u8>, FormatError> {
         let (os, ls) = (self.offset_size(), self.length_size());
-        let elem_size = dt.type_size() as usize;
+        let elem_size = dt.element_size_usize()?;
         // Elements per row (product of inner dims; 1 when 0-D or 1-D). Checked so
         // a crafted dataspace whose inner dims overflow `usize` errors instead of
         // panicking (debug) or wrapping (release).
@@ -1410,12 +1410,13 @@ impl FileInner {
                     length: d,
                 })
         })?;
-        let row_bytes = row_elems
-            .checked_mul(elem_size)
-            .ok_or(FormatError::OffsetOverflow {
-                offset: row_elems as u64,
-                length: elem_size as u64,
-            })?;
+        let row_bytes =
+            row_elems
+                .checked_mul(elem_size.get())
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: row_elems as u64,
+                    length: elem_size.get() as u64,
+                })?;
 
         // Compact data is inline in the layout message — no I/O, no framing.
         if let DataLayout::Compact { data } = dl {
@@ -3180,7 +3181,7 @@ impl Dataset {
     /// file-mode and eligibility rules.
     pub fn append_raw(&mut self, bytes: &[u8]) -> Result<(), Error> {
         let g = self.append_geometry()?;
-        let es = g.element_size.max(1);
+        let es = g.element_size;
         // Whole-element length is checked before any batch applies, so the
         // refusal is atomic (the per-batch validation would only reject the
         // final, short batch after earlier ones had durably committed).
@@ -3191,7 +3192,7 @@ impl Dataset {
         }
         let total = (bytes.len() / es) as u64;
         self.append_batches(g, total, |b, r| {
-            b.append_raw(&bytes[r.start * es..r.end * es]);
+            b.append_raw(&bytes[r.start * es.get()..r.end * es.get()]);
         })
     }
 
@@ -4286,7 +4287,7 @@ impl Dataset {
             return Ok(Vec::new());
         };
         let dataspace = self.dataspace()?;
-        let elem_size = self.datatype()?.type_size() as usize;
+        let elem_size = self.datatype()?.element_size_usize()?;
         let base = self.file.addr_offset;
         // The chunk index — its root at `addr` and every internal node — stores
         // addresses relative to the base address. Walk it through a base-relative
@@ -4588,7 +4589,7 @@ impl Dataset {
     /// memory layout, so padded compound records are supported safely.
     pub fn read_compound<T: CompoundType>(&self) -> Result<Vec<T>, Error> {
         let datatype = self.datatype()?;
-        let element_size = datatype.type_size().to_usize()?;
+        let element_size = datatype.element_size_usize()?;
         if !matches!(datatype, Datatype::Compound { .. }) {
             return Err(FormatError::TypeMismatch {
                 expected: "Compound",
@@ -4597,14 +4598,14 @@ impl Dataset {
             .into());
         }
         let raw = self.read_raw()?;
-        if element_size == 0 || !raw.len().is_multiple_of(element_size) {
+        if !raw.len().is_multiple_of(element_size.get()) {
             return Err(FormatError::DataSizeMismatch {
-                expected: element_size,
+                expected: element_size.get(),
                 actual: raw.len(),
             }
             .into());
         }
-        raw.chunks_exact(element_size)
+        raw.chunks_exact(element_size.get())
             .map(|bytes| T::decode(&datatype, bytes).map_err(Error::from))
             .collect()
     }

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -637,7 +637,7 @@ fn emit_dataset(
                 .as_ref()
                 .filter(|ms| *ms != &dims)
                 .map(|ms| ms.as_slice());
-            let elem_size = datatype.type_size() as usize;
+            let elem_size = datatype.element_size_usize()?;
             // Stream the chunks from the source at write time rather than reading
             // them all now: the provider holds an `Arc<File>` and fetches one
             // chunk at a time, so a huge dataset never sits in memory.

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -7,6 +7,8 @@ use alloc::{boxed::Box, string::String, string::ToString, vec, vec::Vec};
 
 use core::fmt;
 
+use core::num::NonZeroUsize;
+
 use crate::attribute::AttributeMessage;
 use crate::chunked_write::{ChunkMeta, ChunkOptions, ChunkProvider};
 use crate::compound::CompoundType;
@@ -1036,9 +1038,8 @@ pub(crate) struct VlStringStaging {
 /// while the heap object still holds the exact bytes.
 pub(crate) fn stage_vl_elements(
     elements: &[VlStringElement],
-    element_size: usize,
+    element_size: NonZeroUsize,
 ) -> VlStringStaging {
-    let element_size = element_size.max(1);
     // Collect the non-null payloads in order; their positions become the heap
     // object indices, 1-based within each collection.
     let mut objects: Vec<&[u8]> = Vec::new();
@@ -1474,8 +1475,8 @@ pub struct ProvenanceConfig {
 pub(crate) struct RawChunkPayload {
     /// Logical chunk dimensions (rank entries, not the trailing element size).
     pub(crate) chunk_dims: Vec<u64>,
-    /// Datatype element size in bytes.
-    pub(crate) element_size: usize,
+    /// Datatype element size in bytes, proven non-zero.
+    pub(crate) element_size: NonZeroUsize,
     /// Full uncompressed byte size of one chunk
     /// (`product(chunk_dims) * element_size`), identical for every chunk.
     pub(crate) raw_size: u64,
@@ -1942,7 +1943,7 @@ impl DatasetBuilder {
         dims: &[u64],
         maxshape: Option<&[u64]>,
         chunk_dims: &[u64],
-        element_size: usize,
+        element_size: NonZeroUsize,
         pipeline_message: Option<Vec<u8>>,
         meta: Vec<ChunkMeta>,
         provider: Box<dyn ChunkProvider>,
@@ -1955,7 +1956,7 @@ impl DatasetBuilder {
             .iter()
             .copied()
             .product::<u64>()
-            .saturating_mul(element_size as u64);
+            .saturating_mul(element_size.get() as u64);
         self.datatype = Some(datatype);
         if self.shape.is_none() {
             self.shape = Some(dims.to_vec());
@@ -2133,7 +2134,7 @@ impl DatasetBuilder {
     fn stage_vlen_strings(&mut self, datatype: Datatype, elements: &[VlStringElement]) {
         // A VL string's base type is one byte, so the reference length is the
         // byte count (element_size = 1).
-        self.stage_vlen_elements(datatype, elements, 1);
+        self.stage_vlen_elements(datatype, elements, NonZeroUsize::MIN);
     }
 
     /// Write a *non-string* variable-length (sequence) dataset from an explicit
@@ -2165,12 +2166,11 @@ impl DatasetBuilder {
                 actual: "VariableLength string",
             });
         }
-        let element_size = base_type.type_size() as usize;
-        if element_size == 0 {
+        let Some(element_size) = NonZeroUsize::new(base_type.type_size() as usize) else {
             return Err(crate::error::FormatError::VlDataError(
                 "non-string VL base type has zero size".into(),
             ));
-        }
+        };
         self.stage_vlen_elements(datatype, elements, element_size);
         Ok(self)
     }
@@ -2210,7 +2210,7 @@ impl DatasetBuilder {
         &mut self,
         datatype: Datatype,
         elements: &[VlStringElement],
-        element_size: usize,
+        element_size: NonZeroUsize,
     ) {
         let n = elements.len() as u64;
         let staging = stage_vl_elements(elements, element_size);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -464,6 +464,7 @@ impl Default for FileBuilder {
 mod streaming_tests {
     use super::*;
     use crate::chunked_write::{ChunkMeta, ChunkProvider};
+    use crate::convert::nz;
     use std::sync::{Arc, Mutex};
 
     type Calls = Arc<Mutex<Vec<usize>>>;
@@ -537,7 +538,7 @@ mod streaming_tests {
             dims,
             maxshape,
             chunk_dims,
-            8,
+            nz(8),
             None,
             meta,
             Box::new(provider),
@@ -784,7 +785,7 @@ mod streaming_tests {
                     &[4],
                     None,
                     &[2],
-                    8,
+                    nz(8),
                     None,
                     meta,
                     Box::new(provider),

--- a/tests/enum_datatype.rs
+++ b/tests/enum_datatype.rs
@@ -179,7 +179,7 @@ fn enum_i32_data_into_u8_enum_type_is_rejected() {
             actual,
             element_size,
         })) => {
-            assert_eq!(element_size, 1);
+            assert_eq!(element_size.get(), 1);
             assert_eq!(expected, 2); // 2 elements * 1 byte
             assert_eq!(actual, 8); // 2 values * 4 bytes each
         }

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1178,7 +1178,7 @@ fn shape_data_mismatch_is_rejected() {
         }) => {
             assert_eq!(expected, 4 * 8); // shape needs 4 f64 = 32 bytes
             assert_eq!(actual, 3 * 8); // only 3 f64 = 24 bytes supplied
-            assert_eq!(element_size, 8); // f64
+            assert_eq!(element_size.get(), 8); // f64
         }
         other => panic!("expected ShapeDataMismatch, got {other:?}"),
     }


### PR DESCRIPTION
Stacked on #271 — review that one first; this PR's diff against `main` includes it.

Follow-up to @CramBL's review comment on #271: use `NonZero` so the size is checked once and the rest of the call stack takes the proof rather than re-deriving it.

## What #271 left behind

#271 established the invariant but did not carry it. `ensure_nonzero_size` returned `()`, so every caller went back to `type_size()` for a bare `u32` that was non-zero only by convention:

```rust
dt.ensure_nonzero_size()?;
// ...
let elem_size = dt.type_size() as u64;   // non-zero by convention only
```

and the two division sites kept a `debug_assert!(elem_size > 0)` restating what had already been proven.

## The change

`Datatype::element_size` replaces `ensure_nonzero_size` and returns the width as a `NonZeroU32` (`element_size_usize` for the byte arithmetic that indexes a buffer). The proof then flows down: `ChunkContext::element_size`, `ChunkedGeometry`, `AppendGeometry`, `RawChunkPayload`, `split_into_chunks`, `plan_chunked_data_verbatim`, `assemble_chunks`, `copy_chunk_to_output`, `row_band_copy`, and the `data_read` decoders all take a non-zero size.

`usize % NonZeroUsize` and `usize / NonZeroUsize` are total, so the divisions cannot fault and **both `debug_assert!`s are deleted rather than merely satisfied**. In `data_read.rs` eight copies of `if elem_size == 0 || !raw.len().is_multiple_of(elem_size)` lose their first disjunct.

`ChunkContext::from_datatype` becomes fallible, which is the right place for it: it is the one constructor that derives an element width from a `Datatype`, and every consumer of the context then takes that width without a check.

## What `type_size()` cannot become, and why

It stays a plain `u32`. It is *computed* — an `Array` reports its base type times its dimensions — so `Array { dimensions: vec![0], .. }` yields zero even if every stored `size` field were already `NonZeroU32`. That construction is legal by design; the enum's own doc comment says only the class set is sealed and "the variants stay open, so an exotic type this crate has no constructor for can still be built as a literal". Making `type_size()` infallibly non-zero would mean `NonZeroU32` on every variant *and* `Vec<NonZeroU32>` dimensions — a much larger break, and worse ergonomics at every literal.

## Three sidesteps removed

Not a rename: these silently rewrote a zero width to one, so a degenerate type produced wrong output instead of an error.

- `Dataset::append_raw`: `let es = g.element_size.max(1);`
- `AppendWriter` construction: `element_size: g.element_size.max(1),`
- `stage_vl_elements`: `let element_size = element_size.max(1);`

Two more were real refusals that now *produce* the proof instead of only gating on it: the chunked layout message's element-size dimension, and `chunk_index_inplace`'s `elem_bytes`.

## Breaking

`FormatError::ShapeDataMismatch::element_size` is now `NonZeroUsize`. Its `Display` divides by that field and carried a comment asserting the value was "guaranteed non-zero at construction" — a claim a reader had to verify by auditing every construction site. The type says it now.

No version bump: 0.37.0 already carries a break this cycle (`CompoundTypeBuilder::build`, in #271), and one bump covers the cycle.

## Deliberately unchanged

`plan_blocking` / `mat::Blocking` keep `usize`. `BlockElement` is sealed and every `ELEMENT_SIZE` is `size_of`-derived, so nothing untrusted reaches it and its one division is already guarded — converting a public reporting struct there would be ceremony. `vl_data`'s `element_size / VL_REF_BYTES` divides by a constant, not by the element size.

## Testing

786 lib + 1692 integration tests pass. Most of this refactor is proven by the compiler rather than at runtime — that is the point — so the new tests cover what stays observable:

- `element_size` agrees with `type_size` for an ordinary type
- it refuses a **constructed** array whose dimensions multiply to zero (the case no header field can catch)
- the class in the error names the refused type, not its base
- the `NonZeroU32` → `NonZeroUsize` narrowing preserves the proof
- a `ChunkContext` cannot be built from a zero-width type

`Datatype::parse` kept its own copy of the check; it now goes through `element_size` too, so the rule has one implementation. Mutating that accessor to substitute `1` rather than refuse fails exactly the five new tests **plus the four read-side refusal tests from #268** — the unification is what puts the last four in that list, and the failure reads `unwrap_err() on an Ok value: 1`, i.e. it trips on the guard under test rather than an earlier one. Mutating only `from_datatype` fails only the context test.
