### PR TITLE
Refuse a malformed Extensible Array element size and a truncated index block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- An Extensible Array header naming a filtered element too narrow to hold the address and filter mask it must contain is refused; the size arithmetic previously underflowed, panicking under the overflow checks tests and fuzz targets build with.
+- A truncated Extensible Array index block is refused when the file is read whole, where the reader returned the chunks it had and reported success; reading the same file through `File::open_streaming` already refused it.
 - A deflated chunk whose zlib stream ends without reaching its checksum is refused rather than decoded. Such a chunk read as valid data whenever it happened to decode to the expected length, since the adler32 that would have caught it was never reached ([#228](https://github.com/stephenberry/hdf5-pure/issues/228)).
 - A datatype declaring a zero-byte element size is refused with the new `FormatError::ZeroSizedDatatype` when its message is parsed; reading such a dataset previously panicked on a division by that size ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).
 - Writing a dataset or committed datatype whose element size is zero is refused with the same error, on both the whole-file and `File::open_rw` paths; a chunked write of one previously panicked, and a contiguous one produced a file this crate refuses to read ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- An Extensible Array header naming a filtered element too narrow to hold the address and filter mask it must contain is refused; the size arithmetic previously underflowed, panicking under the overflow checks tests and fuzz targets build with.
-- A truncated Extensible Array index block is refused when the file is read whole, where the reader returned the chunks it had and reported success; reading the same file through `File::open_streaming` already refused it.
+- An Extensible Array header naming a filtered element too narrow to hold the address and filter mask it must contain is refused; the size arithmetic previously underflowed, panicking under the overflow checks tests and fuzz targets build with ([#278](https://github.com/stephenberry/hdf5-pure/pull/278)).
+- A truncated Extensible Array index block is refused when the file is read whole, where the reader returned the chunks it had and reported success; reading the same file through `File::open_streaming` already refused it ([#278](https://github.com/stephenberry/hdf5-pure/pull/278)).
 - A deflated chunk whose zlib stream ends without reaching its checksum is refused rather than decoded. Such a chunk read as valid data whenever it happened to decode to the expected length, since the adler32 that would have caught it was never reached ([#228](https://github.com/stephenberry/hdf5-pure/issues/228)).
 - A datatype declaring a zero-byte element size is refused with the new `FormatError::ZeroSizedDatatype` when its message is parsed; reading such a dataset previously panicked on a division by that size ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).
 - Writing a dataset or committed datatype whose element size is zero is refused with the same error, on both the whole-file and `File::open_rw` paths; a chunked write of one previously panicked, and a contiguous one produced a file this crate refuses to read ([#268](https://github.com/stephenberry/hdf5-pure/issues/268)).

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -295,8 +295,14 @@ fn read_element(
             os,
         ))
     } else {
-        // Filtered: address + compressed_size + filter_mask
-        let chunk_size_bytes = element_size as usize - os - 4;
+        // Filtered: address + compressed_size + filter_mask. `element_size` is
+        // the EAHD's own byte (`d[6]`), so a crafted header can name a width
+        // that cannot hold the address and mask it must contain; subtract with
+        // a check rather than underflowing. This mirrors the Fixed Array twin
+        // in `fixed_array::read_fixed_array_chunks`.
+        let chunk_size_bytes = (element_size as usize).checked_sub(os + 4).ok_or_else(|| {
+            FormatError::ChunkedReadError("Extensible Array element size too small".into())
+        })?;
         let elem_total = os + chunk_size_bytes + 4;
         if elem_total > data.len() || pos > data.len() - elem_total {
             return Err(FormatError::UnexpectedEof {
@@ -628,9 +634,6 @@ pub fn read_extensible_array_chunks(
     //    refers to super block `first_indirect_sblk + j`.
     let mut sblk_addrs: Vec<u64> = Vec::with_capacity(geom.nsblk_addrs);
     for _ in 0..geom.nsblk_addrs {
-        if os > file_data.len() || pos > file_data.len() - os {
-            break;
-        }
         sblk_addrs.push(read_offset(file_data, pos, offset_size)?);
         pos += os;
     }
@@ -1808,6 +1811,152 @@ mod tests {
         assert_eq!(ci.filter_mask, 0);
         assert_eq!(ci.offsets, vec![20]);
         assert_eq!(consumed, elem_size);
+    }
+
+    /// A filtered element record holds an address, a chunk size, and a 4-byte
+    /// filter mask, so its width cannot be smaller than `offset_size + 4`. The
+    /// width comes from the EAHD's own `element_size` byte, which no parse
+    /// validates, so a crafted header can name a smaller one. That must be
+    /// refused: the size arithmetic used to underflow, which panics under the
+    /// overflow checks that `cargo test` and the fuzz targets build with.
+    #[test]
+    fn filtered_element_smaller_than_its_own_fields_is_refused() {
+        let os: u8 = 8;
+        let num_chunks = vec![5u64];
+        let chunk_dims = vec![10u32];
+        let data = vec![0u8; 64];
+
+        // `element_size` must be at least os + 4 = 12 to hold what it claims.
+        for element_size in 0..(os + 4) {
+            let err = read_element(
+                &data,
+                0,
+                1,
+                element_size,
+                os,
+                80,
+                0,
+                &num_chunks,
+                &chunk_dims,
+            )
+            .expect_err("a filtered element narrower than its own fields must be refused");
+            assert!(
+                matches!(err, FormatError::ChunkedReadError(_)),
+                "element_size {element_size} gave {err:?}, want a ChunkedReadError"
+            );
+        }
+
+        // The first width that can hold them is accepted.
+        read_element(&data, 0, 1, os + 4 + 1, os, 80, 0, &num_chunks, &chunk_dims)
+            .expect("a width that fits address + 1-byte size + mask must parse");
+    }
+
+    /// A truncated super-block address array must be refused by both backends.
+    ///
+    /// The buffered reader used to `break` out of the address loop on a short
+    /// read and return `Ok` with a silently shortened chunk list, while the
+    /// streaming reader returned `UnexpectedEof` for the identical bytes -- so
+    /// the same file decoded two different ways depending on whether it was
+    /// opened with `File::open` or `File::open_streaming`. The error is
+    /// asserted down to the offset it faults at, so this cannot pass on an
+    /// unrelated failure earlier in the walk.
+    #[cfg(feature = "std")]
+    #[test]
+    fn truncated_super_block_addresses_are_refused_by_both_backends() {
+        use crate::chunked_write::{WrittenChunk, build_extensible_array_at};
+        use crate::source::BytesSource;
+
+        let n = 100u64;
+        let chunks: Vec<WrittenChunk> = (0..n)
+            .map(|i| WrittenChunk {
+                address: 0x10 + i * 8,
+                compressed_size: 8,
+                raw_size: 8,
+                filter_mask: 0,
+            })
+            .collect();
+        let base = 0x1000u64;
+        let ea = build_extensible_array_at(&chunks, 8, 8, false, base).unwrap();
+        let mut file = vec![0u8; base as usize + ea.len()];
+        file[base as usize..].copy_from_slice(&ea);
+
+        let ds_dims = vec![n];
+        let chunk_dims = vec![1u32];
+        let built = ExtensibleArrayHeader::parse(&file, base as usize, 8, 8).unwrap();
+        let geom = EaGeometry::from_header(&built);
+        assert!(
+            geom.nsblk_addrs > 0,
+            "fixture must reach the super-block address array"
+        );
+
+        // This crate's writer lays the index block down *before* the data
+        // blocks it points at, so truncating into the block's address array
+        // also truncates those data blocks and the walk faults on one of them
+        // first. The format does not require that order, and a file whose
+        // index block trails its data blocks is what reaches the address loop
+        // with everything before it intact -- so move the index block to the
+        // end and repoint the header at it. Nothing else about the file
+        // changes; both header and index-block checksums go unvalidated on
+        // this path, so the copy needs no fixing up.
+        let old_ib = built.index_block_address.to_usize().unwrap();
+        let ib_len = 4 + 1 + 1 + 8                            // sig + ver + client + header addr
+            + built.idx_blk_elmts as usize * 8                // inline elements
+            + geom.direct_dblk_nelmts.len() * 8               // direct-block addresses
+            + geom.nsblk_addrs * 8                            // super-block addresses
+            + 4; // checksum
+        let block = file[old_ib..old_ib + ib_len].to_vec();
+        let new_ib = file.len();
+        file.extend_from_slice(&block);
+        // The header's index-block address sits after the 12-byte prefix and
+        // the six length-sized statistics fields.
+        let addr_field = base as usize + 12 + 6 * 8;
+        file[addr_field..addr_field + 8].copy_from_slice(&(new_ib as u64).to_le_bytes());
+
+        let header = ExtensibleArrayHeader::parse(&file, base as usize, 8, 8).unwrap();
+        assert_eq!(header.index_block_address as usize, new_ib);
+        // The relocated file must still read identically before it is cut.
+        let intact =
+            read_extensible_array_chunks(&file, &header, &ds_dims, &chunk_dims, 8, 8, 8).unwrap();
+        assert_eq!(intact.len() as u64, n, "relocation must preserve the read");
+
+        // Where the first super-block address begins: index block prefix,
+        // then the inline elements, then the direct-block addresses.
+        let sblk_start = new_ib
+            + 4
+            + 1
+            + 1
+            + 8
+            + header.idx_blk_elmts as usize * 8
+            + geom.direct_dblk_nelmts.len() * 8;
+
+        // Cut the file in the middle of that first address. Every data block
+        // now lies before the cut, so the address loop is what faults.
+        file.truncate(sblk_start + 4);
+
+        let buffered = read_extensible_array_chunks(&file, &header, &ds_dims, &chunk_dims, 8, 8, 8);
+        match buffered {
+            Err(FormatError::UnexpectedEof {
+                expected,
+                available,
+            }) => {
+                assert_eq!(
+                    expected,
+                    sblk_start + 8,
+                    "the buffered read must fault on the super-block address itself"
+                );
+                assert_eq!(available, file.len());
+            }
+            other => panic!("buffered read must refuse a truncated address array, got {other:?}"),
+        }
+
+        let mem = BytesSource::new(&file);
+        let hm = ExtensibleArrayHeader::parse_from_source(&mem, base, 8, 8).unwrap();
+        let streamed =
+            read_extensible_array_chunks_from_source(&mem, &hm, &ds_dims, &chunk_dims, 8, 8, 8);
+        assert!(
+            streamed.is_err(),
+            "streaming read must refuse the same file, got {streamed:?}"
+        );
     }
 
     /// `extensible_array_index_spans` must account for exactly the index


### PR DESCRIPTION
Two defects in the Extensible Array reader, both found by comparing it against its own Fixed Array twin and its own streaming counterpart.

## An element size the header controls, subtracted without a check

A filtered Extensible Array element holds an address, a chunk size, and a 4-byte filter mask, so its width cannot be smaller than `offset_size + 4`. That width is the EAHD's own `element_size` byte, read raw at `d[6]`; the header parse validates the signature and version and nothing else. A crafted header naming a smaller width reached `element_size as usize - os - 4`, which underflows. That panics under the overflow checks `cargo test` and the fuzz targets build with, and `fuzz_targets/parse_file.rs` reaches it. The Fixed Array twin has done the identical arithmetic with `checked_sub` and a clean error since it was written; this makes the two agree.

A width of exactly `offset_size + 4` stays accepted, as it is in the twin: it names a zero-byte chunk-size field, which is degenerate but not malformed.

## A short read that returned success

The super-block address loop tested its own bound and `break`s when the file ends inside the array, returning `Ok` with whatever chunks it had already collected. The direct-address loop thirty lines above it propagates through `?`, the streaming counterpart propagates, and `source.rs` states that a short read is always an error — so a truncated file decoded two different ways depending on whether it was opened with `File::open` or `File::open_streaming`. The guard is removed and `read_offset`'s error propagates.

This is reachable only for a file whose index block trails the data blocks it points at. This crate's writer emits the index block first, so truncating into its address array also truncates those data blocks and the walk faults on one of them first; the test relocates the index block to the end of the file to reach the loop with everything before it intact. The format does not constrain that order, so a file from another writer can take this path.

**Behaviour change worth a reviewer's attention:** reading such a file whole now fails where it used to succeed, including when the chunks were already recovered from the inline and direct blocks and the addresses were never needed. That is the behaviour the streaming path has always had, and neither this crate nor libhdf5 writes a short address array, so no well-formed file is affected. The two libhdf5 crosscheck tests (`c_writes_pure_reads`, `eahd_stats_match_c`) pass.

## Tests

Both tests were mutation-verified: restoring either defect fails exactly one test and leaves the other 803 library tests passing, so the suite was blind to both.

| mutation | result |
| --- | --- |
| restore the unchecked subtraction | 1 failure, `attempt to subtract with overflow` |
| restore the `break` | 1 failure, buffered returns `Ok` with all 100 chunks of a truncated file |

The truncation test asserts the error down to the offset it faults at, which is what keeps it from passing on an unrelated failure earlier in the walk — the first draft did exactly that, faulting on a data block rather than the address array.

No public API change, so no version bump. `cargo fmt --check` and `cargo clippy --all-targets` are clean and the full default-feature suite passes (1713 tests).
