### PR TITLE
Derive a relocatable blob's length instead of building it twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Breaking:** `CompoundTypeBuilder::build` returns `Result<Datatype, FormatError>`, refusing a compound of no fields and one whose fields pack to zero bytes, the way `ExplicitCompoundTypeBuilder::build` already did ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).
 - **Breaking:** `FormatError::ShapeDataMismatch`'s `element_size` field is a `NonZeroUsize`, so the element counts its message reports are well defined by type rather than by convention ([#272](https://github.com/stephenberry/hdf5-pure/pull/272)).
 - `Dataset::append` accepts a filtered append of any length, where it required a whole number of chunks; the dataset's own length must still be chunk-aligned ([#262](https://github.com/stephenberry/hdf5-pure/issues/262)).
+- Writing a dense attribute heap, and appending to an unlimited chunked dataset, no longer build the structure a second time purely to measure it, so large attribute sets and high chunk counts cost less to write; creating a chunked dataset in place still measures its index that way ([#265](https://github.com/stephenberry/hdf5-pure/issues/265)).
 
 ### Fixed
 

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -1040,8 +1040,8 @@ pub(crate) fn aeib_size(
 }
 
 /// The six Extensible Array header statistics, in the C library's stored order.
-/// Used by the SWMR append writer (`std` only).
-#[cfg(feature = "std")]
+/// Read by the incremental append writer, and by [`ea_layout`], for which two of
+/// them add up to the array's body length.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct EaStats {
     pub nsuper_blks: u64,
@@ -1054,7 +1054,6 @@ pub(crate) struct EaStats {
 
 /// On-disk byte size of one non-paged Extensible Array data block (`EADB`)
 /// holding `dblk_nelmts` element slots.
-#[cfg(feature = "std")]
 pub(crate) fn eadb_size(
     dblk_nelmts: u64,
     elem_size: usize,
@@ -1079,7 +1078,6 @@ pub(crate) fn eadb_size(
 
 /// On-disk byte size of one Extensible Array super block (`EASB`) with `ndblks`
 /// data-block pointers and (when its data blocks are paged) a page-init bitmap.
-#[cfg(feature = "std")]
 pub(crate) fn aesb_size(
     ndblks: u64,
     dblk_nelmts: u64,
@@ -1110,7 +1108,10 @@ pub(crate) fn aesb_size(
 /// `num_elements` densely-filled elements. Mirrors the allocation performed by
 /// [`build_extensible_array_at`] so the bulk writer and the incremental append
 /// writer always agree (asserted by a unit test).
-#[cfg(feature = "std")]
+///
+/// The two size statistics are also what [`extensible_array_len`] reports, since
+/// the array's body is its allocated blocks and nothing else — so this walk
+/// decides a reservation as well as a set of header fields.
 pub(crate) fn ea_compute_stats(
     geom: &EaGeometry,
     idx_blk_elmts: u64,
@@ -1159,24 +1160,58 @@ pub(crate) fn ea_compute_stats(
     s
 }
 
-/// Build a complete Extensible Array at a known absolute address.
+/// Everything about an Extensible Array that does not depend on where it is
+/// placed: the element encoding, the block geometry, and every byte count.
 ///
-/// Lays out the header (`EAHD`), index block (`EAIB`), and — for datasets with
-/// more than `idx_blk_elmts + sum(direct data blocks)` chunks — the on-disk
-/// super blocks (`EASB`) and their data blocks (`EADB`, paged when large). The
-/// super-block / data-block size progression comes from the shared
-/// [`EaGeometry`], so the writer and reader cannot drift. Byte-for-byte
-/// compatible with the reference HDF5 C library across inline, direct, super
-/// block, and paged ranges (verified by crosscheck tests).
-pub fn build_extensible_array_at(
+/// [`build_extensible_array_at`] writes an array's bytes at a chosen base
+/// address, but no term of this layout is that address — each block's size, and
+/// so the array's total length, is the same for every base. That is what lets
+/// [`extensible_array_len`] answer the length without emitting the array.
+///
+/// The builder shares this layout's *geometry*, so no second derivation of the
+/// block sizes can drift from what is written. It does not share the walk that
+/// decides which of those blocks a given element count allocates: that is
+/// written once here (through [`ea_compute_stats`]) and once in the builder's
+/// own body. Those two are what the length assertion at the end of the builder,
+/// and `extensible_array_len_matches_what_it_builds`, hold together.
+struct EaLayout {
+    /// Byte size of one element record: an address, plus the compressed size and
+    /// filter mask when the dataset is filtered.
+    elem_size: usize,
+    /// Width of the compressed-size field inside a filtered element record, sized
+    /// to the largest raw chunk. Zero when the dataset is unfiltered.
+    chunk_size_bytes: usize,
+    client_id: u8,
+    /// EA creation parameters — these must match the HDF5 C library defaults
+    /// exactly, and are held here so the header writer and the size computation
+    /// read the same values.
+    max_nelmts_bits: u8,
+    idx_blk_elmts: u8,
+    min_dblk_nelmts: u8,
+    super_blk_min_nelmts: u8,
+    max_dblk_nelmts_bits: u8,
+    geom: EaGeometry,
+    page_nelmts: usize,
+    blk_off_size: usize,
+    /// Element slots held inline in the index block (`idx_blk_elmts`).
+    inline: usize,
+    aehd_size: usize,
+    aeib_size: usize,
+    /// The six header statistics, two of which (`data_blk_size` and
+    /// `super_blk_size`) are exactly the body's byte length.
+    stats: EaStats,
+    /// Header + index block + body: the whole array.
+    total_len: u64,
+}
+
+/// Lay out the Extensible Array that would hold `chunks`, without building it.
+fn ea_layout(
     chunks: &[WrittenChunk],
     offset_size: u8,
     length_size: u8,
     has_filters: bool,
-    ea_base_address: u64,
-) -> Result<Vec<u8>, FormatError> {
+) -> EaLayout {
     let os = offset_size as usize;
-    let num_elements = chunks.len();
 
     // Compute element encoding size (same logic as Fixed Array)
     let chunk_size_bytes: usize = if has_filters {
@@ -1230,11 +1265,101 @@ pub fn build_extensible_array_at(
     let inline = idx_blk_elmts as usize;
 
     let aehd_size = ExtensibleArrayHeader::serialized_size(offset_size, length_size);
-    let aeib_address = ea_base_address + aehd_size as u64;
+    let aeib_size = aeib_size(
+        offset_size,
+        inline,
+        elem_size,
+        geom.direct_dblk_nelmts.len(),
+        geom.nsblk_addrs,
+    );
 
-    let ndblk_addrs = geom.direct_dblk_nelmts.len();
-    let nsblk_addrs = geom.nsblk_addrs;
-    let aeib_size = aeib_size(offset_size, inline, elem_size, ndblk_addrs, nsblk_addrs);
+    // The body is the allocated data blocks and super blocks, concatenated with
+    // nothing between them, so the two size statistics are its byte length.
+    let stats = ea_compute_stats(
+        &geom,
+        idx_blk_elmts as u64,
+        elem_size,
+        page_nelmts as u64,
+        offset_size,
+        blk_off_size,
+        chunks.len() as u64,
+    );
+    let total_len = (aehd_size + aeib_size) as u64 + stats.data_blk_size + stats.super_blk_size;
+
+    EaLayout {
+        elem_size,
+        chunk_size_bytes,
+        client_id,
+        max_nelmts_bits,
+        idx_blk_elmts,
+        min_dblk_nelmts,
+        super_blk_min_nelmts,
+        max_dblk_nelmts_bits,
+        geom,
+        page_nelmts,
+        blk_off_size,
+        inline,
+        aehd_size,
+        aeib_size,
+        stats,
+        total_len,
+    }
+}
+
+/// The byte length [`build_extensible_array_at`] would produce for `chunks`,
+/// without building it.
+///
+/// A caller that has to reserve space for the array before it exists — the
+/// in-place editor placing one into freed space — needs the length first. It
+/// comes from the same [`EaLayout`] the builder emits from, so no second
+/// derivation of the block geometry can drift away from what is written.
+pub(crate) fn extensible_array_len(
+    chunks: &[WrittenChunk],
+    offset_size: u8,
+    length_size: u8,
+    has_filters: bool,
+) -> u64 {
+    ea_layout(chunks, offset_size, length_size, has_filters).total_len
+}
+
+/// Build a complete Extensible Array at a known absolute address.
+///
+/// Lays out the header (`EAHD`), index block (`EAIB`), and — for datasets with
+/// more than `idx_blk_elmts + sum(direct data blocks)` chunks — the on-disk
+/// super blocks (`EASB`) and their data blocks (`EADB`, paged when large). The
+/// super-block / data-block size progression comes from the shared
+/// [`EaGeometry`], so the writer and reader cannot drift. Byte-for-byte
+/// compatible with the reference HDF5 C library across inline, direct, super
+/// block, and paged ranges (verified by crosscheck tests).
+pub fn build_extensible_array_at(
+    chunks: &[WrittenChunk],
+    offset_size: u8,
+    length_size: u8,
+    has_filters: bool,
+    ea_base_address: u64,
+) -> Result<Vec<u8>, FormatError> {
+    let num_elements = chunks.len();
+
+    let layout = ea_layout(chunks, offset_size, length_size, has_filters);
+    let EaLayout {
+        elem_size,
+        chunk_size_bytes,
+        client_id,
+        max_nelmts_bits,
+        idx_blk_elmts,
+        min_dblk_nelmts,
+        super_blk_min_nelmts,
+        max_dblk_nelmts_bits,
+        ref geom,
+        page_nelmts,
+        blk_off_size,
+        inline,
+        aehd_size,
+        aeib_size,
+        ..
+    } = layout;
+
+    let aeib_address = ea_base_address + aehd_size as u64;
     let body_base = aeib_address + aeib_size as u64;
 
     let undef_addr: u64 = match offset_size {
@@ -1245,9 +1370,10 @@ pub fn build_extensible_array_at(
     // ---- Build the body (direct data blocks, then super blocks) -----------
     // Addresses are absolute, computed from `body_base`, so the body can be
     // built before the index block that references it.
-    let mut body: Vec<u8> = Vec::new();
-    let mut direct_addrs: Vec<u64> = Vec::with_capacity(ndblk_addrs);
-    let mut sblk_addrs: Vec<u64> = Vec::with_capacity(nsblk_addrs);
+    let mut body: Vec<u8> =
+        Vec::with_capacity((layout.stats.data_blk_size + layout.stats.super_blk_size).to_usize()?);
+    let mut direct_addrs: Vec<u64> = Vec::with_capacity(geom.direct_dblk_nelmts.len());
+    let mut sblk_addrs: Vec<u64> = Vec::with_capacity(geom.nsblk_addrs);
 
     // Stats (match the C library's EAHD fields exactly).
     let mut ndata_blks: u64 = 0;
@@ -1295,7 +1421,7 @@ pub fn build_extensible_array_at(
 
     // Super blocks: addresses stored in the index block; super-block pointer `j`
     // refers to super block `first_indirect_sblk + j`.
-    for j in 0..nsblk_addrs {
+    for j in 0..geom.nsblk_addrs {
         let sblk_idx = geom.first_indirect_sblk + j;
         // `ndblks` and `dblk_nelmts` are u64 element counts from the EA geometry.
         // Their product (this super block's element span) and the running cursor
@@ -1458,6 +1584,15 @@ pub fn build_extensible_array_at(
     let mut combined = aehd;
     combined.extend_from_slice(&aeib);
     combined.extend_from_slice(&body);
+    // The length `extensible_array_len` promises a caller reserving space for
+    // this array, checked against the bytes actually produced. A reservation
+    // that disagrees with the emission would place the next object on top of
+    // this one, so pin it where it is emitted as well as in a test.
+    debug_assert_eq!(
+        combined.len() as u64,
+        layout.total_len,
+        "an extensible array must fill the length its layout promised"
+    );
     Ok(combined)
 }
 
@@ -2719,6 +2854,98 @@ mod tests {
             let computed = super::ea_compute_stats(&geom, 4, 8, 1024, 8, 4, n);
             assert_eq!(computed, built, "stats mismatch at n={n}");
         }
+    }
+
+    /// `extensible_array_len` is the span the in-place editor reserves for an
+    /// array before a byte of it exists, so it has to equal the length
+    /// `build_extensible_array_at` goes on to emit. A reservation that came out
+    /// short would place the next object on top of the array.
+    ///
+    /// The small counts are swept *contiguously* rather than at hand-picked
+    /// boundaries: which blocks an element count allocates is decided twice over
+    /// — once by `ea_compute_stats`, which this length comes from, and once by
+    /// the builder's own body — and a contiguous sweep crosses every transition
+    /// between those two walks without anyone having to work out where the
+    /// transitions are. It covers the inline slots, all six direct data blocks,
+    /// and the first on-disk super block. The larger counts then reach the deeper
+    /// super blocks and, at 131,061, the first *paged* data block.
+    #[test]
+    fn extensible_array_len_matches_what_it_builds() {
+        fn check(n: u64, raw_size: u64, offset_size: u8, length_size: u8, has_filters: bool) {
+            let chunks: Vec<WrittenChunk> = (0..n)
+                .map(|i| WrittenChunk {
+                    address: 0x1000 + i * 8,
+                    compressed_size: 8,
+                    raw_size,
+                    filter_mask: 0,
+                })
+                .collect();
+            let planned = extensible_array_len(&chunks, offset_size, length_size, has_filters);
+            let built = build_extensible_array_at(
+                &chunks,
+                offset_size,
+                length_size,
+                has_filters,
+                0x10_0000,
+            )
+            .unwrap();
+            assert_eq!(
+                planned,
+                built.len() as u64,
+                "planned length must match the emitted array at n={n}, raw_size={raw_size}, \
+                 offset_size={offset_size}, has_filters={has_filters}"
+            );
+        }
+
+        for &(offset_size, length_size) in &[(8u8, 8u8), (4u8, 4u8)] {
+            for &has_filters in &[false, true] {
+                // Contiguous across the inline, direct-block and first
+                // super-block ranges.
+                for n in 0..=250u64 {
+                    check(n, 8, offset_size, length_size, has_filters);
+                }
+                // The deeper super blocks, and the paged boundary: 131,060 is the
+                // last element the unpaged super block 12 holds, 131,061 the first
+                // that allocates a paged data block.
+                for &n in &[300u64, 2_000, 50_000, 131_060, 131_061, 140_000] {
+                    check(n, 8, offset_size, length_size, has_filters);
+                }
+            }
+        }
+
+        // A filtered element record carries the chunk's compressed size in a field
+        // sized to the largest *raw* chunk, so the record width — and with it the
+        // index block and every data block — changes with that size.
+        const RAW_SIZES: [u64; 4] = [8, 300, 100_000, 1 << 32];
+        for &raw_size in &RAW_SIZES {
+            for &n in &[1u64, 5, 244, 300, 2_000] {
+                check(n, raw_size, 8, 8, true);
+            }
+        }
+        // Those four raw sizes have to select four *different* field widths, or
+        // the loop above is one fixture written four times. Asserted as
+        // distinctness rather than as four literals: the rule is that the width
+        // tracks the raw size, not that it takes any particular value.
+        let widths: Vec<usize> = RAW_SIZES
+            .iter()
+            .map(|&raw_size| {
+                let chunks = [WrittenChunk {
+                    address: 0,
+                    compressed_size: 8,
+                    raw_size,
+                    filter_mask: 0,
+                }];
+                super::ea_layout(&chunks, 8, 8, true).chunk_size_bytes
+            })
+            .collect();
+        let mut distinct = widths.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            distinct.len(),
+            RAW_SIZES.len(),
+            "each raw size must select a different compressed-size field width, got {widths:?}"
+        );
     }
 
     // ---- h5py round-trip tests for chunked writes ----

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -191,7 +191,8 @@ use crate::chunked_read::{
 use crate::chunked_write::{
     ChunkMeta, ChunkOptions, ChunkProvider, WrittenChunk, assemble_chunked_at,
     build_extensible_array_at, chunked_data_len, compress_chunks, emit_chunked_data_verbatim,
-    plan_chunked_data_verbatim, serialize_v4_extensible_array, split_into_chunks,
+    extensible_array_len, plan_chunked_data_verbatim, serialize_v4_extensible_array,
+    split_into_chunks,
 };
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
@@ -5640,15 +5641,14 @@ impl WriteEngine {
     /// blob for it, place it, and splice the matching Attribute Info message onto
     /// `region`. A no-op for an empty set.
     ///
-    /// The blob produced by [`file_writer::build_dense_attrs`] is fully
+    /// The blob produced by [`file_writer::DenseAttrPlan::build`] is fully
     /// relocatable: every address it embeds is `base + fixed offset`, and its
     /// length is the same for every base, so it can go into a freed metadata
     /// region as readily as at end-of-file — the base it is built for is whichever
-    /// address it gets. Sizing it costs a throwaway build at a provisional
-    /// address, which is bounded by the attribute set's own size. The freshly
-    /// built heap is always same-file, so it never aliases the source heap even
-    /// for an in-file copy. The caller has already validated
-    /// [`file_writer::dense_attrs_check`].
+    /// address it gets. The reservation comes from the plan the blob is then
+    /// built from, so sizing it costs no bytes. The freshly built heap is always
+    /// same-file, so it never aliases the source heap even for an in-file copy.
+    /// The caller has already validated [`file_writer::dense_attrs_check`].
     fn append_dense_attrs(
         &mut self,
         region: &mut Vec<u8>,
@@ -5657,10 +5657,10 @@ impl WriteEngine {
         if attrs.is_empty() {
             return Ok(());
         }
-        let len = crate::file_writer::build_dense_attrs(attrs, 0).blob.len() as u64;
+        let plan = crate::file_writer::dense_attrs_plan(attrs);
         let (_addr, attr_info_message) =
-            self.place_relocatable(len, PageType::Meta, |stored_base| {
-                let blob = crate::file_writer::build_dense_attrs(attrs, stored_base);
+            self.place_relocatable(plan.blob_len(), PageType::Meta, |stored_base| {
+                let blob = plan.build(stored_base);
                 Ok((blob.blob, blob.attr_info_message))
             })?;
         region.extend_from_slice(&region_message(
@@ -5818,16 +5818,15 @@ impl WriteEngine {
         // Build the fresh Extensible Array for wherever it is placed: its embedded
         // block addresses are computed from `ea_base` (base-relative), so they
         // resolve correctly on a userblock (`base != 0`) file too. Its length does
-        // not depend on that base, so a throwaway build at 0 sizes it.
+        // not depend on that base, so `extensible_array_len` gives the reservation
+        // from the array's layout without emitting a byte of it.
         //
         // The index goes in a *raw* page, not a metadata one: every other writer in
         // this crate places a chunk index in the same run as the chunk data, and
         // `chunked_storage_spans` reclaims every index as raw on that basis. Placing
         // this one in a metadata page would make it the single exception the reclaim
         // side then mis-files, advertising a metadata hole inside a raw page.
-        let ea_len = build_extensible_array_at(&combined, OFFSET_SIZE, LENGTH_SIZE, has_filters, 0)
-            .map_err(Error::Format)?
-            .len() as u64;
+        let ea_len = extensible_array_len(&combined, OFFSET_SIZE, LENGTH_SIZE, has_filters);
         let (ea_addr, ()) = self.place_relocatable(ea_len, PageType::Raw, |ea_base| {
             let bytes = build_extensible_array_at(
                 &combined,
@@ -6002,8 +6001,16 @@ impl WriteEngine {
     /// `len` must be the length `build` will produce; [`place`](Self::place)
     /// rejects a mismatch. For every blob placed this way the length is a function
     /// of the content alone — the addresses sit in fixed-width fields — so it can
-    /// be planned (or measured from a build at a provisional address) before the
-    /// real one is known.
+    /// be derived before the real address is known.
+    ///
+    /// Two callers derive it ([`DenseAttrPlan::blob_len`](crate::file_writer::DenseAttrPlan::blob_len)
+    /// and [`extensible_array_len`]). The two that lay out a whole chunked data
+    /// region still measure it by building the chunk *index* at a provisional
+    /// base and discarding it — `chunked_data_len` and the sizing call to
+    /// `plan_chunked_data_verbatim`. Neither materializes the chunk data, which
+    /// is the bulk of the region, but both build the index twice; finishing that
+    /// needs a length for the Fixed Array as well (issue #265 covered the other
+    /// two).
     fn place_relocatable<T>(
         &mut self,
         len: u64,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -6009,8 +6009,7 @@ impl WriteEngine {
     /// base and discarding it — `chunked_data_len` and the sizing call to
     /// `plan_chunked_data_verbatim`. Neither materializes the chunk data, which
     /// is the bulk of the region, but both build the index twice; finishing that
-    /// needs a length for the Fixed Array as well (issue #265 covered the other
-    /// two).
+    /// needs a length for the Fixed Array as well, tracked in issue #275.
     fn place_relocatable<T>(
         &mut self,
         len: u64,

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -81,7 +81,7 @@ pub(crate) fn build_chunked_dataset_oh(
     layout_message: &[u8],
     pipeline_message: Option<&[u8]>,
     attrs: &[AttributeMessage],
-    dense_blob: Option<&DenseAttrBlob>,
+    attr_info: Option<&[u8]>,
     fill: Option<&[u8]>,
 ) -> Result<Vec<u8>, FormatError> {
     let mut w = ObjectHeaderWriter::new();
@@ -96,7 +96,7 @@ pub(crate) fn build_chunked_dataset_oh(
     if let Some(pm) = pipeline_message {
         w.add_message(MessageType::FilterPipeline, pm.to_vec());
     }
-    add_attributes(&mut w, attrs, dense_blob);
+    add_attributes(&mut w, attrs, attr_info);
     w.serialize()
 }
 
@@ -130,7 +130,7 @@ pub(crate) fn build_dataset_oh(
     data_addr: u64,
     data_size: u64,
     attrs: &[AttributeMessage],
-    dense_blob: Option<&DenseAttrBlob>,
+    attr_info: Option<&[u8]>,
     fill: Option<&[u8]>,
     libver: LibVer,
 ) -> Result<Vec<u8>, FormatError> {
@@ -148,7 +148,7 @@ pub(crate) fn build_dataset_oh(
     dl.extend_from_slice(&data_addr.to_le_bytes());
     dl.extend_from_slice(&data_size.to_le_bytes());
     w.add_message(MessageType::DataLayout, dl);
-    add_attributes(&mut w, attrs, dense_blob);
+    add_attributes(&mut w, attrs, attr_info);
     w.serialize()
 }
 
@@ -211,7 +211,7 @@ pub(crate) fn build_committed_datatype_oh(
 pub(crate) fn build_group_oh(
     links: &[LinkMessage],
     attrs: &[AttributeMessage],
-    dense_blob: Option<&DenseAttrBlob>,
+    attr_info: Option<&[u8]>,
 ) -> Result<Vec<u8>, FormatError> {
     let mut w = ObjectHeaderWriter::new();
     let mut li = Vec::new();
@@ -230,21 +230,26 @@ pub(crate) fn build_group_oh(
     for link in links {
         w.add_message(MessageType::Link, link.serialize(OFFSET_SIZE));
     }
-    add_attributes(&mut w, attrs, dense_blob);
+    add_attributes(&mut w, attrs, attr_info);
     w.serialize()
 }
 
 /// Add an object's attribute storage to its header: either the Attribute Info
-/// message naming a pre-built fractal heap, or the inline Attribute messages
-/// preceded by the compact-storage Attribute Info message that lets the
-/// reference library count them (see [`compact_attribute_info_message`]).
+/// message naming a dense (fractal-heap) attribute store, or the inline
+/// Attribute messages preceded by the compact-storage Attribute Info message
+/// that lets the reference library count them (see
+/// [`compact_attribute_info_message`]).
+///
+/// The dense case takes the Attribute Info message rather than the heap itself
+/// because that message is all a header needs. A sizing pass can therefore get
+/// its header size from a [`DenseAttrPlan`] without the heap's bytes existing.
 fn add_attributes(
     w: &mut ObjectHeaderWriter,
     attrs: &[AttributeMessage],
-    dense_blob: Option<&DenseAttrBlob>,
+    attr_info: Option<&[u8]>,
 ) {
-    if let Some(blob) = dense_blob {
-        w.add_message(MessageType::AttributeInfo, blob.attr_info_message.clone());
+    if let Some(message) = attr_info {
+        w.add_message(MessageType::AttributeInfo, message.to_vec());
     } else {
         if !attrs.is_empty() {
             w.add_message(MessageType::AttributeInfo, compact_attribute_info_message());
@@ -408,7 +413,39 @@ pub(crate) fn dense_attrs_check(attrs: &[AttributeMessage]) -> Result<(), Format
     }
 }
 
-/// Build dense attribute storage for a set of attributes.
+/// Everything about a set of attributes' dense storage that does not depend on
+/// where the heap is placed: the serialized attribute messages, the fractal
+/// heap's doubling-table layout, both B-tree v2 layouts, and the blob's length.
+///
+/// [`DenseAttrPlan::build`] emits the blob at a chosen base address, but no term
+/// of this plan is that address — the length is the same for every base. That is
+/// what lets a caller reserve the span before the bytes exist
+/// ([`DenseAttrPlan::blob_len`]), and take that length from the very computation
+/// the emission then works from rather than from a whole throwaway build.
+pub(crate) struct DenseAttrPlan {
+    /// Each attribute's version 3 message bytes, in the caller's order.
+    serialized: Vec<Vec<u8>>,
+    /// Huge-object ID for each attribute whose bytes go outside the managed
+    /// blocks; `None` for a managed one.
+    huge_id_of: Vec<Option<u64>>,
+    huge_count: usize,
+    huge_total: u64,
+    managed_plan: ManagedPlan,
+    name_plan: BTreeV2Plan,
+    huge_plan: Option<BTreeV2Plan>,
+    /// `(name hash, attribute index)` in the order the name index is searched.
+    order: Vec<(u32, u32)>,
+    /// Where each part of the blob starts, relative to its base address.
+    managed_off: u64,
+    btree_off: u64,
+    name_nodes_off: u64,
+    huge_bthd_off: u64,
+    huge_nodes_off: u64,
+    huge_data_off: u64,
+    total_len: u64,
+}
+
+/// Lay out dense attribute storage for a set of attributes, without building it.
 ///
 /// Attributes that fit [`DENSE_ATTR_MAX_MANAGED_OBJECT`] are stored as managed
 /// objects in the heap's direct blocks; larger ones are stored as *huge*
@@ -418,7 +455,7 @@ pub(crate) fn dense_attrs_check(attrs: &[AttributeMessage]) -> Result<(), Format
 /// The caller must have checked [`dense_attrs_check`] first: an attribute set
 /// past the heap's own address space cannot be laid out, and this emitter has
 /// nowhere left to put it.
-pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -> DenseAttrBlob {
+pub(crate) fn dense_attrs_plan(attrs: &[AttributeMessage]) -> DenseAttrPlan {
     // Dense attrs use v3 attribute messages (adds character set encoding byte).
     let serialized: Vec<Vec<u8>> = attrs.iter().map(|a| a.serialize_v3(LENGTH_SIZE)).collect();
 
@@ -448,57 +485,25 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
         .map(|(s, _)| s.len() as u64)
         .sum();
 
-    let os = OFFSET_SIZE as usize;
-    let ls = LENGTH_SIZE as usize;
-    let max_heap_size: u16 = DENSE_ATTR_MAX_HEAP_SIZE_BITS;
-    let block_offset_bytes = DENSE_ATTR_BLOCK_OFFSET_BYTES; // 5
-    let heap_id_length: u16 = 8;
-
     // Only managed objects occupy the doubling table, so only they are planned
-    // into it. `managed` holds their bytes in attribute order, and the plan's
-    // object indices are indices into it.
-    let managed: Vec<&[u8]> = serialized
+    // into it. `managed_sizes` holds their sizes in attribute order, and the
+    // plan's object indices are indices into that order.
+    let managed_sizes: Vec<u64> = serialized
         .iter()
         .zip(&huge_id_of)
         .filter(|(_, id)| id.is_none())
-        .map(|(s, _)| s.as_slice())
+        .map(|(s, _)| s.len() as u64)
         .collect();
-    let managed_sizes: Vec<u64> = managed.iter().map(|s| s.len() as u64).collect();
     let managed_plan = ManagedPlan::new(&managed_sizes, OFFSET_SIZE)
         .expect("dense_attrs_check, which every caller must run first, plans the same layout");
-
-    // Fractal heap header size
-    let frhp_size = 4
-        + 1
-        + 2
-        + 2
-        + 1
-        + 4
-        + ls
-        + os
-        + ls
-        + os
-        + ls
-        + ls
-        + ls
-        + ls
-        + ls
-        + ls
-        + ls
-        + ls
-        + 2
-        + ls
-        + ls
-        + 2
-        + 2
-        + os
-        + 2
-        + 4;
 
     // Every v2 B-tree header this emitter writes has the same fixed layout, so
     // one size covers both the name index and the huge-objects index.
     let bthd_size = btree_v2_write::header_size(OFFSET_SIZE, LENGTH_SIZE);
-    debug_assert_eq!(bthd_size, 4 + 1 + 1 + 4 + 2 + 2 + 1 + 1 + os + 2 + ls + 4);
+    debug_assert_eq!(
+        bthd_size,
+        4 + 1 + 1 + 4 + 2 + 2 + 1 + 1 + OFFSET_SIZE as usize + 2 + LENGTH_SIZE as usize + 4
+    );
 
     // Both indexes are planned before anything is placed, because their node
     // counts decide where everything after them goes. The node and record sizes
@@ -524,135 +529,32 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
         .expect("a 512-byte node holds 20 huge records, enough to plan any count")
     });
 
-    // Blob layout, all relative to `base_address` so the caller can size the blob
-    // with a throwaway build at address 0 and get the same bytes back at the real
-    // address: heap header, the managed blocks, name index (header + nodes),
-    // then — only when there are huge objects — the huge index (header + nodes)
-    // and the huge object bytes themselves.
-    let frhp_addr = base_address;
-    let managed_addr = frhp_addr + frhp_size as u64;
-    let btree_addr = managed_addr + managed_plan.region_size();
-    let name_nodes_addr = btree_addr + bthd_size as u64;
-    let huge_bthd_addr = name_nodes_addr + name_plan.nodes_size();
-    let huge_nodes_addr = huge_bthd_addr + bthd_size as u64;
-    let huge_data_addr = huge_nodes_addr + huge_plan.as_ref().map_or(0, BTreeV2Plan::nodes_size);
-
-    // The reference C library does not read a heap ID's length field at a fixed
-    // width: it derives that width from the heap's declared maximum managed
-    // object size, then decodes `1 + offset_bytes + length_bytes` from the ID. If
-    // that total ever exceeded `heap_id_length` it would read past the ID stored
-    // in each B-tree record. Keeping the declared maximum pinned to
-    // DENSE_ATTR_MAX_MANAGED_OBJECT is what holds the two in agreement, so assert
-    // it here rather than leaving it to the constant's doc comment.
-    debug_assert_eq!(
-        1 + block_offset_bytes + encoded_size_width(DENSE_ATTR_MAX_MANAGED_OBJECT as u64),
-        heap_id_length as usize,
-        "managed heap ID width must match what the declared maximum managed object size implies"
-    );
-
-    // Build fractal heap header
-    let mut frhp = Vec::with_capacity(frhp_size);
-    frhp.extend_from_slice(b"FRHP");
-    frhp.push(0); // version
-    frhp.extend_from_slice(&heap_id_length.to_le_bytes());
-    frhp.extend_from_slice(&0u16.to_le_bytes()); // io_filter_encoded_length
-    frhp.push(0x02); // flags: bit 1 = checksum direct blocks
-    // Deliberately a constant rather than a function of `max_direct_block_size`:
-    // this is the per-object cap the 2-byte length field of an 8-byte managed
-    // heap ID can encode, so it must not grow with the block. `dense_attrs_check`
-    // bounds every attribute by the same constant.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "DENSE_ATTR_MAX_MANAGED_OBJECT is 65,514, well inside the 4-byte \
-                  max-managed-object-size field"
-    )]
-    let max_managed = DENSE_ATTR_MAX_MANAGED_OBJECT as u32;
-    frhp.extend_from_slice(&max_managed.to_le_bytes());
-    write_length(&mut frhp, huge_count as u64, LENGTH_SIZE); // next_huge_object_id
-    if huge_count == 0 {
-        write_undef_offset(&mut frhp, OFFSET_SIZE); // btree_huge_objects_address
+    // Blob layout, all relative to the base address the blob is built for, so
+    // its length is the same for every base: heap header, the managed blocks,
+    // name index (header + nodes), then — only when there are huge objects — the
+    // huge index (header + nodes) and the huge object bytes themselves.
+    let managed_off = DENSE_ATTR_FRHP_SIZE as u64;
+    let btree_off = managed_off + managed_plan.region_size();
+    let name_nodes_off = btree_off + bthd_size as u64;
+    let huge_bthd_off = name_nodes_off + name_plan.nodes_size();
+    let huge_nodes_off = huge_bthd_off + bthd_size as u64;
+    let huge_data_off = huge_nodes_off + huge_plan.as_ref().map_or(0, BTreeV2Plan::nodes_size);
+    // With no huge objects the blob ends where the huge index would have begun;
+    // with them it ends past their bytes.
+    let total_len = if huge_count > 0 {
+        huge_data_off + huge_total
     } else {
-        write_offset(&mut frhp, huge_bthd_addr, OFFSET_SIZE);
-    }
-    write_length(&mut frhp, managed_plan.free_space(), LENGTH_SIZE); // free_space_managed_blocks
-    write_undef_offset(&mut frhp, OFFSET_SIZE); // free_space_mgr_addr
-    write_length(&mut frhp, managed_plan.managed_space(), LENGTH_SIZE); // managed_space_in_heap
-    write_length(&mut frhp, managed_plan.allocated_space(), LENGTH_SIZE); // allocated_managed_space
-    write_length(&mut frhp, managed_plan.allocation_iterator(), LENGTH_SIZE); // dblock_alloc_iter
-    // Managed and huge objects are counted separately; an attribute is in exactly
-    // one of the two.
-    let managed_count = (attrs.len() - huge_count) as u64;
-    write_length(&mut frhp, managed_count, LENGTH_SIZE); // managed_objects_count
-    write_length(&mut frhp, huge_total, LENGTH_SIZE); // huge_objects_size
-    write_length(&mut frhp, huge_count as u64, LENGTH_SIZE); // huge_objects_count
-    write_length(&mut frhp, 0, LENGTH_SIZE); // tiny_objects_size
-    write_length(&mut frhp, 0, LENGTH_SIZE); // tiny_objects_count
-    frhp.extend_from_slice(&fractal_heap_write::TABLE_WIDTH.to_le_bytes()); // table_width
-    write_length(
-        &mut frhp,
-        fractal_heap_write::STARTING_BLOCK_SIZE,
-        LENGTH_SIZE,
-    );
-    write_length(
-        &mut frhp,
-        fractal_heap_write::MAX_DIRECT_BLOCK_SIZE,
-        LENGTH_SIZE,
-    ); // max_direct_block_size
-    frhp.extend_from_slice(&max_heap_size.to_le_bytes());
-    frhp.extend_from_slice(&fractal_heap_write::START_ROOT_ROWS.to_le_bytes()); // start_root_rows
-    write_offset(
-        &mut frhp,
-        managed_plan.root_address(managed_addr),
-        OFFSET_SIZE,
-    );
-    // Zero when the root is a direct block, which is how a reader tells which of
-    // the two the address above points at.
-    frhp.extend_from_slice(&managed_plan.root_rows().to_le_bytes());
-    let frhp_checksum = crate::checksum::jenkins_lookup3(&frhp);
-    frhp.extend_from_slice(&frhp_checksum.to_le_bytes());
-    debug_assert_eq!(frhp.len(), frhp_size);
+        huge_bthd_off
+    };
 
-    // Heap IDs. A managed object's carries the offset the plan gave it; a huge
-    // object's carries a B-tree key instead, since its bytes sit outside the
-    // managed blocks entirely.
-    let mut heap_ids: Vec<Vec<u8>> = Vec::with_capacity(attrs.len());
-    // (huge object ID, address, length) for the huge-objects B-tree, in ID order.
-    let mut huge_records: Vec<(u64, u64, u64)> = Vec::with_capacity(huge_count);
-    let mut next_huge_addr = huge_data_addr;
-    let mut next_managed = 0usize;
-    for (s, huge_id) in serialized.iter().zip(&huge_id_of) {
-        match huge_id {
-            Some(id) => {
-                huge_records.push((*id, next_huge_addr, s.len() as u64));
-                next_huge_addr += s.len() as u64;
-                heap_ids.push(encode_huge_id(*id, heap_id_length));
-            }
-            None => {
-                heap_ids.push(encode_managed_id(
-                    managed_plan.heap_offset(next_managed),
-                    s.len() as u64,
-                    max_heap_size,
-                    heap_id_length,
-                ));
-                next_managed += 1;
-            }
-        }
-    }
-    debug_assert_eq!(next_managed, managed.len());
-
-    let managed_blocks = managed_plan.serialize(&managed, managed_addr, frhp_addr);
-    debug_assert_eq!(managed_blocks.len() as u64, managed_plan.region_size());
-
-    // Build B-tree v2 type 8 records (17 bytes each), sorted into the order the
-    // index is searched in: by name hash, and by the name itself where two names
-    // hash alike. The tie-break has to be the name because that is what the
-    // reference C library compares on a hash collision — `H5A__dense_fh_name_cmp`
-    // does `strcmp` against the name pulled back out of the heap — and a binary
-    // search ordered any other way walks away from a colliding record. Rust's
-    // `str` ordering is byte-wise over unsigned bytes, which is what `strcmp`
-    // specifies, so the two agree for non-ASCII names as well.
-    let record_size: u16 = heap_id_length + 1 + 4 + 4;
-    debug_assert_eq!(record_size, DENSE_ATTR_BTREE_RECORD);
+    // Records are ordered the way the index is searched: by name hash, and by
+    // the name itself where two names hash alike. The tie-break has to be the
+    // name because that is what the reference C library compares on a hash
+    // collision — `H5A__dense_fh_name_cmp` does `strcmp` against the name pulled
+    // back out of the heap — and a binary search ordered any other way walks
+    // away from a colliding record. Rust's `str` ordering is byte-wise over
+    // unsigned bytes, which is what `strcmp` specifies, so the two agree for
+    // non-ASCII names as well.
     #[expect(
         clippy::cast_possible_truncation,
         reason = "i is an attribute index bounded by the attribute count, far below u32::MAX"
@@ -665,54 +567,284 @@ pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -
             .then_with(|| attrs[a.1 as usize].name.cmp(&attrs[b.1 as usize].name))
     });
 
-    let mut name_records = Vec::with_capacity(attrs.len() * record_size as usize);
-    for &(hash, i) in &order {
-        name_records.extend_from_slice(&heap_ids[i as usize]);
-        name_records.push(0); // msg_flags
-        name_records.extend_from_slice(&i.to_le_bytes()); // creation_order
-        name_records.extend_from_slice(&hash.to_le_bytes()); // hash
+    DenseAttrPlan {
+        serialized,
+        huge_id_of,
+        huge_count,
+        huge_total,
+        managed_plan,
+        name_plan,
+        huge_plan,
+        order,
+        managed_off,
+        btree_off,
+        name_nodes_off,
+        huge_bthd_off,
+        huge_nodes_off,
+        huge_data_off,
+        total_len,
+    }
+}
+
+/// On-disk byte size of the fractal heap header this emitter writes.
+const DENSE_ATTR_FRHP_SIZE: usize = {
+    let os = OFFSET_SIZE as usize;
+    let ls = LENGTH_SIZE as usize;
+    4 + 1
+        + 2
+        + 2
+        + 1
+        + 4
+        + ls
+        + os
+        + ls
+        + os
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + ls
+        + 2
+        + ls
+        + ls
+        + 2
+        + 2
+        + os
+        + 2
+        + 4
+};
+
+impl DenseAttrPlan {
+    /// Byte length of the blob [`DenseAttrPlan::build`] produces, at any base
+    /// address.
+    pub(crate) fn blob_len(&self) -> u64 {
+        self.total_len
     }
 
-    let bthd_addr = btree_addr;
-    let name_tree = name_plan.serialize(&name_records, name_nodes_addr, OFFSET_SIZE, LENGTH_SIZE);
+    /// The Attribute Info (0x0015) message naming this heap once it is placed at
+    /// `base_address`. Its length does not depend on the address, so an
+    /// object-header sizing pass can take it from a provisional base.
+    pub(crate) fn attr_info_message(&self, base_address: u64) -> Vec<u8> {
+        serialize_attribute_info(base_address, base_address + self.btree_off)
+    }
 
-    let mut blob =
-        Vec::with_capacity(frhp.len() + managed_blocks.len() + bthd_size + name_tree.nodes.len());
-    blob.extend_from_slice(&frhp);
-    blob.extend_from_slice(&managed_blocks);
-    debug_assert_eq!(blob.len() as u64, bthd_addr - base_address);
-    blob.extend_from_slice(&name_tree.header);
-    blob.extend_from_slice(&name_tree.nodes);
+    /// Emit the blob for a heap placed at `base_address`.
+    pub(crate) fn build(&self, base_address: u64) -> DenseAttrBlob {
+        let max_heap_size: u16 = DENSE_ATTR_MAX_HEAP_SIZE_BITS;
+        let block_offset_bytes = DENSE_ATTR_BLOCK_OFFSET_BYTES; // 5
+        let heap_id_length: u16 = 8;
 
-    if let Some(huge_plan) = &huge_plan {
-        // Records are already in ascending ID order, which is the order the
-        // B-tree is searched in.
-        let mut huge_bytes =
-            Vec::with_capacity(huge_records.len() * DENSE_ATTR_HUGE_BTREE_RECORD as usize);
-        for (id, addr, len) in &huge_records {
-            write_offset(&mut huge_bytes, *addr, OFFSET_SIZE);
-            write_length(&mut huge_bytes, *len, LENGTH_SIZE);
-            write_length(&mut huge_bytes, *id, LENGTH_SIZE);
+        let Self {
+            serialized,
+            huge_id_of,
+            huge_count,
+            huge_total,
+            managed_plan,
+            name_plan,
+            huge_plan,
+            order,
+            ..
+        } = self;
+        let huge_count = *huge_count;
+
+        // Every address the blob embeds is `base_address + <plan offset>`, which
+        // is what makes the bytes relocatable: the same plan emits the same
+        // length at any base.
+        let frhp_addr = base_address;
+        let managed_addr = base_address + self.managed_off;
+        let btree_addr = base_address + self.btree_off;
+        let name_nodes_addr = base_address + self.name_nodes_off;
+        let huge_bthd_addr = base_address + self.huge_bthd_off;
+        let huge_nodes_addr = base_address + self.huge_nodes_off;
+        let huge_data_addr = base_address + self.huge_data_off;
+
+        // The reference C library does not read a heap ID's length field at a fixed
+        // width: it derives that width from the heap's declared maximum managed
+        // object size, then decodes `1 + offset_bytes + length_bytes` from the ID. If
+        // that total ever exceeded `heap_id_length` it would read past the ID stored
+        // in each B-tree record. Keeping the declared maximum pinned to
+        // DENSE_ATTR_MAX_MANAGED_OBJECT is what holds the two in agreement, so assert
+        // it here rather than leaving it to the constant's doc comment.
+        debug_assert_eq!(
+            1 + block_offset_bytes + encoded_size_width(DENSE_ATTR_MAX_MANAGED_OBJECT as u64),
+            heap_id_length as usize,
+            "managed heap ID width must match what the declared maximum managed object size implies"
+        );
+
+        // Build fractal heap header
+        let mut frhp = Vec::with_capacity(DENSE_ATTR_FRHP_SIZE);
+        frhp.extend_from_slice(b"FRHP");
+        frhp.push(0); // version
+        frhp.extend_from_slice(&heap_id_length.to_le_bytes());
+        frhp.extend_from_slice(&0u16.to_le_bytes()); // io_filter_encoded_length
+        frhp.push(0x02); // flags: bit 1 = checksum direct blocks
+        // Deliberately a constant rather than a function of `max_direct_block_size`:
+        // this is the per-object cap the 2-byte length field of an 8-byte managed
+        // heap ID can encode, so it must not grow with the block. `dense_attrs_check`
+        // bounds every attribute by the same constant.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "DENSE_ATTR_MAX_MANAGED_OBJECT is 65,514, well inside the 4-byte \
+                      max-managed-object-size field"
+        )]
+        let max_managed = DENSE_ATTR_MAX_MANAGED_OBJECT as u32;
+        frhp.extend_from_slice(&max_managed.to_le_bytes());
+        write_length(&mut frhp, huge_count as u64, LENGTH_SIZE); // next_huge_object_id
+        if huge_count == 0 {
+            write_undef_offset(&mut frhp, OFFSET_SIZE); // btree_huge_objects_address
+        } else {
+            write_offset(&mut frhp, huge_bthd_addr, OFFSET_SIZE);
         }
-        let huge_tree = huge_plan.serialize(&huge_bytes, huge_nodes_addr, OFFSET_SIZE, LENGTH_SIZE);
+        write_length(&mut frhp, managed_plan.free_space(), LENGTH_SIZE); // free_space_managed_blocks
+        write_undef_offset(&mut frhp, OFFSET_SIZE); // free_space_mgr_addr
+        write_length(&mut frhp, managed_plan.managed_space(), LENGTH_SIZE); // managed_space_in_heap
+        write_length(&mut frhp, managed_plan.allocated_space(), LENGTH_SIZE); // allocated_managed_space
+        write_length(&mut frhp, managed_plan.allocation_iterator(), LENGTH_SIZE); // dblock_alloc_iter
+        // Managed and huge objects are counted separately; an attribute is in exactly
+        // one of the two.
+        let managed_count = (serialized.len() - huge_count) as u64;
+        write_length(&mut frhp, managed_count, LENGTH_SIZE); // managed_objects_count
+        write_length(&mut frhp, *huge_total, LENGTH_SIZE); // huge_objects_size
+        write_length(&mut frhp, huge_count as u64, LENGTH_SIZE); // huge_objects_count
+        write_length(&mut frhp, 0, LENGTH_SIZE); // tiny_objects_size
+        write_length(&mut frhp, 0, LENGTH_SIZE); // tiny_objects_count
+        frhp.extend_from_slice(&fractal_heap_write::TABLE_WIDTH.to_le_bytes()); // table_width
+        write_length(
+            &mut frhp,
+            fractal_heap_write::STARTING_BLOCK_SIZE,
+            LENGTH_SIZE,
+        );
+        write_length(
+            &mut frhp,
+            fractal_heap_write::MAX_DIRECT_BLOCK_SIZE,
+            LENGTH_SIZE,
+        ); // max_direct_block_size
+        frhp.extend_from_slice(&max_heap_size.to_le_bytes());
+        frhp.extend_from_slice(&fractal_heap_write::START_ROOT_ROWS.to_le_bytes()); // start_root_rows
+        write_offset(
+            &mut frhp,
+            managed_plan.root_address(managed_addr),
+            OFFSET_SIZE,
+        );
+        // Zero when the root is a direct block, which is how a reader tells which of
+        // the two the address above points at.
+        frhp.extend_from_slice(&managed_plan.root_rows().to_le_bytes());
+        let frhp_checksum = crate::checksum::jenkins_lookup3(&frhp);
+        frhp.extend_from_slice(&frhp_checksum.to_le_bytes());
+        debug_assert_eq!(frhp.len(), DENSE_ATTR_FRHP_SIZE);
 
-        debug_assert_eq!(blob.len() as u64, huge_bthd_addr - base_address);
-        blob.extend_from_slice(&huge_tree.header);
-        blob.extend_from_slice(&huge_tree.nodes);
-        debug_assert_eq!(blob.len() as u64, huge_data_addr - base_address);
-        for (s, huge_id) in serialized.iter().zip(&huge_id_of) {
-            if huge_id.is_some() {
-                blob.extend_from_slice(s);
+        // Heap IDs. A managed object's carries the offset the plan gave it; a huge
+        // object's carries a B-tree key instead, since its bytes sit outside the
+        // managed blocks entirely.
+        let mut heap_ids: Vec<Vec<u8>> = Vec::with_capacity(serialized.len());
+        // (huge object ID, address, length) for the huge-objects B-tree, in ID order.
+        let mut huge_records: Vec<(u64, u64, u64)> = Vec::with_capacity(huge_count);
+        // The managed objects' bytes in attribute order, which is the order the
+        // plan assigned their heap offsets in.
+        let mut managed: Vec<&[u8]> = Vec::with_capacity(serialized.len() - huge_count);
+        let mut next_huge_addr = huge_data_addr;
+        for (s, huge_id) in serialized.iter().zip(huge_id_of) {
+            match huge_id {
+                Some(id) => {
+                    huge_records.push((*id, next_huge_addr, s.len() as u64));
+                    next_huge_addr += s.len() as u64;
+                    heap_ids.push(encode_huge_id(*id, heap_id_length));
+                }
+                None => {
+                    heap_ids.push(encode_managed_id(
+                        managed_plan.heap_offset(managed.len()),
+                        s.len() as u64,
+                        max_heap_size,
+                        heap_id_length,
+                    ));
+                    managed.push(s.as_slice());
+                }
             }
         }
-    }
 
-    let attr_info = serialize_attribute_info(frhp_addr, bthd_addr);
+        let managed_blocks = managed_plan.serialize(&managed, managed_addr, frhp_addr);
+        debug_assert_eq!(managed_blocks.len() as u64, managed_plan.region_size());
 
-    DenseAttrBlob {
-        attr_info_message: attr_info,
-        blob,
+        // Build B-tree v2 type 8 records (17 bytes each), in the order the plan
+        // sorted them into — the order the index is searched in.
+        let record_size: u16 = heap_id_length + 1 + 4 + 4;
+        debug_assert_eq!(record_size, DENSE_ATTR_BTREE_RECORD);
+        let mut name_records = Vec::with_capacity(serialized.len() * record_size as usize);
+        for &(hash, i) in order {
+            name_records.extend_from_slice(&heap_ids[i as usize]);
+            name_records.push(0); // msg_flags
+            name_records.extend_from_slice(&i.to_le_bytes()); // creation_order
+            name_records.extend_from_slice(&hash.to_le_bytes()); // hash
+        }
+
+        let bthd_addr = btree_addr;
+        let name_tree =
+            name_plan.serialize(&name_records, name_nodes_addr, OFFSET_SIZE, LENGTH_SIZE);
+
+        let mut blob = Vec::with_capacity(self.total_len.to_usize().unwrap_or(0));
+        blob.extend_from_slice(&frhp);
+        blob.extend_from_slice(&managed_blocks);
+        debug_assert_eq!(blob.len() as u64, bthd_addr - base_address);
+        blob.extend_from_slice(&name_tree.header);
+        blob.extend_from_slice(&name_tree.nodes);
+
+        if let Some(huge_plan) = huge_plan {
+            // Records are already in ascending ID order, which is the order the
+            // B-tree is searched in.
+            let mut huge_bytes =
+                Vec::with_capacity(huge_records.len() * DENSE_ATTR_HUGE_BTREE_RECORD as usize);
+            for (id, addr, len) in &huge_records {
+                write_offset(&mut huge_bytes, *addr, OFFSET_SIZE);
+                write_length(&mut huge_bytes, *len, LENGTH_SIZE);
+                write_length(&mut huge_bytes, *id, LENGTH_SIZE);
+            }
+            let huge_tree =
+                huge_plan.serialize(&huge_bytes, huge_nodes_addr, OFFSET_SIZE, LENGTH_SIZE);
+
+            debug_assert_eq!(blob.len() as u64, huge_bthd_addr - base_address);
+            blob.extend_from_slice(&huge_tree.header);
+            blob.extend_from_slice(&huge_tree.nodes);
+            debug_assert_eq!(blob.len() as u64, huge_data_addr - base_address);
+            for (s, huge_id) in serialized.iter().zip(huge_id_of) {
+                if huge_id.is_some() {
+                    blob.extend_from_slice(s);
+                }
+            }
+        }
+
+        // The length `blob_len` promises a caller reserving a span for this heap,
+        // checked against the bytes actually produced. A reservation that
+        // disagreed with the emission would put the next object on top of this
+        // one, so pin it where it is emitted as well as in a test.
+        debug_assert_eq!(
+            blob.len() as u64,
+            self.total_len,
+            "a dense attribute heap must fill the length its plan promised"
+        );
+
+        DenseAttrBlob {
+            attr_info_message: serialize_attribute_info(frhp_addr, bthd_addr),
+            blob,
+        }
     }
+}
+
+/// The base address pass 1 of a file build asks a [`DenseAttrPlan`] for its
+/// Attribute Info message at, before the heap's real address is known. The
+/// message's *length* is what that pass needs, and that does not depend on the
+/// address; pass 2 emits the real message at the address it reserves.
+const DUMMY_DENSE_BASE: u64 = 0;
+
+/// Build dense attribute storage for a set of attributes, at a known address.
+///
+/// A caller that has to reserve the heap's span before its bytes exist wants
+/// [`dense_attrs_plan`] and [`DenseAttrPlan::blob_len`] instead; this is the
+/// one-shot form for callers that already know where the heap goes.
+pub(crate) fn build_dense_attrs(attrs: &[AttributeMessage], base_address: u64) -> DenseAttrBlob {
+    dense_attrs_plan(attrs).build(base_address)
 }
 
 /// Bytes the reference C library uses to encode a limit of `value`
@@ -2078,42 +2210,51 @@ impl FileWriter {
             /// of those attributes are huge — no term of it is the address it is
             /// built at. Patching cannot move any of those terms either: it takes
             /// the attribute bytes as `&mut [u8]` and overwrites references in
-            /// place, so the slice it returns is the length it was given. The
-            /// assertion below is therefore a guard on future edits rather than on
-            /// this call.
+            /// place, so the slice it returns is the length it was given.
+            ///
+            /// The span was reserved from [`DenseAttrPlan::blob_len`], which
+            /// derives the length rather than measuring a build of it, and the
+            /// cursor that reservation advanced is what every later object's
+            /// address is computed from. So a disagreement between the two would
+            /// not stop at this heap: it would move every address after it, in a
+            /// file that still looks well formed. That is a refusal rather than a
+            /// `debug_assert`, because a release build has to catch it too.
             fn build(
                 &self,
                 root_attrs: &[AttributeMessage],
                 groups: &[GrpFlat],
                 datasets: &[DsFlat],
-            ) -> DenseBlobs {
+            ) -> Result<DenseBlobs, FormatError> {
                 fn one(
                     attrs: &[AttributeMessage],
                     span: Option<(u64, usize)>,
-                ) -> Option<DenseAttrBlob> {
-                    let (address, reserved) = span?;
+                ) -> Result<Option<DenseAttrBlob>, FormatError> {
+                    let Some((address, reserved)) = span else {
+                        return Ok(None);
+                    };
                     let blob = build_dense_attrs(attrs, address);
-                    debug_assert_eq!(
-                        blob.blob.len(),
-                        reserved,
-                        "a dense attribute heap must fill the span reserved for it, or every \
-                         address after it is wrong"
-                    );
-                    Some(blob)
+                    if blob.blob.len() != reserved {
+                        return Err(FormatError::SerializationError(format!(
+                            "a dense attribute heap built {} bytes into a span of {reserved} \
+                             reserved for it; every address after it would be wrong",
+                            blob.blob.len(),
+                        )));
+                    }
+                    Ok(Some(blob))
                 }
-                DenseBlobs {
-                    root: one(root_attrs, self.root),
+                Ok(DenseBlobs {
+                    root: one(root_attrs, self.root)?,
                     groups: groups
                         .iter()
                         .zip(&self.groups)
                         .map(|(g, &span)| one(&g.attrs, span))
-                        .collect(),
+                        .collect::<Result<_, _>>()?,
                     datasets: datasets
                         .iter()
                         .zip(&self.datasets)
                         .map(|(d, &span)| one(&d.attrs, span))
-                        .collect(),
-                }
+                        .collect::<Result<_, _>>()?,
+                })
             }
         }
 
@@ -2121,6 +2262,13 @@ impl FileWriter {
         // dense attributes also records its heap's byte length here, so pass 2
         // can reserve the span without yet building the bytes that go in it —
         // see `DenseSpans`.
+        //
+        // Each plan is used for its length and its Attribute Info message and is
+        // then dropped; `DenseSpans::build` plans again from scratch. Do not
+        // "optimize" that by carrying these plans forward: `patch_vl_refs` below
+        // overwrites variable-length references inside `attrs` between the two
+        // passes, so a plan made here holds pre-patch bytes. Only its *length*
+        // survives the patch, which is why that is all this pass takes from it.
         // Built here rather than beside the dummy addresses above because the
         // passes between still mutate `all_ds` (VL staging, compression), and
         // these tables borrow it.
@@ -2138,11 +2286,18 @@ impl FileWriter {
             let dummy_links =
                 dummy_tables.links(&g.ds_indices, &g.committed_indices, &g.sub_group_indices);
             let (oh, dense_len) = if group_dense[gi] {
-                let dummy_blob = build_dense_attrs(&g.attrs, 0);
-                let len = dummy_blob.blob.len();
+                // The plan answers both questions this pass asks — how long the
+                // heap will be, and what its Attribute Info message costs the
+                // header — without emitting the heap, which pass 2 does once at
+                // the address reserved here.
+                let plan = dense_attrs_plan(&g.attrs);
                 (
-                    build_group_oh(&dummy_links, &g.attrs, Some(&dummy_blob))?,
-                    Some(len),
+                    build_group_oh(
+                        &dummy_links,
+                        &g.attrs,
+                        Some(&plan.attr_info_message(DUMMY_DENSE_BASE)),
+                    )?,
+                    Some(plan.blob_len().to_usize()?),
                 )
             } else {
                 (build_group_oh(&dummy_links, &g.attrs, None)?, None)
@@ -2157,11 +2312,15 @@ impl FileWriter {
             &root_group_indices,
         );
         let (root_oh_size, root_dense_len) = if root_dense {
-            let dummy_blob = build_dense_attrs(&root_attrs, 0);
-            let len = dummy_blob.blob.len();
+            let plan = dense_attrs_plan(&root_attrs);
             (
-                build_group_oh(&root_dummy_links, &root_attrs, Some(&dummy_blob))?.len(),
-                Some(len),
+                build_group_oh(
+                    &root_dummy_links,
+                    &root_attrs,
+                    Some(&plan.attr_info_message(DUMMY_DENSE_BASE)),
+                )?
+                .len(),
+                Some(plan.blob_len().to_usize()?),
             )
         } else {
             (
@@ -2185,12 +2344,20 @@ impl FileWriter {
         let mut ds_dense_lens: Vec<Option<usize>> = Vec::with_capacity(all_ds.len());
         let mut dummy_cursor = 0u64;
         for (i, d) in all_ds.iter().enumerate() {
-            let dense_blob = if ds_dense[i] {
-                Some(build_dense_attrs(&d.attrs, 0))
+            let dense_plan = if ds_dense[i] {
+                Some(dense_attrs_plan(&d.attrs))
             } else {
                 None
             };
-            ds_dense_lens.push(dense_blob.as_ref().map(|b| b.blob.len()));
+            let dense_attr_info = dense_plan
+                .as_ref()
+                .map(|plan| plan.attr_info_message(DUMMY_DENSE_BASE));
+            ds_dense_lens.push(
+                dense_plan
+                    .as_ref()
+                    .map(|plan| plan.blob_len().to_usize())
+                    .transpose()?,
+            );
             let oh = if is_chunked[i] {
                 let built = build_chunked(d, dummy_cursor, chunk_sets[i].as_ref())?;
                 dummy_cursor += built.data.len();
@@ -2202,7 +2369,7 @@ impl FileWriter {
                     &built.layout_message,
                     built.pipeline_message.as_deref(),
                     &d.attrs,
-                    dense_blob.as_ref(),
+                    dense_attr_info.as_deref(),
                     d.fill.as_deref(),
                 )?
             } else {
@@ -2214,7 +2381,7 @@ impl FileWriter {
                     0,
                     d.contiguous_len(),
                     &d.attrs,
-                    dense_blob.as_ref(),
+                    dense_attr_info.as_deref(),
                     d.fill.as_deref(),
                     libver,
                 )?
@@ -2437,7 +2604,9 @@ impl FileWriter {
                         lm,
                         pm.as_deref(),
                         &d.attrs,
-                        ds_dense_blobs[i].as_ref(),
+                        ds_dense_blobs[i]
+                            .as_ref()
+                            .map(|b| b.attr_info_message.as_slice()),
                         d.fill.as_deref(),
                     )?
                 } else {
@@ -2448,7 +2617,9 @@ impl FileWriter {
                         layout.data_addr,
                         layout.data.len(),
                         &d.attrs,
-                        ds_dense_blobs[i].as_ref(),
+                        ds_dense_blobs[i]
+                            .as_ref()
+                            .map(|b| b.attr_info_message.as_slice()),
                         d.fill.as_deref(),
                         libver,
                     )?
@@ -2518,7 +2689,7 @@ impl FileWriter {
                 root: root_dense_blob,
                 groups: group_dense_blobs,
                 datasets: ds_dense_blobs,
-            } = dense_spans.build(&root_attrs, &groups, &all_ds);
+            } = dense_spans.build(&root_attrs, &groups, &all_ds)?;
 
             // (b) Superblock extension (File Space Info) in the metadata region.
             let ext_addr = meta;
@@ -2832,7 +3003,13 @@ impl FileWriter {
                 &root_committed_indices,
                 &root_group_indices,
             );
-            let root_oh = build_group_oh(&root_links, &root_attrs, root_dense_blob.as_ref())?;
+            let root_oh = build_group_oh(
+                &root_links,
+                &root_attrs,
+                root_dense_blob
+                    .as_ref()
+                    .map(|b| b.attr_info_message.as_slice()),
+            )?;
             debug_assert_eq!(root_oh.len(), root_oh_size);
             sink.put(&root_oh)?;
             if let Some(ref blob) = root_dense_blob {
@@ -2841,7 +3018,13 @@ impl FileWriter {
             // Group OHs + dense blobs.
             for (gi, g) in groups.iter().enumerate() {
                 let links = tables.links(&g.ds_indices, &g.committed_indices, &g.sub_group_indices);
-                let oh = build_group_oh(&links, &g.attrs, group_dense_blobs[gi].as_ref())?;
+                let oh = build_group_oh(
+                    &links,
+                    &g.attrs,
+                    group_dense_blobs[gi]
+                        .as_ref()
+                        .map(|b| b.attr_info_message.as_slice()),
+                )?;
                 debug_assert_eq!(oh.len(), group_oh_sizes[gi]);
                 sink.put(&oh)?;
                 if let Some(ref blob) = group_dense_blobs[gi] {
@@ -3033,7 +3216,7 @@ impl FileWriter {
             root: root_dense_blob,
             groups: group_dense_blobs,
             datasets: ds_dense_blobs,
-        } = dense_spans.build(&root_attrs, &groups, &all_ds);
+        } = dense_spans.build(&root_attrs, &groups, &all_ds)?;
 
         // Build dataset OHs now that attrs are patched. Only the header bytes
         // are kept here; each dataset's data is emitted directly from
@@ -3109,7 +3292,13 @@ impl FileWriter {
             &root_committed_indices,
             &root_group_indices,
         );
-        let root_oh = build_group_oh(&root_links, &root_attrs, root_dense_blob.as_ref())?;
+        let root_oh = build_group_oh(
+            &root_links,
+            &root_attrs,
+            root_dense_blob
+                .as_ref()
+                .map(|b| b.attr_info_message.as_slice()),
+        )?;
         debug_assert_eq!(root_oh.len(), root_oh_size);
         sink.put(&root_oh)?;
         if let Some(ref blob) = root_dense_blob {
@@ -3119,7 +3308,13 @@ impl FileWriter {
         // Group OHs + dense blobs
         for (gi, g) in groups.iter().enumerate() {
             let links = tables.links(&g.ds_indices, &g.committed_indices, &g.sub_group_indices);
-            let oh = build_group_oh(&links, &g.attrs, group_dense_blobs[gi].as_ref())?;
+            let oh = build_group_oh(
+                &links,
+                &g.attrs,
+                group_dense_blobs[gi]
+                    .as_ref()
+                    .map(|b| b.attr_info_message.as_slice()),
+            )?;
             debug_assert_eq!(oh.len(), group_oh_sizes[gi]);
             sink.put(&oh)?;
             if let Some(ref blob) = group_dense_blobs[gi] {
@@ -3673,6 +3868,92 @@ mod tests {
         assert_eq!(dense_attrs_check(&past), Ok(()));
         assert_eq!(huge_object_count(&build_dense_attrs(&past, 0).blob), 1);
         assert_eq!(huge_object_count(&build_dense_attrs(&at_limit, 0).blob), 0);
+    }
+
+    /// `DenseAttrPlan::blob_len` is the span a caller reserves for a heap before
+    /// a byte of it exists, so it has to equal the length `build` goes on to
+    /// emit — at whatever base address the reservation lands on. A reservation
+    /// that came out short would place the next object on top of the heap.
+    ///
+    /// The attribute counts are swept *contiguously* rather than at hand-picked
+    /// boundaries, so the sweep crosses every direct-block fill and every new row
+    /// of the doubling table in its range, and every split of the name index's
+    /// leaf, without anyone having to work out where those fall. The named shapes
+    /// after it reach what a contiguous sweep of small attributes cannot: blocks
+    /// large enough to be reached through nested indirect blocks, and the
+    /// managed/huge boundary from both sides and mixed.
+    #[test]
+    fn dense_attr_plan_length_matches_what_it_builds() {
+        let mut shapes: Vec<(String, Vec<AttributeMessage>)> = Vec::new();
+
+        for n in 0..=64usize {
+            shapes.push((
+                format!("{n} x 512B"),
+                (0..n)
+                    .map(|i| dense_attr_of_size(&format!("a{i}"), 512))
+                    .collect(),
+            ));
+        }
+        for n in [100usize, 200] {
+            shapes.push((
+                format!("{n} x 512B"),
+                (0..n)
+                    .map(|i| dense_attr_of_size(&format!("a{i}"), 512))
+                    .collect(),
+            ));
+        }
+
+        // Objects this size need a block from a row past the last direct one, so
+        // the heap reaches them through nested indirect blocks.
+        shapes.push((
+            "40 x 60,000B".to_string(),
+            (0..40)
+                .map(|i| dense_attr_of_size(&format!("big{i}"), 60_000))
+                .collect(),
+        ));
+
+        // The managed/huge boundary, from both sides and mixed. "One past" also
+        // leaves the doubling table with no managed objects at all.
+        shapes.push((
+            "at the managed limit".to_string(),
+            vec![dense_attr_of_size("edge", DENSE_ATTR_MAX_MANAGED_OBJECT)],
+        ));
+        shapes.push((
+            "one past the managed limit".to_string(),
+            vec![dense_attr_of_size(
+                "edge",
+                DENSE_ATTR_MAX_MANAGED_OBJECT + 1,
+            )],
+        ));
+        // Managed attributes on both sides of the huge ones, so a managed object
+        // that *follows* a huge one still takes the heap offset its own position
+        // in the managed order implies.
+        let mut mixed: Vec<AttributeMessage> = (0..10)
+            .map(|i| dense_attr_of_size(&format!("small{i}"), 300))
+            .collect();
+        mixed.push(dense_attr_of_size(
+            "huge0",
+            DENSE_ATTR_MAX_MANAGED_OBJECT + 1,
+        ));
+        mixed.push(dense_attr_of_size(
+            "huge1",
+            DENSE_ATTR_MAX_MANAGED_OBJECT * 4,
+        ));
+        mixed.extend((10..20).map(|i| dense_attr_of_size(&format!("small{i}"), 300)));
+        shapes.push(("managed and huge mixed".to_string(), mixed));
+
+        for (label, attrs) in shapes {
+            assert_eq!(dense_attrs_check(&attrs), Ok(()), "{label}");
+            let plan = dense_attrs_plan(&attrs);
+            for base in [0u64, 0x1000, 0x8000_0000] {
+                let built = plan.build(base);
+                assert_eq!(
+                    plan.blob_len(),
+                    built.blob.len() as u64,
+                    "planned length must match the emitted heap for {label} at base {base:#x}"
+                );
+            }
+        }
     }
 
     /// The attribute names of a built heap's name-index records, in the order the


### PR DESCRIPTION
Closes #265.

`WriteEngine::place_relocatable` picks a blob's address first and then builds the blob for that address, so it needs the length before the bytes exist. Two callers got that length by building the whole structure at a provisional base, reading `.len()`, and discarding it — `append_dense_attrs` for the dense-attribute fractal heap, `write_appended_chunks` for the Extensible Array. Both were introduced by #264 and have not shipped.

## Plan, don't mirror

The issue proposes a closed-form `dense_attrs_len` and `extensible_array_len` beside each builder, and then names the hazard itself: two pieces of layout arithmetic that have to stay in step, where a drift surfaces as a write failure. This takes the other route — split the plan from the emission, so the length and the bytes come from one computation and cannot disagree.

**Extensible Array.** `ea_layout` returns an `EaLayout` holding the element encoding, the block geometry, the header statistics and `total_len`. `extensible_array_len` returns that length; `build_extensible_array_at` takes its preamble from the same call. The body length needed no new derivation at all: the body is the allocated data blocks and super blocks concatenated with nothing between them, so `ea_compute_stats`'s existing `data_blk_size + super_blk_size` *is* the body's byte count.

The builder still accumulates its own statistics from the bytes it emits, and still writes those into the header. That was deliberate — routing the header fields through `ea_compute_stats` would have made `ea_compute_stats_matches_builder` compare a value against itself. It stays a genuine two-implementation cross-check.

**Dense attributes.** `dense_attrs_plan` returns a `DenseAttrPlan` holding the serialized attribute messages, the huge/managed split, the doubling-table plan, both v2 B-tree plans, the name-index order, and the offset of every part of the blob relative to its base. `blob_len()`, `attr_info_message(base)` and `build(base)` come off it. `build_dense_attrs` remains as a one-shot wrapper for callers that already know the address.

## A third double-build the issue did not name

The whole-file writer's pass 1 built every dense heap at address 0 too, purely to obtain an 18-byte Attribute Info message and a length. The four object-header builders only ever read `blob.attr_info_message` and never `blob.blob`, so they now take `Option<&[u8]>` and pass 1 emits nothing.

Pass 2 still plans from scratch rather than reusing pass 1's plan, and must: `patch_vl_refs` overwrites variable-length references inside `attrs` between the two passes, so a pass-1 plan holds pre-patch bytes. Only its *length* survives the patch, which is why that is all pass 1 takes from it. There is now a comment saying so at that site, because it reads like an obvious thing to hoist.

## A derived length needs a stronger guard than a measured one

`DenseSpans::build` checked its heaps against their reserved spans with a `debug_assert`. That was adequate while the reservation came from an actual build — a mismatch would have required the length to depend on the base address. Now that it is derived, a drift would be arithmetic, and the reservation advances the cursor every later object's address is computed from, so a release build would write a file that still parses with every address after the heap wrong. It is a returned `FormatError::SerializationError` now. The edit path already refused this in release, through `place`.

## What is left

Two `place_relocatable` callers still measure by building: `chunked_data_len` and the sizing call to `plan_chunked_data_verbatim` both materialize the chunk *index* at base 0 and discard it. Neither materializes the chunk data, which is the bulk of the region, so the issue's description of them as "the cheaper pattern" is right about the data and wrong about the index. Finishing them needs a length for the Fixed Array as well; tracked in #275, and stated at `place_relocatable` so the doc does not claim more than the code does.

## Correctness gate

Byte identity, not a timing comparison — removing a redundant build is less work by construction, so what needed proving is that nothing moved. A probe wrote five files covering the dense whole-file path (including huge objects and a variable-length attribute), a 140,000-chunk Extensible Array, an `open_rw` copy of a dense-attributed object, an in-place append that rebuilds an index, and the same copy on a paged file. All five hash identically to `main`, before and after the review fixes above.

Both new tests sweep their small ranges **contiguously** rather than at hand-picked boundaries, so they cross every direct-block fill, doubling-table row and index-node split in range without encoding an assumption about where those fall. My first attempt did hand-pick, and put "just under the Extensible Array's paged boundary" four elements short of it. The far boundary is still explicit, as the pair 131,060 / 131,061, and four raw chunk sizes drive the filtered element-record width — with an assertion that those four widths are actually distinct, so the fixture cannot quietly collapse into one.

Mutation-verified in both directions: perturbing either reservation by four bytes fails exactly one test with the other 787 passing, and so does indexing a managed attribute's heap offset by its attribute position rather than its managed position — the mistake this rewrite could most easily have made, which only bites when a managed attribute follows a huge one.

No public API change: `chunked_write` and `file_writer` are both `pub(crate)`, so nothing here is publicly reachable and no version bump is needed.

`cargo nextest run --all-features` 2,036 passing, `cargo test --all-features --doc` 46 passing, clippy clean on `--all-targets --all-features`, `cargo check --no-default-features` clean.

