### PR TITLE
Cut the test suite from 2m43s to 20s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,32 @@
+# cargo-nextest configuration (issue #269).
+#
+# Why nextest at all: `cargo test` runs the integration binaries one after
+# another, so a suite spread over 100+ of them spends most of its wall clock on
+# one core. Measured here on a 10-core machine at `--all-features`, after the
+# per-append `fsync` fix in the same issue: 46.1s under `cargo test` (115% CPU)
+# against 17.9s under nextest (421% CPU). The work is identical; only the
+# scheduling differs.
+#
+# nextest does not run doctests -- it has no way to, since they are compiled by
+# `rustdoc` rather than into a test binary. The pre-push gate is therefore
+# `cargo nextest run` *and* `cargo test --doc`; CI runs both as separate steps
+# so a doctest failure is not silently dropped. See CLAUDE.md.
+
+# Require a version that understands this file's schema, so an older nextest
+# fails loudly instead of ignoring settings the gate depends on.
+nextest-version = "0.9.90"
+
+[profile.default]
+# A test that takes 30s is reported; one that takes 90s fails the run.
+#
+# This exists because of what #269 found: a single test spent 117s issuing one
+# `fsync` per appended element, five times the rest of the suite combined, and
+# nothing flagged it -- nextest's stock 60s warning was not in play because the
+# suite ran under `cargo test`, which reports no per-test timings at all.
+#
+# The bound has room. The slowest legitimate test in the suite is ~13s here
+# (`dense_attr_limits_crosscheck`, `c_absence_predicate`), and CI runners are
+# slower than a dev machine but not seven times slower. A test that genuinely
+# needs longer should say so with an override below rather than by raising this
+# ceiling for everything.
+slow-timeout = { period = "30s", terminate-after = 3 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,16 @@
 # `rustdoc` rather than into a test binary. The pre-push gate is therefore
 # `cargo nextest run` *and* `cargo test --doc`; CI runs both as separate steps
 # so a doctest failure is not silently dropped. See CLAUDE.md.
+#
+# One property this scheduling now depends on: tests in *different* binaries run
+# at the same time, which `cargo test` never did (it ran binaries one at a time,
+# concurrent only within each). Most tests here work in a `tempdir()` and are
+# unaffected, but 225 of them write a hardcoded name into the shared system
+# temp directory, and those were previously serialized by binary. They are all
+# distinct -- each file prefixes its own (`hdf5_pure_ub_`, `hdf5_pure_fs_`, ...)
+# -- so nothing collides. Keep it that way: a name reused across two test files
+# would now be two processes writing one path, which fails only sometimes and,
+# because the locks are mandatory there, mostly on Windows.
 
 # Require a version that understands this file's schema, so an older nextest
 # fails loudly instead of ignoring settings the gate depends on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-${{ matrix.config.name }}
-      - run: cargo test --locked ${{ matrix.config.flags }}
+      # nextest schedules every test across all ~110 integration binaries in one
+      # pool; `cargo test` runs the binaries one at a time and leaves most of the
+      # machine idle. Measured at `--all-features` on a 10-core host: 46.1s
+      # against 17.9s (issue #269). `.config/nextest.toml` also fails the run on
+      # a test that takes longer than 90s, which is the regression that issue
+      # was opened over.
+      - name: Test (nextest)
+        run: cargo nextest run --locked ${{ matrix.config.flags }}
+      # nextest cannot run doctests -- `rustdoc` compiles those, not the test
+      # harness -- so they need their own step. Without it this job would go on
+      # passing while 32 doctests (46 under `full`) stopped running.
+      - name: Doctests
+        run: cargo test --locked --doc ${{ matrix.config.flags }}
 
   # Run every example end-to-end. The examples are self-checking (each ends in
   # `assert!`s and panics on mismatch), so a regression in the public API surfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,21 @@ Run `cargo clean -p hdf5-pure` when builds start taking tens of seconds before a
 
 `[profile.dev]` and `[profile.test]` set `codegen-units = 4` against rustc's default of 256, which cuts objects per full rebuild from ~9,800 to ~600 for about one second on a library build. That slows the accumulation; it does not stop it, so the periodic clean is still the remedy. The reasoning and the measured curve are in `Cargo.toml` beside the setting.
 
-`cargo clean -p hdf5-pure` drops this package's artifacts across every profile and feature set, including all 97 integration binaries, and leaves dependencies (and the compiled libhdf5) alone. It costs one non-incremental rebuild of the crate, about five seconds. `CARGO_INCREMENTAL=0` stops the accumulation outright, but it makes every rebuild of the library non-incremental — 4.6s against 0.9s — so the periodic clean is the better trade.
+`cargo clean -p hdf5-pure` drops this package's artifacts across every profile and feature set, including all ~110 integration binaries, and leaves dependencies (and the compiled libhdf5) alone. It costs one non-incremental rebuild of the crate, about five seconds. `CARGO_INCREMENTAL=0` stops the accumulation outright, but it makes every rebuild of the library non-incremental — 4.6s against 0.9s — so the periodic clean is the better trade.
 
-Prefer `cargo test --lib` for the fast loop: the ~580 library tests run in about two seconds, and the mutation checks that prove a new test is load-bearing belong there. `cargo test --all-features` builds 97 separate integration binaries and compiles libhdf5 from source through `hdf5-metno-src`, so treat it as a pre-push gate rather than an inner-loop command, and keep to one feature set locally — every distinct set is a full parallel copy of the build graph.
+Prefer `cargo test --lib` for the fast loop: the ~580 library tests run in about two seconds, and the mutation checks that prove a new test is load-bearing belong there. The full suite builds ~110 separate integration binaries and compiles libhdf5 from source through `hdf5-metno-src`, so treat it as a pre-push gate rather than an inner-loop command, and keep to one feature set locally — every distinct set is a full parallel copy of the build graph.
+
+## The pre-push gate
+
+```
+cargo nextest run --all-features && cargo test --all-features --doc
+```
+
+Both halves are needed. **nextest does not run doctests** and never will: `rustdoc` compiles those, not the test harness. Running only the first command leaves 46 doctests silently unexecuted.
+
+nextest rather than `cargo test` because `cargo test` runs the ~110 integration binaries one after another, so the suite spends most of its wall clock on a single core no matter how many the machine has. Measured on a 10-core host at `--all-features`: **46.1s under `cargo test` (115% CPU) against 17.9s under nextest (421% CPU)**, running the identical 2,034 tests. Install it with `cargo install cargo-nextest --locked`; CI runs the same two commands per matrix config.
+
+`.config/nextest.toml` fails the run on any test slower than 90s and prints a warning at 30s. That gate exists because a single test once spent 117s issuing one `fsync` per appended element — five times the rest of the suite combined — and nothing surfaced it, since `cargo test` reports no per-test timings at all. **A long-running test in this suite is a defect signal, not a cost of doing business**: the usual cause is a session left on the default `SyncPolicy::Always` while looping over appends, and the fix is `SyncPolicy::OnClose`, which writes byte-identical files (`tests/sync_policy.rs` asserts exactly that) and still barriers at `close`. Reach for a per-test override in that config only after ruling this out.
 
 ## The HDF5 1.8 output format
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,8 +162,38 @@ approx_constant = "allow"
 #
 # `release` and `bench` keep their default of 16 — a throughput trade-off for
 # generated code rather than a build-artifact one.
+# Line tables instead of full DWARF (issue #269).
+#
+# Nothing in this repository's workflow inspects locals in a debugger; what it
+# reads is panic backtraces, and `line-tables-only` keeps those complete —
+# function names, files, and line numbers. What it drops is the type and
+# variable description of every symbol, which for ~110 test binaries that each
+# link this crate is a large share of the debug info emitted per build.
+#
+# Measured at `--all-features` from `cargo clean -p hdf5-pure` with the
+# dependency graph already built, on a 10-core macOS host:
+#
+#                              full debug   line-tables-only
+#   build this crate + tests    25.0/28.9s        16.6/16.8s
+#   object files (1,357)            590 MiB           476 MiB
+#   test binaries (130)            1.35 GiB          1.31 GiB
+#   target/debug                   4.19 GiB          3.96 GiB
+#
+# The win is the ~40% off the build, not the disk. Emitting less debug info is
+# less work by construction; the modest size figures are a macOS artifact and
+# do not carry to Linux — Mach-O leaves DWARF in the object files and links a
+# debug *map* into the executable, so a test binary here barely shrinks even as
+# the objects behind it lose 19%. The statically linked libhdf5 inside every
+# crosscheck binary is a further fixed weight this setting cannot touch.
+#
+# `[profile.test]` inherits `debug` from `[profile.dev]` — verified, not
+# assumed: `cargo test -v` passes `-C debuginfo=line-tables-only` to all 130
+# test targets. `codegen-units` is repeated below only because it already was.
+# `release` and `bench` are untouched, so a backtrace from a release build is
+# unaffected either way.
 [profile.dev]
 codegen-units = 4
+debug = "line-tables-only"
 
 [profile.test]
 codegen-units = 4

--- a/tests/append_writer.rs
+++ b/tests/append_writer.rs
@@ -4,7 +4,7 @@
 //! unfiltered, chunk-aligned and not, across one or many calls and sessions —
 //! read back with this crate. C-library interop lives in
 //! `append_writer_crosscheck.rs`.
-use hdf5_pure::{Error, File, FileBuilder, ScaleOffset};
+use hdf5_pure::{Error, File, FileAccessProperties, FileBuilder, ScaleOffset, SyncPolicy};
 use tempfile::tempdir;
 
 /// Create a rank-1, unlimited i32 dataset with the given chunk length and
@@ -46,7 +46,16 @@ fn read_i32(path: &std::path::Path) -> Vec<i32> {
 /// before the closure returns to the caller (so a subsequent read can reopen the
 /// file — the lock is mandatory on Windows).
 fn with_writer<T>(path: &std::path::Path, f: impl FnOnce(&File) -> T) -> T {
-    let file = File::open_rw(path).unwrap();
+    // `SyncPolicy::OnClose`: every test here asserts what the file contains, not
+    // when it reached the platter, and the default costs one `fsync` per append
+    // — the dominant cost of the session loops below. The policies write
+    // byte-identical files (`tests/sync_policy.rs` asserts that directly), and
+    // dropping the handle still issues the closing barrier.
+    let file = File::open_rw_with_options(
+        path,
+        FileAccessProperties::new().with_sync_policy(SyncPolicy::OnClose),
+    )
+    .unwrap();
     let out = f(&file);
     drop(file);
     out

--- a/tests/append_writer_crosscheck.rs
+++ b/tests/append_writer_crosscheck.rs
@@ -13,7 +13,7 @@
 
 use hdf5::Extent;
 use hdf5::file::LibraryVersion;
-use hdf5_pure::{File, FileBuilder};
+use hdf5_pure::{File, FileAccessProperties, FileBuilder, SyncPolicy};
 use tempfile::tempdir;
 
 fn incompressible(seed: u32, n: usize) -> Vec<i32> {
@@ -79,8 +79,19 @@ fn writer_append(path: &std::path::Path, values: &[i32]) {
 }
 
 /// Append `values` one element per call in a single session.
+///
+/// `SyncPolicy::OnClose` because these tests assert what the file *contains*,
+/// not when it reached the platter, and the default `Always` costs one `fsync`
+/// per call — the dominant cost of a several-thousand-append loop, and nothing
+/// this test measures. The two policies write byte-identical files, which
+/// `tests/sync_policy.rs` asserts directly; `close` still issues the closing
+/// barrier, so the C library reads a fully published file either way.
 fn writer_append_each(path: &std::path::Path, values: &[i32]) {
-    let file = File::open_rw(path).unwrap();
+    let file = File::open_rw_with_options(
+        path,
+        FileAccessProperties::new().with_sync_policy(SyncPolicy::OnClose),
+    )
+    .unwrap();
     let mut ds = file.dataset("d").unwrap();
     for &v in values {
         ds.append(&[v]).unwrap();

--- a/tests/bounded_append.rs
+++ b/tests/bounded_append.rs
@@ -4,7 +4,7 @@
 
 use hdf5_pure::{
     AttrValue, Error, File, FileAccessProperties, FileBuilder, FileSpaceStrategy, MemoryStrategy,
-    MetadataCacheConfig,
+    MetadataCacheConfig, SyncPolicy,
 };
 use tempfile::tempdir;
 
@@ -14,10 +14,17 @@ use tempfile::tempdir;
 /// tests are *about* the bounded engine: asking for it explicitly means a file
 /// that stops being bounded-editable fails here instead of quietly retargeting
 /// the whole file at the mirror.
+///
+/// `SyncPolicy::OnClose` for the same reason the memory strategy is explicit:
+/// what these tests assert is content and batching behaviour, not durability,
+/// and the default `Always` costs one `fsync` per append. The policies write
+/// byte-identical files (`tests/sync_policy.rs`), and close still barriers.
 fn open_bounded(path: &std::path::Path) -> Result<File, Error> {
     File::open_rw_with_options(
         path,
-        FileAccessProperties::new().with_memory_strategy(MemoryStrategy::Bounded),
+        FileAccessProperties::new()
+            .with_memory_strategy(MemoryStrategy::Bounded)
+            .with_sync_policy(SyncPolicy::OnClose),
     )
 }
 


### PR DESCRIPTION
Acts on #269. The full gate (2,034 tests + 46 doctests) goes from **2m43s to 19.7s** on a 10-core host.

## One test was 5x the rest of the suite

`append_writer_crosscheck::streaming_many_appends_c_reads` appended 4,032 single elements under the default `SyncPolicy::Always`, forcing an `fsync` per call: **117.3s**. Nothing it asserts is about durability. Under `SyncPolicy::OnClose` it is **0.32s** — `close` still barriers, and byte identity across the two policies is already asserted by `tests/sync_policy.rs::on_close_writes_the_same_file_as_always`. Same change on the two other helpers that own a long append session.

Compilation was never the bottleneck: a warm rebuild of the library plus all ~110 test binaries is 6.7s (default) / 19.6s (`--all-features`), already at ~6x parallelism.

## nextest

`cargo test` runs the ~110 integration binaries one at a time, so the suite sat on ~1 core of 10. **46.1s → 17.9s** on identical tests (115% → 421% CPU).

- **nextest cannot run doctests**, so the gate is two commands and CI is two steps. Without the second, the job passes while 32 doctests (46 under `full`) stop running.
- **Cross-binary concurrency is new.** 225 tests write hardcoded names into the shared system temp dir instead of a `tempdir()`, previously serialized by binary. All 225 are distinct; `.config/nextest.toml` says so, because a duplicate would fail intermittently and mostly on Windows.
- That config warns at 30s and **fails at 90s** — the gate the 117s test slipped past, since `cargo test` reports no per-test timings. Verified non-vacuous by tightening the period against a known-1.1s test until the run failed with `TIMEOUT`.

## `debug = "line-tables-only"`

| | full debug | line-tables-only |
| --- | --- | --- |
| build this crate + tests | 25.0/28.9s | 16.6/16.8s |
| object files (1,357) | 590 MiB | 476 MiB |
| test binaries (130) | 1.35 GiB | 1.31 GiB |

The win is ~40% off the build, not the disk: Mach-O leaves DWARF in the object files and links only a debug map, so binaries barely shrink while the objects lose 19%. Backtraces keep function, file, and line. Costs one full dev-profile rebuild, libhdf5 included (53s here).

## Measured and not taken

**One merged test binary via `#[path]`.** Cargo already parallelizes the ~110 links to ~6x and the whole build is 20s. Merging trades that for a serial 43k-line compile, and costs `--test <name>` targeting plus makes one compile error take out all 110. Its real benefit — `deps/` object accumulation — the periodic `cargo clean -p` already handles.

**mold.** x86-64 Linux only; the dev host here is macOS. A committed `.cargo/config.toml` linker would also break contributors without `clang`+`mold`, so it belongs in a CI env var or `~/.cargo/config.toml`.

## Notes

No changelog entry or version bump: nothing touches the public API, and `[profile.dev]` does not reach downstream consumers.

Three smaller `fsync`-bound tests (~8s total) are left alone deliberately — they open sessions at ~20 inline call sites each and already sit below the non-`fsync` critical path (`c_absence_predicate`, `dense_attr_limits_crosscheck`, ~13s each).

Refs #269
