### PR TITLE
Remove six import-silencing stubs and a no-op parse block

### DIFF
--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -115,12 +115,9 @@ impl Dataspace {
             None
         };
 
-        // v1 flags bit 1 = permutation indices present (skip them)
-        if version == 1 && flags & 0x02 != 0 {
-            // rank × length_size bytes of permutation indices — skip
-            let _skip = rank as usize * ls;
-            // pos += _skip; // not needed since we don't use pos after this
-        }
+        // A v1 dataspace with flags bit 1 set carries rank × length_size bytes
+        // of permutation indices here. Nothing below reads `pos`, so they need
+        // no skipping; this crate does not expose them.
 
         Ok(Dataspace {
             space_type,

--- a/src/mat/de/value_de.rs
+++ b/src/mat/de/value_de.rs
@@ -6,7 +6,7 @@
 use std::collections::VecDeque;
 
 use serde::de::{
-    self, DeserializeSeed, Deserializer, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
+    DeserializeSeed, Deserializer, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
     VariantAccess, Visitor,
 };
 use serde::forward_to_deserialize_any;
@@ -1212,12 +1212,6 @@ impl NumVec {
             ScalarNum::U8(x) => NumVec::U8(vec![x]),
         }
     }
-}
-
-// Silence unused imports in some builds.
-#[allow(dead_code)]
-fn _touch<E: de::Error>() -> E {
-    E::custom("x")
 }
 
 #[cfg(test)]

--- a/src/mat/ser/emit.rs
+++ b/src/mat/ser/emit.rs
@@ -9,9 +9,7 @@ use crate::mat::error::MatError;
 use crate::mat::options::Options;
 use crate::mat::userblock::{self, USERBLOCK_SIZE};
 use crate::mat::utf16;
-use crate::type_builders::{
-    DatasetBuilder, FinishedGroup, GroupBuilder, make_f32_type, make_f64_type,
-};
+use crate::type_builders::{DatasetBuilder, FinishedGroup, GroupBuilder};
 use crate::writer::FileBuilder;
 
 use crate::mat::value::{ComplexVec, MatValue, NumVec, ScalarNum, ScalarTag};
@@ -597,13 +595,6 @@ fn set_logical_decode(ds: &mut DatasetBuilder) {
 /// UTF-16 characters rather than a numeric array.
 fn set_char_decode(ds: &mut DatasetBuilder) {
     ds.set_attr("MATLAB_int_decode", AttrValue::I32(2));
-}
-
-// Silence the "unused import" on the no-test build.
-#[allow(dead_code)]
-fn _touch() {
-    let _ = make_f64_type();
-    let _ = make_f32_type();
 }
 
 #[cfg(test)]

--- a/src/mat/ser/root.rs
+++ b/src/mat/ser/root.rs
@@ -4,7 +4,7 @@
 //! file. A flat `HashMap<String, T>` is also accepted, matching
 //! `scipy.io.savemat`'s dict-at-root convention.
 
-use serde::ser::{self, Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
+use serde::ser::{Impossible, Serialize, SerializeMap, SerializeStruct, Serializer};
 
 use crate::mat::error::MatError;
 use crate::mat::options::Options;
@@ -353,10 +353,4 @@ impl SerializeMap for RootMapSer<'_> {
     fn end(self) -> Result<Vec<(String, MatValue)>, MatError> {
         Ok(self.fields)
     }
-}
-
-// Silence unused-import warnings in some builds.
-#[allow(dead_code)]
-fn _touch<E: ser::Error>() -> E {
-    E::custom("x")
 }

--- a/src/mat/ser/value_ser.rs
+++ b/src/mat/ser/value_ser.rs
@@ -5,7 +5,7 @@
 //! tree, then the emitter walks the tree to build the HDF5 file.
 
 use serde::ser::{
-    self, Impossible, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeTuple,
+    Impossible, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeTuple,
     SerializeTupleStruct, Serializer,
 };
 
@@ -13,11 +13,8 @@ use crate::mat::complex::{complex_tag_for_array_sentinel, complex_tag_for_sentin
 use crate::mat::error::MatError;
 use crate::mat::matrix::{MATRIX_SENTINEL, complex_tag_for_matrix_sentinel};
 use crate::mat::options::{EmptySequencePolicy, NullPolicy, Options, UnitVariantEncoding};
-use crate::mat::utf16;
 
-use crate::mat::value::{
-    ComplexNum, ComplexTag, ComplexVec, MatValue, NumVec, ScalarNum, ScalarTag,
-};
+use crate::mat::value::{ComplexNum, ComplexTag, ComplexVec, MatValue, NumVec, ScalarNum};
 
 // ---------------------------------------------------------------------------
 // Public entry: serialize a value into a MatValue
@@ -946,19 +943,4 @@ fn expect_component(v: MatValue) -> Result<ScalarNum, MatError> {
             other.kind()
         ))),
     }
-}
-
-// Silence unused-import warnings for items only referenced in specific
-// serializer methods.
-#[allow(dead_code)]
-fn _touch_utf16() -> Vec<u16> {
-    utf16::encode_utf16("x")
-}
-
-#[allow(dead_code)]
-fn _touch_tag(_: ScalarTag) {}
-
-#[allow(dead_code)]
-fn _touch_ser_err<E: ser::Error>() -> E {
-    E::custom("x")
 }


### PR DESCRIPTION
Follow-up to #278, taking the two items from the simplification review that the compiler can prove.

## Six `_touch` stubs

`src/mat/` carried six `#[allow(dead_code)]` functions whose only job was to reference an import so it would not warn:

```rust
// Silence the "unused import" on the no-test build.
#[allow(dead_code)]
fn _touch() {
    let _ = make_f64_type();
    let _ = make_f32_type();
}
```

The import each one protected was genuinely unused, so the stub was keeping a dead import alive rather than the other way round. Deleting the six and compiling names exactly six unused imports — `make_f64_type`, `make_f32_type`, `crate::mat::utf16`, `ScalarTag`, and the `serde::ser::self` / `serde::de::self` re-exports — which go with them. The removals are the compiler's own suggestions, applied with `cargo fix`.

## A no-op block in `Dataspace::parse`

It computed the width of a v1 dataspace's permutation indices into a discarded binding, beside a commented-out `pos +=` explaining that nothing below reads `pos`. The block had no effect. The format fact it recorded — that those bytes sit there in a v1 dataspace with flags bit 1 set — is kept as a comment.

## Verification

No public API or behaviour change, so no changelog entry and no version bump. Checked under `--all-features --all-targets` (which builds the test cfg the stubs claimed to serve), the default feature set, and `--no-default-features` for the no_std gate; `cargo fmt --check` and `cargo clippy --all-features --all-targets` are clean, and the full gate passes — 2055 tests plus 46 doctests.
