### PR TITLE
Collapse 42 per-module byte readers into one `bytes` module

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -7,6 +7,7 @@ use crate::attribute_info::AttributeInfoMessage;
 use crate::btree_v2::{
     BTreeV2Header, collect_btree_v2_records, collect_btree_v2_records_from_source,
 };
+use crate::bytes::ensure_len;
 use crate::convert::TryToUsize;
 use crate::data_read;
 use crate::dataspace::Dataspace;
@@ -51,17 +52,6 @@ pub struct AttributeMessage {
     /// show: both forms decode to the same type.
     pub datatype_location: DatatypeLocation,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 /// Round up to the next multiple of 8.
 fn pad8(x: usize) -> usize {
     (x + 7) & !7

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -52,6 +52,7 @@ pub struct AttributeMessage {
     /// show: both forms decode to the same type.
     pub datatype_location: DatatypeLocation,
 }
+
 /// Round up to the next multiple of 8.
 fn pad8(x: usize) -> usize {
     (x + 7) & !7

--- a/src/attribute_info.rs
+++ b/src/attribute_info.rs
@@ -3,6 +3,8 @@
 //! The Attribute Info message describes dense attribute storage: a fractal heap
 //! and B-tree v2 indexes for attribute lookup by name or creation order.
 
+use crate::bytes::{ensure_len, read_offset};
+use crate::convert::is_undefined_addr;
 use crate::error::FormatError;
 
 /// Parsed Attribute Info message from an object header.
@@ -17,51 +19,6 @@ pub struct AttributeInfoMessage {
     /// Address of B-tree v2 (type 9) for creation-order attribute index.
     pub btree_creation_order_address: Option<u64>,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn is_undefined(val: u64, offset_size: u8) -> bool {
-    match offset_size {
-        2 => val == 0xFFFF,
-        4 => val == 0xFFFF_FFFF,
-        8 => val == 0xFFFF_FFFF_FFFF_FFFF,
-        _ => false,
-    }
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 impl AttributeInfoMessage {
     /// Parse an Attribute Info message from raw message data.
     ///
@@ -93,7 +50,7 @@ impl AttributeInfoMessage {
 
         let fh_addr = read_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let fractal_heap_address = if is_undefined(fh_addr, offset_size) {
+        let fractal_heap_address = if is_undefined_addr(fh_addr, offset_size) {
             None
         } else {
             Some(fh_addr)
@@ -101,7 +58,7 @@ impl AttributeInfoMessage {
 
         let btree_addr = read_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let btree_name_index_address = if is_undefined(btree_addr, offset_size) {
+        let btree_name_index_address = if is_undefined_addr(btree_addr, offset_size) {
             None
         } else {
             Some(btree_addr)
@@ -109,7 +66,7 @@ impl AttributeInfoMessage {
 
         let btree_creation_order_address = if has_creation_order_index {
             let addr = read_offset(data, pos, offset_size)?;
-            if is_undefined(addr, offset_size) {
+            if is_undefined_addr(addr, offset_size) {
                 None
             } else {
                 Some(addr)

--- a/src/attribute_info.rs
+++ b/src/attribute_info.rs
@@ -19,6 +19,7 @@ pub struct AttributeInfoMessage {
     /// Address of B-tree v2 (type 9) for creation-order attribute index.
     pub btree_creation_order_address: Option<u64>,
 }
+
 impl AttributeInfoMessage {
     /// Parse an Attribute Info message from raw message data.
     ///

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -46,6 +46,7 @@ pub struct BTreeV1Node {
     /// Child addresses (entries_used values).
     pub children: Vec<u64>,
 }
+
 impl BTreeV1Node {
     /// Parse a B-tree v1 node at the given offset in the file data.
     ///

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::{is_undefined_at, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -45,34 +46,6 @@ pub struct BTreeV1Node {
     /// Child addresses (entries_used values).
     pub children: Vec<u64>,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn is_undefined(data: &[u8], pos: usize, size: u8) -> bool {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return false;
-    }
-    data[pos..pos + s].iter().all(|&b| b == 0xFF)
-}
-
 impl BTreeV1Node {
     /// Parse a B-tree v1 node at the given offset in the file data.
     ///
@@ -103,13 +76,13 @@ impl BTreeV1Node {
         let entries_used = u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]);
 
         let mut pos = offset + BTREE_V1_NODE_PREFIX_LEN;
-        let left_sibling = if is_undefined(file_data, pos, offset_size) {
+        let left_sibling = if is_undefined_at(file_data, pos, offset_size) {
             None
         } else {
             Some(read_offset(file_data, pos, offset_size)?)
         };
         pos += os;
-        let right_sibling = if is_undefined(file_data, pos, offset_size) {
+        let right_sibling = if is_undefined_at(file_data, pos, offset_size) {
             None
         } else {
             Some(read_offset(file_data, pos, offset_size)?)

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -36,6 +36,7 @@ pub struct BTreeV2Record {
     /// Raw record bytes (record_size bytes).
     pub data: Vec<u8>,
 }
+
 /// Compute the number of bytes needed to represent a count, using variable-width encoding.
 /// B-tree v2 uses this for the number of records fields in internal nodes.
 fn bytes_for_max_records(max_nrec: u64) -> usize {

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -6,6 +6,7 @@ use alloc::{vec, vec::Vec};
 #[cfg(feature = "checksum")]
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::bytes::{ensure_len, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -35,42 +36,6 @@ pub struct BTreeV2Record {
     /// Raw record bytes (record_size bytes).
     pub data: Vec<u8>,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 /// Compute the number of bytes needed to represent a count, using variable-width encoding.
 /// B-tree v2 uses this for the number of records fields in internal nodes.
 fn bytes_for_max_records(max_nrec: u64) -> usize {

--- a/src/btree_v2.rs
+++ b/src/btree_v2.rs
@@ -6,7 +6,7 @@ use alloc::{vec, vec::Vec};
 #[cfg(feature = "checksum")]
 use byteorder::{ByteOrder, LittleEndian};
 
-use crate::bytes::{ensure_len, read_offset};
+use crate::bytes::{ensure_len, read_length, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -95,7 +95,7 @@ impl BTreeV2Header {
         let num_records_in_root = u16::from_le_bytes([file_data[pos], file_data[pos + 1]]);
         pos += 2;
 
-        let total_records = read_offset(file_data, pos, length_size)?;
+        let total_records = read_length(file_data, pos, length_size)?;
         #[allow(unused_assignments)]
         {
             pos += length_size as usize;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,214 @@
+//! Bounds-checked reads of the little-endian fields HDF5 writes on disk.
+//!
+//! Every format module parses the same handful of shapes: check that `needed`
+//! bytes are available at `offset`, then read a 2/4/8-byte file address, a
+//! 2/4/8-byte length, or a 1/2/4/8-byte variable-width integer. Before this
+//! module each one carried its own private copy — 42 of them across 21 files,
+//! several byte-identical — which is the duplication [`crate::source`] named as
+//! step 2 of its plan and never collapsed.
+//!
+//! Three distinctions are worth keeping, because they are the ones the copies
+//! actually disagreed on:
+//!
+//! * [`read_offset`] and [`read_length`] differ only in which error they report
+//!   for an unsupported width. That error names the on-disk field the width came
+//!   from ("size of offsets" against "size of lengths"), so a malformed file is
+//!   reported against the field that is wrong rather than a generic one.
+//! * [`read_uint_width`] is **not** an address read. Object header and link
+//!   messages store a width in a two-bit flag field, where 1 is a legal value;
+//!   a file address is 2, 4, or 8 and a 1 there is malformed. Giving the two
+//!   cases separate names keeps a caller from widening its own accepted set by
+//!   reaching for the wrong helper.
+//! * The bound is checked without `offset + needed` ever overflowing. `offset`
+//!   is file-derived, so on a 32-bit target that sum can wrap and admit a read
+//!   past the end of the buffer (issue #140).
+//!
+//! Reads are from an in-memory slice. A parser working through [`crate::source`]
+//! reads its bytes into a buffer first and then uses these on that buffer.
+
+use crate::convert::is_undefined_addr;
+use crate::error::FormatError;
+
+/// Check that `needed` bytes are readable at `offset`.
+///
+/// Returns [`FormatError::UnexpectedEof`] otherwise. `offset + needed` is
+/// computed with [`usize::checked_add`], so a file-derived `offset` near
+/// `usize::MAX` reports the truncation rather than wrapping into a valid-looking
+/// range.
+#[inline]
+pub(crate) fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
+    match offset.checked_add(needed) {
+        Some(end) if end <= data.len() => Ok(()),
+        _ => Err(FormatError::UnexpectedEof {
+            expected: offset.saturating_add(needed),
+            available: data.len(),
+        }),
+    }
+}
+
+/// Read a little-endian unsigned integer of `width` bytes at `pos`.
+///
+/// The width is assumed already validated; the caller-facing wrappers below own
+/// the "which widths are legal here" decision and the error that reports it.
+#[inline]
+fn read_le(data: &[u8], pos: usize, width: u8) -> u64 {
+    debug_assert!(
+        matches!(width, 1 | 2 | 4 | 8),
+        "width validated by the caller"
+    );
+    let mut acc: u64 = 0;
+    for i in (0..width as usize).rev() {
+        acc = (acc << 8) | u64::from(data[pos + i]);
+    }
+    acc
+}
+
+/// Read a file address of `offset_size` bytes at `pos`.
+///
+/// `offset_size` is the superblock's "size of offsets" and must be 2, 4, or 8;
+/// anything else is [`FormatError::InvalidOffsetSize`]. For the 1/2/4/8 widths
+/// that object header and link messages encode in a flag field, use
+/// [`read_uint_width`] instead.
+pub(crate) fn read_offset(data: &[u8], pos: usize, offset_size: u8) -> Result<u64, FormatError> {
+    if !matches!(offset_size, 2 | 4 | 8) {
+        return Err(FormatError::InvalidOffsetSize(offset_size));
+    }
+    ensure_len(data, pos, offset_size as usize)?;
+    Ok(read_le(data, pos, offset_size))
+}
+
+/// Read a length of `length_size` bytes at `pos`.
+///
+/// Identical to [`read_offset`] but reports [`FormatError::InvalidLengthSize`],
+/// naming the "size of lengths" superblock field the width came from.
+pub(crate) fn read_length(data: &[u8], pos: usize, length_size: u8) -> Result<u64, FormatError> {
+    if !matches!(length_size, 2 | 4 | 8) {
+        return Err(FormatError::InvalidLengthSize(length_size));
+    }
+    ensure_len(data, pos, length_size as usize)?;
+    Ok(read_le(data, pos, length_size))
+}
+
+/// Read a variable-width unsigned integer of `width` bytes at `pos`, where
+/// `width` is 1, 2, 4, or 8.
+///
+/// This is the width an object header or link message encodes in a two-bit flag
+/// field, for a value that is a size or an index rather than a file address —
+/// so 1 is legal here and malformed in [`read_offset`].
+pub(crate) fn read_uint_width(data: &[u8], pos: usize, width: u8) -> Result<u64, FormatError> {
+    if !matches!(width, 1 | 2 | 4 | 8) {
+        return Err(FormatError::InvalidOffsetSize(width));
+    }
+    ensure_len(data, pos, width as usize)?;
+    Ok(read_le(data, pos, width))
+}
+
+/// True when the address stored at `pos` is the all-`0xFF` "undefined address"
+/// sentinel for a file whose size-of-offsets is `offset_size`.
+///
+/// Out-of-range or unsupported widths read as "not undefined", matching the
+/// per-module copies this replaces: every caller treats a `false` here as "there
+/// is an address to follow", and the read that follows reports the truncation
+/// with the position it actually failed at.
+pub(crate) fn is_undefined_at(data: &[u8], pos: usize, offset_size: u8) -> bool {
+    match read_offset(data, pos, offset_size) {
+        Ok(addr) => is_undefined_addr(addr, offset_size),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_len_accepts_an_exact_fit_and_rejects_one_byte_more() {
+        let data = [0u8; 8];
+        assert!(ensure_len(&data, 4, 4).is_ok());
+        assert!(ensure_len(&data, 4, 5).is_err());
+        assert!(ensure_len(&data, 8, 0).is_ok());
+    }
+
+    #[test]
+    fn ensure_len_reports_a_wrapping_offset_instead_of_admitting_it() {
+        // `offset + needed` overflows usize. The pre-collapse copies that wrote
+        // `pos + s` would wrap to a small number and pass the bound check,
+        // admitting a read past the end of the buffer (issue #140).
+        let data = [0u8; 16];
+        let err = ensure_len(&data, usize::MAX - 1, 8).unwrap_err();
+        assert!(matches!(err, FormatError::UnexpectedEof { .. }));
+    }
+
+    #[test]
+    fn each_supported_width_reads_little_endian() {
+        let data = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        assert_eq!(read_offset(&data, 0, 2).unwrap(), 0x2211);
+        assert_eq!(read_offset(&data, 0, 4).unwrap(), 0x4433_2211);
+        assert_eq!(read_offset(&data, 0, 8).unwrap(), 0x8877_6655_4433_2211);
+        assert_eq!(read_length(&data, 0, 4).unwrap(), 0x4433_2211);
+        assert_eq!(read_uint_width(&data, 0, 1).unwrap(), 0x11);
+        // Reading at a non-zero position uses that position's bytes, not the
+        // buffer's first ones — a `read_le` that ignored `pos` would still pass
+        // every assertion above.
+        assert_eq!(read_offset(&data, 2, 2).unwrap(), 0x4433);
+    }
+
+    #[test]
+    fn a_file_address_of_width_one_is_refused_where_a_flag_width_is_not() {
+        // The distinction the two names exist to hold: 1 is a legal flag width
+        // and a malformed size-of-offsets.
+        let data = [0xABu8; 8];
+        assert_eq!(
+            read_offset(&data, 0, 1).unwrap_err(),
+            FormatError::InvalidOffsetSize(1)
+        );
+        assert_eq!(read_uint_width(&data, 0, 1).unwrap(), 0xAB);
+    }
+
+    #[test]
+    fn an_unsupported_width_names_the_field_it_came_from() {
+        let data = [0u8; 8];
+        assert_eq!(
+            read_offset(&data, 0, 3).unwrap_err(),
+            FormatError::InvalidOffsetSize(3)
+        );
+        assert_eq!(
+            read_length(&data, 0, 3).unwrap_err(),
+            FormatError::InvalidLengthSize(3)
+        );
+        assert_eq!(
+            read_uint_width(&data, 0, 3).unwrap_err(),
+            FormatError::InvalidOffsetSize(3)
+        );
+    }
+
+    #[test]
+    fn width_is_validated_before_the_bound_is_checked() {
+        // An empty buffer would fail `ensure_len` for any width, so checking the
+        // bound first would report EOF and hide the real defect (the width).
+        let err = read_offset(&[], 0, 3).unwrap_err();
+        assert_eq!(err, FormatError::InvalidOffsetSize(3));
+    }
+
+    #[test]
+    fn the_all_ones_sentinel_is_undefined_at_each_width() {
+        let ones = [0xFFu8; 8];
+        assert!(is_undefined_at(&ones, 0, 2));
+        assert!(is_undefined_at(&ones, 0, 4));
+        assert!(is_undefined_at(&ones, 0, 8));
+
+        // One byte short of the sentinel is a real address.
+        let mut nearly = [0xFFu8; 8];
+        nearly[0] = 0xFE;
+        assert!(!is_undefined_at(&nearly, 0, 8));
+    }
+
+    #[test]
+    fn an_unreadable_address_is_not_reported_as_undefined() {
+        // Past the end, and an unsupported width: both read as "there is an
+        // address here", leaving the error to the read that follows.
+        let ones = [0xFFu8; 8];
+        assert!(!is_undefined_at(&ones, 4, 8));
+        assert!(!is_undefined_at(&ones, 0, 3));
+    }
+}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -50,17 +50,43 @@ pub(crate) fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<()
 ///
 /// The width is assumed already validated; the caller-facing wrappers below own
 /// the "which widths are legal here" decision and the error that reports it.
+///
+/// Written as a match over fixed-size arrays rather than a loop over `width`
+/// bytes. A loop whose trip count is the runtime `width` keeps its per-byte
+/// bounds check and a live panic edge — LLVM cannot use the `ensure_len` that
+/// ran immediately above, because the index is not a constant — so an 8-byte
+/// address costs eight loads and eight branches. Each arm here hands
+/// `from_le_bytes` a constant-length array, which compiles to one load.
 #[inline]
 fn read_le(data: &[u8], pos: usize, width: u8) -> u64 {
-    debug_assert!(
-        matches!(width, 1 | 2 | 4 | 8),
-        "width validated by the caller"
-    );
-    let mut acc: u64 = 0;
-    for i in (0..width as usize).rev() {
-        acc = (acc << 8) | u64::from(data[pos + i]);
+    match width {
+        1 => u64::from(data[pos]),
+        2 => u64::from(u16::from_le_bytes([data[pos], data[pos + 1]])),
+        4 => u64::from(u32::from_le_bytes([
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+        ])),
+        8 => u64::from_le_bytes([
+            data[pos],
+            data[pos + 1],
+            data[pos + 2],
+            data[pos + 3],
+            data[pos + 4],
+            data[pos + 5],
+            data[pos + 6],
+            data[pos + 7],
+        ]),
+        // Unreachable: all three callers `matches!` the width against their own
+        // legal set before calling. Not `unreachable!()`, which would make a
+        // future fourth caller's omission a panic in a parser rather than an
+        // error; the `debug_assert` catches it in the tests instead.
+        _ => {
+            debug_assert!(false, "width validated by the caller");
+            0
+        }
     }
-    acc
 }
 
 /// Read a file address of `offset_size` bytes at `pos`.
@@ -69,6 +95,7 @@ fn read_le(data: &[u8], pos: usize, width: u8) -> u64 {
 /// anything else is [`FormatError::InvalidOffsetSize`]. For the 1/2/4/8 widths
 /// that object header and link messages encode in a flag field, use
 /// [`read_uint_width`] instead.
+#[inline]
 pub(crate) fn read_offset(data: &[u8], pos: usize, offset_size: u8) -> Result<u64, FormatError> {
     if !matches!(offset_size, 2 | 4 | 8) {
         return Err(FormatError::InvalidOffsetSize(offset_size));
@@ -81,6 +108,7 @@ pub(crate) fn read_offset(data: &[u8], pos: usize, offset_size: u8) -> Result<u6
 ///
 /// Identical to [`read_offset`] but reports [`FormatError::InvalidLengthSize`],
 /// naming the "size of lengths" superblock field the width came from.
+#[inline]
 pub(crate) fn read_length(data: &[u8], pos: usize, length_size: u8) -> Result<u64, FormatError> {
     if !matches!(length_size, 2 | 4 | 8) {
         return Err(FormatError::InvalidLengthSize(length_size));
@@ -95,6 +123,15 @@ pub(crate) fn read_length(data: &[u8], pos: usize, length_size: u8) -> Result<u6
 /// This is the width an object header or link message encodes in a two-bit flag
 /// field, for a value that is a size or an index rather than a file address —
 /// so 1 is legal here and malformed in [`read_offset`].
+///
+/// Its error is [`FormatError::InvalidOffsetSize`], whose message names a
+/// superblock field this width did not come from and a legal set that excludes
+/// the 1 this function accepts. That contradicts the naming principle in the
+/// module doc above, and it stands because the arm is unreachable: both callers
+/// derive the width as `1 << (flags & 3)`, which is 1, 2, 4, or 8 by
+/// construction. Adding a public error variant for a case no input can reach
+/// would cost more than it states.
+#[inline]
 pub(crate) fn read_uint_width(data: &[u8], pos: usize, width: u8) -> Result<u64, FormatError> {
     if !matches!(width, 1 | 2 | 4 | 8) {
         return Err(FormatError::InvalidOffsetSize(width));
@@ -110,6 +147,7 @@ pub(crate) fn read_uint_width(data: &[u8], pos: usize, width: u8) -> Result<u64,
 /// per-module copies this replaces: every caller treats a `false` here as "there
 /// is an address to follow", and the read that follows reports the truncation
 /// with the position it actually failed at.
+#[inline]
 pub(crate) fn is_undefined_at(data: &[u8], pos: usize, offset_size: u8) -> bool {
     match read_offset(data, pos, offset_size) {
         Ok(addr) => is_undefined_addr(addr, offset_size),
@@ -137,6 +175,67 @@ mod tests {
         let data = [0u8; 16];
         let err = ensure_len(&data, usize::MAX - 1, 8).unwrap_err();
         assert!(matches!(err, FormatError::UnexpectedEof { .. }));
+    }
+
+    #[test]
+    fn the_eof_payload_reports_what_was_wanted_and_what_was_there() {
+        // The payload, not just the variant. Three differently-written copies
+        // fed this collapse and all three reported `pos + needed` against
+        // `data.len()`; asserting only the variant leaves the numbers free to
+        // drift, and they are what a caller debugging a truncated file reads.
+        let data = [0u8; 8];
+        assert_eq!(
+            ensure_len(&data, 6, 4).unwrap_err(),
+            FormatError::UnexpectedEof {
+                expected: 10,
+                available: 8,
+            }
+        );
+        // On overflow the sum saturates rather than wrapping into a small,
+        // plausible-looking `expected`.
+        assert_eq!(
+            ensure_len(&data, usize::MAX - 1, 8).unwrap_err(),
+            FormatError::UnexpectedEof {
+                expected: usize::MAX,
+                available: 8,
+            }
+        );
+        // A read reports the same payload its own bound check produced.
+        assert_eq!(
+            read_offset(&data, 6, 4).unwrap_err(),
+            FormatError::UnexpectedEof {
+                expected: 10,
+                available: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn ensure_len_of_nothing_past_the_end_is_still_out_of_range() {
+        // `offset > len` with `needed == 0`. The two bound formulations this
+        // collapse merged reach this answer by different routes, so it is worth
+        // pinning: an empty read at an impossible offset is not "fits".
+        let data = [0u8; 4];
+        assert!(ensure_len(&data, 4, 0).is_ok());
+        assert!(ensure_len(&data, 5, 0).is_err());
+    }
+
+    #[test]
+    fn every_helper_reads_every_width_it_accepts() {
+        // Each helper's full accepted set, not just the one width its call
+        // sites happen to use most: `read_uint_width` is otherwise only
+        // exercised at 1, and `read_length` at 4.
+        let data = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        for (width, expected) in [
+            (2u8, 0x2211u64),
+            (4, 0x4433_2211),
+            (8, 0x8877_6655_4433_2211),
+        ] {
+            assert_eq!(read_offset(&data, 0, width).unwrap(), expected);
+            assert_eq!(read_length(&data, 0, width).unwrap(), expected);
+            assert_eq!(read_uint_width(&data, 0, width).unwrap(), expected);
+        }
+        assert_eq!(read_uint_width(&data, 0, 1).unwrap(), 0x11);
     }
 
     #[test]

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use core::num::NonZeroUsize;
 
 use crate::btree_v1::btree_v1_node_header_size;
+use crate::bytes::read_offset;
 use crate::chunk_cache::ChunkCache;
 use crate::chunk_span::ChunkSpanReader;
 use crate::convert::{TryToUsize, nonzero_usize_from, slice_range, u32_from};
@@ -66,26 +67,6 @@ pub struct ChunkInfo {
     /// File address of the chunk data.
     pub address: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
 /// Size of a single key in a version 1 B-tree of type 1 (raw data chunks):
 /// `chunk_size(4) + filter_mask(4) + ndims * offset_size`. The `ndims` trailing
 /// offsets are the per-dimension scaled chunk coordinates (rank + 1 values, the

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -67,6 +67,7 @@ pub struct ChunkInfo {
     /// File address of the chunk data.
     pub address: u64,
 }
+
 /// Size of a single key in a version 1 B-tree of type 1 (raw data chunks):
 /// `chunk_size(4) + filter_mask(4) + ndims * offset_size`. The `ndims` trailing
 /// offsets are the per-dimension scaled chunk coordinates (rank + 1 values, the

--- a/src/data_layout.rs
+++ b/src/data_layout.rs
@@ -42,6 +42,7 @@ pub enum DataLayout {
         version: u8,
     },
 }
+
 impl DataLayout {
     /// Parse a data layout message from raw message bytes.
     ///

--- a/src/data_layout.rs
+++ b/src/data_layout.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::{ensure_len, is_undefined_at, read_length, read_offset};
 use crate::error::FormatError;
 
 /// Parsed HDF5 data layout message.
@@ -41,46 +42,6 @@ pub enum DataLayout {
         version: u8,
     },
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    ensure_len(data, pos, s)?;
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => {
-            return Err(FormatError::InvalidOffsetSize(size));
-        }
-    })
-}
-
-fn read_length(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    read_offset(data, pos, size)
-}
-
-/// Check if all bytes in a slice are 0xFF (undefined address).
-fn is_undefined(data: &[u8], pos: usize, size: u8) -> bool {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return false;
-    }
-    data[pos..pos + s].iter().all(|&b| b == 0xFF)
-}
-
 impl DataLayout {
     /// Parse a data layout message from raw message bytes.
     ///
@@ -118,7 +79,7 @@ impl DataLayout {
                 let os = offset_size as usize;
                 let ls = length_size as usize;
                 ensure_len(data, pos, os + ls)?;
-                let address = if is_undefined(data, pos, offset_size) {
+                let address = if is_undefined_at(data, pos, offset_size) {
                     None
                 } else {
                     Some(read_offset(data, pos, offset_size)?)
@@ -134,7 +95,7 @@ impl DataLayout {
                 // btree address first
                 let os = offset_size as usize;
                 ensure_len(data, p, os)?;
-                let btree_address = if is_undefined(data, p, offset_size) {
+                let btree_address = if is_undefined_at(data, p, offset_size) {
                     None
                 } else {
                     Some(read_offset(data, p, offset_size)?)
@@ -182,7 +143,7 @@ impl DataLayout {
                 let os = offset_size as usize;
                 let ls = length_size as usize;
                 ensure_len(data, pos, os + ls)?;
-                let address = if is_undefined(data, pos, offset_size) {
+                let address = if is_undefined_at(data, pos, offset_size) {
                     None
                 } else {
                     Some(read_offset(data, pos, offset_size)?)
@@ -248,7 +209,7 @@ impl DataLayout {
                                 data[p + 3],
                             ]));
                             p += 4;
-                            if is_undefined(data, p, offset_size) {
+                            if is_undefined_at(data, p, offset_size) {
                                 None
                             } else {
                                 Some(read_offset(data, p, offset_size)?)
@@ -256,7 +217,7 @@ impl DataLayout {
                         } else {
                             // just address(offset_size)
                             ensure_len(data, p, offset_size as usize)?;
-                            if is_undefined(data, p, offset_size) {
+                            if is_undefined_at(data, p, offset_size) {
                                 None
                             } else {
                                 Some(read_offset(data, p, offset_size)?)
@@ -266,7 +227,7 @@ impl DataLayout {
                     2 => {
                         // Implicit: just address
                         ensure_len(data, p, offset_size as usize)?;
-                        if is_undefined(data, p, offset_size) {
+                        if is_undefined_at(data, p, offset_size) {
                             None
                         } else {
                             Some(read_offset(data, p, offset_size)?)
@@ -276,7 +237,7 @@ impl DataLayout {
                         // Fixed Array: max_dblk_page_nelmts_bits(1) + address(offset_size)
                         ensure_len(data, p, 1 + offset_size as usize)?;
                         p += 1; // skip max_dblk_page_nelmts_bits
-                        if is_undefined(data, p, offset_size) {
+                        if is_undefined_at(data, p, offset_size) {
                             None
                         } else {
                             Some(read_offset(data, p, offset_size)?)
@@ -286,7 +247,7 @@ impl DataLayout {
                         // Extensible Array: 5 creation params + address(offset_size)
                         ensure_len(data, p, 5 + offset_size as usize)?;
                         p += 5; // skip EA creation parameters
-                        if is_undefined(data, p, offset_size) {
+                        if is_undefined_at(data, p, offset_size) {
                             None
                         } else {
                             Some(read_offset(data, p, offset_size)?)
@@ -296,7 +257,7 @@ impl DataLayout {
                         // B-tree v2: node_size(4) + split_percent(1) + merge_percent(1) + address
                         ensure_len(data, p, 6 + offset_size as usize)?;
                         p += 6;
-                        if is_undefined(data, p, offset_size) {
+                        if is_undefined_at(data, p, offset_size) {
                             None
                         } else {
                             Some(read_offset(data, p, offset_size)?)
@@ -305,7 +266,7 @@ impl DataLayout {
                     _ => {
                         // Unknown index type: try just address
                         ensure_len(data, p, offset_size as usize)?;
-                        if is_undefined(data, p, offset_size) {
+                        if is_undefined_at(data, p, offset_size) {
                             None
                         } else {
                             Some(read_offset(data, p, offset_size)?)

--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -29,6 +29,7 @@ pub struct Dataspace {
     /// Maximum dimension sizes, if present. `u64::MAX` means unlimited.
     pub max_dimensions: Option<Vec<u64>>,
 }
+
 impl Dataspace {
     /// Parse a dataspace message from raw message bytes.
     ///

--- a/src/dataspace.rs
+++ b/src/dataspace.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::{ensure_len, read_length};
 use crate::error::FormatError;
 
 /// Type of dataspace.
@@ -28,33 +29,6 @@ pub struct Dataspace {
     /// Maximum dimension sizes, if present. `u64::MAX` means unlimited.
     pub max_dimensions: Option<Vec<u64>>,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn read_length(data: &[u8], offset: usize, length_size: u8) -> Result<u64, FormatError> {
-    let s = length_size as usize;
-    ensure_len(data, offset, s)?;
-    let slice = &data[offset..offset + s];
-    Ok(match length_size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => {
-            return Err(FormatError::InvalidLengthSize(length_size));
-        }
-    })
-}
-
 impl Dataspace {
     /// Parse a dataspace message from raw message bytes.
     ///

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -341,6 +341,7 @@ impl fmt::Display for Datatype {
         }
     }
 }
+
 fn parse_string_padding(val: u8) -> Result<StringPadding, FormatError> {
     match val {
         0 => Ok(StringPadding::NullTerminate),

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -11,6 +11,7 @@ use core::num::{NonZeroU32, NonZeroUsize};
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::bytes::ensure_len;
 use crate::display::{DISPLAY_MAX_MEMBERS, Dims, EscapedName, QuotedBytes, write_elided};
 use crate::error::FormatError;
 
@@ -340,17 +341,6 @@ impl fmt::Display for Datatype {
         }
     }
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 fn parse_string_padding(val: u8) -> Result<StringPadding, FormatError> {
     match val {
         0 => Ok(StringPadding::NullTerminate),

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
-use crate::bytes::{is_undefined_at, read_offset};
+use crate::bytes::{is_undefined_at, read_length, read_offset};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
@@ -103,7 +103,7 @@ impl ExtensibleArrayHeader {
         // rounded-up-to-block-boundary slot count, which we do not need.
         let ls = length_size as usize;
         pos += 4 * ls; // skip [0]..[3]
-        let num_elements = read_offset(d, pos, length_size)?; // [4] max_idx_set
+        let num_elements = read_length(d, pos, length_size)?; // [4] max_idx_set
         pos += ls;
         pos += ls; // skip [5] nelmts
         let index_block_address = read_offset(d, pos, offset_size)?;

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -37,6 +37,7 @@ pub struct ExtensibleArrayHeader {
     /// Address of the index block.
     pub index_block_address: u64,
 }
+
 fn read_variable_length(data: &[u8], size: usize) -> Result<u64, FormatError> {
     if size > 8 || data.len() < size {
         return Err(FormatError::ChunkedReadError(

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
+use crate::bytes::{is_undefined_at, read_offset};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
@@ -36,34 +37,6 @@ pub struct ExtensibleArrayHeader {
     /// Address of the index block.
     pub index_block_address: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn is_undefined(data: &[u8], pos: usize, size: u8) -> bool {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return false;
-    }
-    data[pos..pos + s].iter().all(|&b| b == 0xFF)
-}
-
 fn read_variable_length(data: &[u8], size: usize) -> Result<u64, FormatError> {
     if size > 8 || data.len() < size {
         return Err(FormatError::ChunkedReadError(
@@ -280,7 +253,7 @@ fn read_element(
                 available: data.len(),
             });
         }
-        if is_undefined(data, pos, offset_size) {
+        if is_undefined_at(data, pos, offset_size) {
             return Ok((None, os));
         }
         let address = read_offset(data, pos, offset_size)?;
@@ -310,7 +283,7 @@ fn read_element(
                 available: data.len(),
             });
         }
-        if is_undefined(data, pos, offset_size) {
+        if is_undefined_at(data, pos, offset_size) {
             return Ok((None, elem_total));
         }
         let address = read_offset(data, pos, offset_size)?;

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, string::ToString, vec, vec::Vec};
 
+use crate::bytes::ensure_len;
 use crate::error::FormatError;
 
 /// Well-known filter IDs.
@@ -40,17 +41,6 @@ pub struct FilterPipeline {
     /// Ordered list of filters.
     pub filters: Vec<FilterDescription>,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 impl FilterPipeline {
     /// Parse a filter pipeline message from raw message bytes.
     pub fn parse(data: &[u8]) -> Result<FilterPipeline, FormatError> {

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -41,6 +41,7 @@ pub struct FilterPipeline {
     /// Ordered list of filters.
     pub filters: Vec<FilterDescription>,
 }
+
 impl FilterPipeline {
     /// Parse a filter pipeline message from raw message bytes.
     pub fn parse(data: &[u8]) -> Result<FilterPipeline, FormatError> {

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -26,6 +26,7 @@ pub struct FixedArrayHeader {
     /// Address of the data block.
     pub data_block_address: u64,
 }
+
 impl FixedArrayHeader {
     /// Parse a Fixed Array header from file data at the given offset.
     pub fn parse(

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
+use crate::bytes::{is_undefined_at, read_length, read_offset};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
@@ -25,38 +26,6 @@ pub struct FixedArrayHeader {
     /// Address of the data block.
     pub data_block_address: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn read_length(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    read_offset(data, pos, size)
-}
-
-fn is_undefined(data: &[u8], pos: usize, size: u8) -> bool {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return false;
-    }
-    data[pos..pos + s].iter().all(|&b| b == 0xFF)
-}
-
 impl FixedArrayHeader {
     /// Parse a Fixed Array header from file data at the given offset.
     pub fn parse(
@@ -221,7 +190,7 @@ fn parse_fa_element(
             available: block.len(),
         });
     }
-    if is_undefined(block, elem_pos, offset_size) {
+    if is_undefined_at(block, elem_pos, offset_size) {
         return Ok(None);
     }
     let address = read_offset(block, elem_pos, offset_size)?;

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -82,6 +82,7 @@ pub struct FractalHeapHeader {
     /// Total number of managed objects.
     pub managed_objects_count: u64,
 }
+
 /// Floor of the base-2 logarithm of `v` (0 for `v == 0`). The doubling-table
 /// block sizes are powers of two, so this is their exact log2; it mirrors
 /// HDF5's `H5VM_log2_gen`.

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -9,9 +9,8 @@ use byteorder::{ByteOrder, LittleEndian};
 use crate::btree_v2::{
     BTreeV2Header, BTreeV2Record, collect_btree_v2_records, collect_btree_v2_records_from_source,
 };
-use crate::bytes::{ensure_len, read_offset};
-use crate::convert::TryToUsize;
-use crate::convert::is_undefined_addr;
+use crate::bytes::{ensure_len, read_length, read_offset};
+use crate::convert::{TryToUsize, is_undefined_addr};
 use crate::error::FormatError;
 use crate::source::Source;
 
@@ -212,8 +211,8 @@ impl HugeObjectIndex {
         for record in records {
             let data = &record.data;
             let addr = read_offset(data, 0, offset_size)?;
-            let len = read_offset(data, os, length_size)?;
-            let id = read_offset(data, os + ls, length_size)?;
+            let len = read_length(data, os, length_size)?;
+            let id = read_length(data, os + ls, length_size)?;
             entries.push((id, addr, len));
         }
         entries.sort_unstable();
@@ -318,7 +317,7 @@ impl HeapObjectReader<'_> {
         {
             // The address and length are stored inline in the heap ID.
             let addr = read_offset(payload, 0, self.offset_size)?;
-            let len = read_offset(payload, self.offset_size as usize, self.length_size)?;
+            let len = read_length(payload, self.offset_size as usize, self.length_size)?;
             return Ok(HugeReference::Inline { addr, len });
         }
 
@@ -506,7 +505,7 @@ impl FractalHeapHeader {
         pos += skip_size;
 
         // managed_objects_count (length_size)
-        let managed_objects_count = read_offset(file_data, pos, length_size)?;
+        let managed_objects_count = read_length(file_data, pos, length_size)?;
         pos += ls;
 
         // huge_objects_size (length_size)
@@ -524,11 +523,11 @@ impl FractalHeapHeader {
         pos += 2;
 
         // starting_block_size (length_size)
-        let starting_block_size = read_offset(file_data, pos, length_size)?;
+        let starting_block_size = read_length(file_data, pos, length_size)?;
         pos += ls;
 
         // max_direct_block_size (length_size)
-        let max_direct_block_size = read_offset(file_data, pos, length_size)?;
+        let max_direct_block_size = read_length(file_data, pos, length_size)?;
         pos += ls;
 
         // max_heap_size (2)

--- a/src/fractal_heap.rs
+++ b/src/fractal_heap.rs
@@ -9,7 +9,9 @@ use byteorder::{ByteOrder, LittleEndian};
 use crate::btree_v2::{
     BTreeV2Header, BTreeV2Record, collect_btree_v2_records, collect_btree_v2_records_from_source,
 };
+use crate::bytes::{ensure_len, read_offset};
 use crate::convert::TryToUsize;
+use crate::convert::is_undefined_addr;
 use crate::error::FormatError;
 use crate::source::Source;
 
@@ -81,51 +83,6 @@ pub struct FractalHeapHeader {
     /// Total number of managed objects.
     pub managed_objects_count: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn is_undefined(val: u64, offset_size: u8) -> bool {
-    match offset_size {
-        2 => val == 0xFFFF,
-        4 => val == 0xFFFF_FFFF,
-        8 => val == 0xFFFF_FFFF_FFFF_FFFF,
-        _ => false,
-    }
-}
-
 /// Floor of the base-2 logarithm of `v` (0 for `v == 0`). The doubling-table
 /// block sizes are powers of two, so this is their exact log2; it mirrors
 /// HDF5's `H5VM_log2_gen`.
@@ -368,7 +325,7 @@ impl HeapObjectReader<'_> {
         // Indirect: the heap ID holds a B-tree key (the huge object ID); the
         // huge-objects v2 B-tree maps it to (address, length).
         let huge_id = read_var_le(payload);
-        if is_undefined(self.header.btree_huge_objects_address, self.offset_size) {
+        if is_undefined_addr(self.header.btree_huge_objects_address, self.offset_size) {
             return Err(FormatError::HugeObjectNotFound(huge_id));
         }
         Ok(HugeReference::Indexed(huge_id))
@@ -706,7 +663,7 @@ impl FractalHeapHeader {
         }
         let (heap_offset, obj_len) = self.decode_managed_id(id_bytes)?;
 
-        if is_undefined(self.root_block_address, offset_size) {
+        if is_undefined_addr(self.root_block_address, offset_size) {
             return Err(FormatError::UnexpectedEof {
                 expected: 1,
                 available: 0,
@@ -859,7 +816,7 @@ impl FractalHeapHeader {
                 // up-front above, so here every entry is a bare child address.
                 let child_addr = read_offset(block, pos, offset_size)?;
                 pos += offset_size as usize;
-                if !is_undefined(child_addr, offset_size) {
+                if !is_undefined_addr(child_addr, offset_size) {
                     let block_end = current_heap_offset.saturating_add(block_size);
                     if target_offset >= current_heap_offset && target_offset < block_end {
                         return Ok(Some(HeapChild::Direct {
@@ -882,7 +839,7 @@ impl FractalHeapHeader {
             for _col in 0..tw {
                 let child_addr = read_offset(block, pos, offset_size)?;
                 pos += offset_size as usize;
-                if !is_undefined(child_addr, offset_size) {
+                if !is_undefined_addr(child_addr, offset_size) {
                     let block_end = current_heap_offset.saturating_add(total_child_space);
                     if target_offset >= current_heap_offset && target_offset < block_end {
                         #[expect(
@@ -1022,7 +979,7 @@ impl FractalHeapHeader {
             return Err(FormatError::UnsupportedFilteredHeapObject);
         }
         let (heap_offset, obj_len) = self.decode_managed_id(id_bytes)?;
-        if is_undefined(self.root_block_address, offset_size) {
+        if is_undefined_addr(self.root_block_address, offset_size) {
             return Err(FormatError::UnexpectedEof {
                 expected: 1,
                 available: 0,

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::read_length;
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -31,31 +32,6 @@ pub struct GlobalHeapObjectInfo {
     /// Object payload size in bytes.
     pub size: u64,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn read_length(data: &[u8], offset: usize, length_size: u8) -> Result<u64, FormatError> {
-    let s = length_size as usize;
-    ensure_len(data, offset, s)?;
-    let slice = &data[offset..offset + s];
-    Ok(match length_size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidLengthSize(length_size)),
-    })
-}
-
 /// Round up to next multiple of 8.
 #[cfg(test)]
 fn pad8(x: usize) -> usize {

--- a/src/global_heap.rs
+++ b/src/global_heap.rs
@@ -32,6 +32,7 @@ pub struct GlobalHeapObjectInfo {
     /// Object payload size in bytes.
     pub size: u64,
 }
+
 /// Round up to next multiple of 8.
 #[cfg(test)]
 fn pad8(x: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ pub(crate) mod attribute_info;
 pub(crate) mod btree_v1;
 pub(crate) mod btree_v2;
 pub(crate) mod btree_v2_write;
+pub(crate) mod bytes;
 pub(crate) mod checksum;
 pub(crate) mod chunk_cache;
 pub(crate) mod chunk_span;

--- a/src/link_info.rs
+++ b/src/link_info.rs
@@ -1,5 +1,7 @@
 //! HDF5 Link Info message parsing (message type 0x0002).
 
+use crate::bytes::{ensure_len, read_offset};
+use crate::convert::is_undefined_addr;
 use crate::error::FormatError;
 
 /// Parsed Link Info message from a v2 group object header.
@@ -14,51 +16,6 @@ pub struct LinkInfoMessage {
     /// Address of B-tree v2 for creation-order link index.
     pub btree_creation_order_address: Option<u64>,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn is_undefined(val: u64, offset_size: u8) -> bool {
-    match offset_size {
-        2 => val == 0xFFFF,
-        4 => val == 0xFFFF_FFFF,
-        8 => val == 0xFFFF_FFFF_FFFF_FFFF,
-        _ => false,
-    }
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 impl LinkInfoMessage {
     /// Parse a Link Info message from raw message data.
     pub fn parse(data: &[u8], offset_size: u8) -> Result<LinkInfoMessage, FormatError> {
@@ -95,7 +52,7 @@ impl LinkInfoMessage {
 
         let fh_addr = read_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let fractal_heap_address = if is_undefined(fh_addr, offset_size) {
+        let fractal_heap_address = if is_undefined_addr(fh_addr, offset_size) {
             None
         } else {
             Some(fh_addr)
@@ -103,7 +60,7 @@ impl LinkInfoMessage {
 
         let btree_addr = read_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let btree_name_index_address = if is_undefined(btree_addr, offset_size) {
+        let btree_name_index_address = if is_undefined_addr(btree_addr, offset_size) {
             None
         } else {
             Some(btree_addr)
@@ -111,7 +68,7 @@ impl LinkInfoMessage {
 
         let btree_creation_order_address = if has_creation_order_index {
             let addr = read_offset(data, pos, offset_size)?;
-            if is_undefined(addr, offset_size) {
+            if is_undefined_addr(addr, offset_size) {
                 None
             } else {
                 Some(addr)

--- a/src/link_info.rs
+++ b/src/link_info.rs
@@ -16,6 +16,7 @@ pub struct LinkInfoMessage {
     /// Address of B-tree v2 for creation-order link index.
     pub btree_creation_order_address: Option<u64>,
 }
+
 impl LinkInfoMessage {
     /// Parse a Link Info message from raw message data.
     pub fn parse(data: &[u8], offset_size: u8) -> Result<LinkInfoMessage, FormatError> {

--- a/src/link_message.rs
+++ b/src/link_message.rs
@@ -34,6 +34,7 @@ pub struct LinkMessage {
     /// Character set of the link name.
     pub charset: CharacterSet,
 }
+
 impl LinkMessage {
     /// Serialize link message to HDF5 message bytes.
     pub fn serialize(&self, offset_size: u8) -> Vec<u8> {

--- a/src/link_message.rs
+++ b/src/link_message.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
+use crate::bytes::{ensure_len, read_offset, read_uint_width};
 use crate::convert::TryToUsize;
 use crate::datatype::CharacterSet;
 use crate::error::FormatError;
@@ -33,45 +34,6 @@ pub struct LinkMessage {
     /// Character set of the link name.
     pub charset: CharacterSet,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        1 => data[pos] as u64,
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => {
-            return Err(FormatError::InvalidOffsetSize(size));
-        }
-    })
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 impl LinkMessage {
     /// Serialize link message to HDF5 message bytes.
     pub fn serialize(&self, offset_size: u8) -> Vec<u8> {
@@ -273,7 +235,7 @@ impl LinkMessage {
         };
 
         // Link name length
-        let name_len = read_offset(data, pos, name_size_field_width)?.to_usize()?;
+        let name_len = read_uint_width(data, pos, name_size_field_width)?.to_usize()?;
         pos += name_size_field_width as usize;
 
         // Link name

--- a/src/local_heap.rs
+++ b/src/local_heap.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 
-use crate::bytes::read_offset;
+use crate::bytes::{read_length, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -57,9 +57,9 @@ impl LocalHeap {
         }
 
         let mut pos = offset + 8;
-        let data_segment_size = read_offset(file_data, pos, length_size)?;
+        let data_segment_size = read_length(file_data, pos, length_size)?;
         pos += ls;
-        let free_list_head_offset = read_offset(file_data, pos, length_size)?;
+        let free_list_head_offset = read_length(file_data, pos, length_size)?;
         pos += ls;
         let data_segment_address = read_offset(file_data, pos, offset_size)?;
 

--- a/src/local_heap.rs
+++ b/src/local_heap.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 
+use crate::bytes::read_offset;
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -19,32 +20,6 @@ pub struct LocalHeap {
     /// File address of the data segment.
     pub data_segment_address: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    // `pos` is derived from a crafted file address, so `pos + s` can overflow
-    // `usize`; check the bound without wrapping (issue #140).
-    let end = pos.checked_add(s).ok_or(FormatError::UnexpectedEof {
-        expected: usize::MAX,
-        available: data.len(),
-    })?;
-    if end > data.len() {
-        return Err(FormatError::UnexpectedEof {
-            expected: end,
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..end];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
 impl LocalHeap {
     /// Parse a local heap header at the given offset in the file data.
     pub fn parse(

--- a/src/local_heap.rs
+++ b/src/local_heap.rs
@@ -20,6 +20,7 @@ pub struct LocalHeap {
     /// File address of the data segment.
     pub data_segment_address: u64,
 }
+
 impl LocalHeap {
     /// Parse a local heap header at the given offset in the file data.
     pub fn parse(

--- a/src/object_header.rs
+++ b/src/object_header.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::bytes::{ensure_len, read_length, read_offset, read_uint_width};
 use crate::convert::{TryToUsize, slice_range};
 use crate::error::FormatError;
 use crate::message_type::MessageType;
@@ -73,32 +74,6 @@ pub struct ObjectHeader {
     /// Birth time (v2, when flags bit 2 set).
     pub birth_time: Option<u32>,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    ensure_len(data, pos, s)?;
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => LittleEndian::read_u16(slice) as u64,
-        4 => LittleEndian::read_u32(slice) as u64,
-        8 => LittleEndian::read_u64(slice),
-        1 => slice[0] as u64,
-        _ => {
-            return Err(FormatError::InvalidOffsetSize(size));
-        }
-    })
-}
-
 impl ObjectHeader {
     /// Parse an object header at the given offset in the data buffer.
     ///
@@ -231,7 +206,7 @@ impl ObjectHeader {
                     let cont_offset_raw = read_offset(cont_msg_data, 0, offset_size)?;
                     let cont_offset = slice_range(cont_offset_raw, base_address)?.end;
                     let cont_length =
-                        read_offset(cont_msg_data, offset_size as usize, length_size)?
+                        read_length(cont_msg_data, offset_size as usize, length_size)?
                             .to_usize()?;
                     // Parse continuation block (v1: just raw messages, no signature)
                     let cont_msgs = Self::parse_v1_continuation(
@@ -317,7 +292,7 @@ impl ObjectHeader {
                     let cont_offset_raw = read_offset(cont_msg_data, 0, offset_size)?;
                     let cont_offset = slice_range(cont_offset_raw, base_address)?.end;
                     let cont_length =
-                        read_offset(cont_msg_data, offset_size as usize, length_size)?
+                        read_length(cont_msg_data, offset_size as usize, length_size)?
                             .to_usize()?;
                     let cont_msgs = Self::parse_v1_continuation(
                         data,
@@ -383,7 +358,7 @@ impl ObjectHeader {
             _ => unreachable!(),
         };
         ensure_len(data, pos, chunk_size_width as usize)?;
-        let chunk0_size = read_offset(data, pos, chunk_size_width)?.to_usize()?;
+        let chunk0_size = read_uint_width(data, pos, chunk_size_width)?.to_usize()?;
         pos += chunk_size_width as usize;
 
         let chunk0_msg_start = pos;
@@ -507,7 +482,7 @@ impl ObjectHeader {
                 // past 4 GiB on a 32-bit host.
                 if msg_data.len() >= (offset_size as usize + length_size as usize) {
                     let cont_off = read_offset(&msg_data, 0, offset_size)?;
-                    let cont_len = read_offset(&msg_data, offset_size as usize, length_size)?;
+                    let cont_len = read_length(&msg_data, offset_size as usize, length_size)?;
                     continuations.push((cont_off, cont_len));
                 }
             } else if msg_type != MessageType::Nil {
@@ -659,7 +634,7 @@ impl ObjectHeader {
             _ => unreachable!(),
         };
         ensure_len(&head, pos, chunk_size_width as usize)?;
-        let chunk0_size = read_offset(&head, pos, chunk_size_width)?.to_usize()?;
+        let chunk0_size = read_uint_width(&head, pos, chunk_size_width)?.to_usize()?;
         pos += chunk_size_width as usize;
         let prefix_len = pos;
 
@@ -835,7 +810,7 @@ impl ObjectHeader {
                 && msg_data.len() >= (offset_size as usize + length_size as usize)
             {
                 let off_raw = read_offset(&msg_data, 0, offset_size)?;
-                let len = read_offset(&msg_data, offset_size as usize, length_size)?;
+                let len = read_length(&msg_data, offset_size as usize, length_size)?;
                 Some((off_raw, len))
             } else {
                 None

--- a/src/object_header.rs
+++ b/src/object_header.rs
@@ -74,6 +74,7 @@ pub struct ObjectHeader {
     /// Birth time (v2, when flags bit 2 set).
     pub birth_time: Option<u32>,
 }
+
 impl ObjectHeader {
     /// Parse an object header at the given offset in the data buffer.
     ///

--- a/src/shared_message.rs
+++ b/src/shared_message.rs
@@ -21,6 +21,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
+use crate::bytes::{ensure_len, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::message_type::MessageType;
@@ -64,42 +65,6 @@ pub struct SharedMessageRef {
     /// Where the referenced message lives.
     pub location: SharedLocation,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    Ok(match size {
-        2 => u16::from_le_bytes([data[pos], data[pos + 1]]) as u64,
-        4 => u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as u64,
-        8 => u64::from_le_bytes([
-            data[pos],
-            data[pos + 1],
-            data[pos + 2],
-            data[pos + 3],
-            data[pos + 4],
-            data[pos + 5],
-            data[pos + 6],
-            data[pos + 7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
-fn ensure_len(data: &[u8], pos: usize, needed: usize) -> Result<(), FormatError> {
-    match pos.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
 /// Check whether a header message record has its shared flag set.
 pub fn is_shared(msg_flags: u8) -> bool {
     msg_flags & 0x02 != 0

--- a/src/shared_message.rs
+++ b/src/shared_message.rs
@@ -65,6 +65,7 @@ pub struct SharedMessageRef {
     /// Where the referenced message lives.
     pub location: SharedLocation,
 }
+
 /// Check whether a header message record has its shared flag set.
 pub fn is_shared(msg_flags: u8) -> bool {
     msg_flags & 0x02 != 0

--- a/src/source.rs
+++ b/src/source.rs
@@ -46,11 +46,19 @@
 //!
 //! # How the reader uses this (issue #27)
 //!
-//! The staged migration this module was built for has landed. The data readers
-//! fetch each chunk through [`Source::read_at`] rather than slicing a whole-file
-//! buffer; the metadata parsers read each bounded structure into a small buffer
-//! on demand; and [`crate::File::open_streaming`] constructs a file backed by a
+//! The staged migration this module was built for has landed far enough to
+//! carry a streaming reader: the data readers fetch each chunk through
+//! [`Source::read_at`] rather than slicing a whole-file buffer, and
+//! [`crate::File::open_streaming`] constructs a file backed by a
 //! [`ReadSeekSource`], so opening one no longer implies buffering it.
+//!
+//! The metadata parsers are the part that is only half done. Each one that a
+//! streaming read reaches has a `*_from_source` twin that reads its bounded
+//! structure into a small buffer on demand, but the whole-file `&[u8]` form
+//! remains beside it for the buffered path — `ObjectHeader::parse` next to
+//! `parse_from_source`, and the same shape in `btree_v1` and `superblock`. The
+//! two are what the duplication survey counted as 47 twins; collapsing them is
+//! separate work from this module.
 //!
 //! One piece of the original plan arrived in a different shape. It called for a
 //! `Cursor<'a>` over a `&'a dyn Source` to absorb the `read_offset` /

--- a/src/source.rs
+++ b/src/source.rs
@@ -44,38 +44,22 @@
 //! mmap (map/unmap sub-ranges) or plain `Read + Seek` works there. It is left
 //! out for now rather than adding a dependency speculatively.
 //!
-//! # Migration plan (this is the first increment)
+//! # How the reader uses this (issue #27)
 //!
-//! The reader is not yet ported onto `Source`; that is a staged effort
-//! tracked by issue #27. This module is the foundation the later stages build
-//! on. The intended path, smallest-risk first:
+//! The staged migration this module was built for has landed. The data readers
+//! fetch each chunk through [`Source::read_at`] rather than slicing a whole-file
+//! buffer; the metadata parsers read each bounded structure into a small buffer
+//! on demand; and [`crate::File::open_streaming`] constructs a file backed by a
+//! [`ReadSeekSource`], so opening one no longer implies buffering it.
 //!
-//! 1. **Foundation (this commit).** Land the trait + in-memory and `Read+Seek`
-//!    backends + tests. Nothing in the existing reader changes, so there is no
-//!    risk to the current in-memory path.
-//! 2. **A cursor.** Introduce a small `Cursor<'a>` over a `&'a dyn Source`
-//!    that offers the `read_offset` / `read_length` / "give me bytes at
-//!    `[off, off+len)`" idioms the parsers already use, with the checked
-//!    [`crate::convert`] conversions built in. The ~15 duplicated per-module
-//!    `read_offset` helpers collapse into it.
-//! 3. **Bulk path first.** Port the contiguous and chunked **data** readers
-//!    (`data_read`, `chunked_read`, `parallel_read`) to fetch each chunk via
-//!    [`Source::read_at`] instead of slicing the whole-file buffer. This is
-//!    self-contained (a chunk is already `{address, size}`) and captures most of
-//!    the memory win, since the data payload is what is actually large. The
-//!    zero-copy `&'a [u8]` return of `data_read::read_raw_data_zerocopy` becomes
-//!    an owned `Vec<u8>` / `Cow` here, since a window may be evicted.
-//! 4. **Metadata parsers.** Migrate the remaining ~56 functions that take a
-//!    whole-file `&[u8]` to borrow the cursor, reading each bounded structure
-//!    into a small buffer on demand.
-//! 5. **Entry point.** Add `File::open_streaming` / `File::from_source` that
-//!    construct a [`crate::File`] backed by a [`ReadSeekSource`], plus SWMR
-//!    `refresh` over a live streaming handle (the consistent-snapshot semantics
-//!    need care over a source that is being appended to).
-//!
-//! Until step 5 lands, opening a file still buffers it; this module is the
-//! building block that makes the staged migration possible without a single
-//! risky rewrite.
+//! One piece of the original plan arrived in a different shape. It called for a
+//! `Cursor<'a>` over a `&'a dyn Source` to absorb the `read_offset` /
+//! `read_length` idioms and collapse the duplicated per-module copies of them.
+//! What those copies had in common turned out to be the *decoding*, not the
+//! fetching: a parser reads its structure into a buffer first, and then every
+//! module was reading little-endian fields out of that buffer the same way. So
+//! the collapse is [`crate::bytes`], which operates on the buffer, and a cursor
+//! over the source itself was not needed to get it.
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -49,6 +49,7 @@ pub struct Superblock {
     /// CRC32C checksum (v2/v3 only).
     pub checksum: Option<u32>,
 }
+
 fn validate_sizes(offset_size: u8, length_size: u8) -> Result<(), FormatError> {
     if !matches!(offset_size, 2 | 4 | 8) {
         return Err(FormatError::InvalidOffsetSize(offset_size));
@@ -58,6 +59,7 @@ fn validate_sizes(offset_size: u8, length_size: u8) -> Result<(), FormatError> {
     }
     Ok(())
 }
+
 impl Superblock {
     /// Serialize this superblock to bytes.
     ///

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 
 use byteorder::{ByteOrder, LittleEndian};
 
+use crate::bytes::{ensure_len, read_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::signature::HDF5_SIGNATURE;
@@ -48,25 +49,6 @@ pub struct Superblock {
     /// CRC32C checksum (v2/v3 only).
     pub checksum: Option<u32>,
 }
-
-/// Read an unsigned integer of `size` bytes (LE) from `data` at `pos`.
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => LittleEndian::read_u16(slice) as u64,
-        4 => LittleEndian::read_u32(slice) as u64,
-        8 => LittleEndian::read_u64(slice),
-        _ => unreachable!(), // validated before calling
-    })
-}
-
 fn validate_sizes(offset_size: u8, length_size: u8) -> Result<(), FormatError> {
     if !matches!(offset_size, 2 | 4 | 8) {
         return Err(FormatError::InvalidOffsetSize(offset_size));
@@ -76,18 +58,6 @@ fn validate_sizes(offset_size: u8, length_size: u8) -> Result<(), FormatError> {
     }
     Ok(())
 }
-
-fn ensure_len(data: &[u8], needed: usize) -> Result<(), FormatError> {
-    if data.len() < needed {
-        Err(FormatError::UnexpectedEof {
-            expected: needed,
-            available: data.len(),
-        })
-    } else {
-        Ok(())
-    }
-}
-
 impl Superblock {
     /// Serialize this superblock to bytes.
     ///
@@ -155,7 +125,7 @@ impl Superblock {
     /// The signature must be present at the given offset.
     pub fn parse(data: &[u8], signature_offset: usize) -> Result<Superblock, FormatError> {
         let d = &data[signature_offset..];
-        ensure_len(d, 9)?; // signature(8) + version(1)
+        ensure_len(d, 0, 9)?; // signature(8) + version(1)
 
         // Verify signature
         if d[..8] != HDF5_SIGNATURE {
@@ -176,7 +146,7 @@ impl Superblock {
         // + shared_hdr_ver(1) + offset_size(1) + length_size(1) + reserved(1)
         // + group_leaf_k(2) + group_internal_k(2) + consistency_flags(4)
         // = 24 bytes before variable-sized fields
-        ensure_len(d, 24)?;
+        ensure_len(d, 0, 24)?;
 
         let offset_size = d[13];
         let length_size = d[14];
@@ -191,7 +161,7 @@ impl Superblock {
         let var_start = 24;
         let sym_entry_size = os + os + 4 + 4 + 16; // link_name_off, obj_hdr_addr, cache_type, reserved, scratch
         let total = var_start + 4 * os + sym_entry_size;
-        ensure_len(d, total)?;
+        ensure_len(d, 0, total)?;
 
         let mut pos = var_start;
         let base_address = read_offset(d, pos, offset_size)?;
@@ -235,7 +205,7 @@ impl Superblock {
         // + shared_hdr_ver(1) + offset_size(1) + length_size(1) + reserved(1)
         // + group_leaf_k(2) + group_internal_k(2) + consistency_flags(4)
         // + indexed_storage_k(2) + reserved(2) = 28
-        ensure_len(d, 28)?;
+        ensure_len(d, 0, 28)?;
 
         let offset_size = d[13];
         let length_size = d[14];
@@ -251,7 +221,7 @@ impl Superblock {
         let var_start = 28;
         let sym_entry_size = os + os + 4 + 4 + 16;
         let total = var_start + 4 * os + sym_entry_size;
-        ensure_len(d, total)?;
+        ensure_len(d, 0, total)?;
 
         let mut pos = var_start;
         let base_address = read_offset(d, pos, offset_size)?;
@@ -288,7 +258,7 @@ impl Superblock {
 
     fn parse_v2v3(d: &[u8], version: u8) -> Result<Superblock, FormatError> {
         // sig(8) + version(1) + offset_size(1) + length_size(1) + consistency_flags(1) = 12
-        ensure_len(d, 12)?;
+        ensure_len(d, 0, 12)?;
 
         let offset_size = d[9];
         let length_size = d[10];
@@ -298,7 +268,7 @@ impl Superblock {
         let os = offset_size as usize;
         // 4 addresses + checksum(4)
         let total = 12 + 4 * os + 4;
-        ensure_len(d, total)?;
+        ensure_len(d, 0, total)?;
 
         let mut pos = 12;
         let base_address = read_offset(d, pos, offset_size)?;

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::read_offset;
 use crate::error::FormatError;
 use crate::source::Source;
 
@@ -14,26 +15,6 @@ pub struct SymbolTableMessage {
     /// Address of the local heap for this group.
     pub local_heap_address: u64,
 }
-
-fn read_offset(data: &[u8], pos: usize, size: u8) -> Result<u64, FormatError> {
-    let s = size as usize;
-    if s > data.len() || pos > data.len() - s {
-        return Err(FormatError::UnexpectedEof {
-            expected: pos.saturating_add(s),
-            available: data.len(),
-        });
-    }
-    let slice = &data[pos..pos + s];
-    Ok(match size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(size)),
-    })
-}
-
 impl SymbolTableMessage {
     /// Parse a Symbol Table message from raw message data bytes.
     pub fn parse(data: &[u8], offset_size: u8) -> Result<SymbolTableMessage, FormatError> {

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -15,6 +15,7 @@ pub struct SymbolTableMessage {
     /// Address of the local heap for this group.
     pub local_heap_address: u64,
 }
+
 impl SymbolTableMessage {
     /// Parse a Symbol Table message from raw message data bytes.
     pub fn parse(data: &[u8], offset_size: u8) -> Result<SymbolTableMessage, FormatError> {

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -7,6 +7,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{format, string::String, vec::Vec};
 
+use crate::bytes::read_offset;
 use crate::convert::{TryToUsize, is_undefined_addr};
 use crate::datatype::{CharacterSet, Datatype};
 use crate::error::FormatError;
@@ -68,31 +69,6 @@ pub struct VlElement {
     /// Index of the object within the collection.
     pub object_index: u32,
 }
-
-fn ensure_len(data: &[u8], offset: usize, needed: usize) -> Result<(), FormatError> {
-    match offset.checked_add(needed) {
-        Some(end) if end <= data.len() => Ok(()),
-        _ => Err(FormatError::UnexpectedEof {
-            expected: offset.saturating_add(needed),
-            available: data.len(),
-        }),
-    }
-}
-
-fn read_offset(data: &[u8], pos: usize, offset_size: u8) -> Result<u64, FormatError> {
-    let s = offset_size as usize;
-    ensure_len(data, pos, s)?;
-    let slice = &data[pos..pos + s];
-    Ok(match offset_size {
-        2 => u16::from_le_bytes([slice[0], slice[1]]) as u64,
-        4 => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64,
-        8 => u64::from_le_bytes([
-            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
-        ]),
-        _ => return Err(FormatError::InvalidOffsetSize(offset_size)),
-    })
-}
-
 /// Parse VL global heap references from raw attribute/dataset data.
 pub fn parse_vl_references(
     raw_data: &[u8],

--- a/src/vl_data.rs
+++ b/src/vl_data.rs
@@ -69,6 +69,7 @@ pub struct VlElement {
     /// Index of the object within the collection.
     pub object_index: u32,
 }
+
 /// Parse VL global heap references from raw attribute/dataset data.
 pub fn parse_vl_references(
     raw_data: &[u8],


### PR DESCRIPTION
Every format module carried private copies of the same four byte-level read helpers: `read_offset` ×16, `ensure_len` ×15, `is_undefined` ×7, `read_length` ×4 — **42 definitions across 21 files**, several byte-identical. `source.rs` named this collapse as step 2 of the issue #27 plan and it never happened.

They now live in one `src/bytes.rs`: **687 lines of duplicated helpers deleted**, against 313 added in one place — of which 156 are tests and 75 are doc comments, so the actual shared implementation is **82 lines**. Net **-278** across 24 files.

## The copies disagreed three ways, and only one was a real distinction

**`local_heap`'s `checked_add` was not a stronger bounds check.** The other fifteen wrote `s > data.len() || pos > data.len() - s`, which already avoids the overflow by construction — the first clause is what makes the subtraction safe. One guarantee spelled two ways. (This is the variation I expected to be the risky one going in; it wasn't.)

**Width 1 is real, and it is a different concept.** `link_message` and `object_header` accept it because those sites read a variable-width integer whose width comes from a two-bit flag field — not a file address, which is 2, 4, or 8. That gets its own name, `read_uint_width`, rather than a `bool` parameter, so a caller cannot widen its own accepted set by reaching for the wrong helper.

**`superblock`'s `unreachable!()`** becomes a returned `InvalidOffsetSize`. `validate_sizes` still rejects such a width upstream, so the arm stays unreachable in practice — it just stops being a panic if that ever ceases to be true.

## Separating the names found two misnamings — not bugs

An earlier revision of this description called these latent bugs. They are not reachable, and the distinction matters for how much scrutiny they deserve:

- **14 call sites read a length through `read_offset`**, so a malformed size-of-lengths field reported `FormatError::InvalidOffsetSize`, naming the wrong superblock field. In `object_header` (4), `fractal_heap` (6), `local_heap` (2), `btree_v2` (1) and `extensible_array` (1) — three of them directly under a comment naming the width being passed. All now use `read_length`.
- The `object_header` sites that genuinely read addresses were accepting a width of 1.

**Neither can fire.** `offset_size` and `length_size` reach these parsers only from a superblock whose `validate_sizes` has already constrained both to 2/4/8, and `ObjectHeader` is `pub(crate)` with every in-crate caller passing superblock values. So `read_offset` and `read_length` are behaviorally identical on every input this crate accepts, and the width-1 rejection is unreachable.

The consequence for review: **nothing pins these 14 changes.** Reverting all of them passes the full suite, and no test could catch it through the public API. They are worth making because the next person to read `read_offset(data, pos, length_size)` should not have to work out whether it is a mistake — but they are a naming improvement, not a fix.

## The five functions

| function | widths | on a bad width |
| --- | --- | --- |
| `ensure_len(data, offset, needed)` | — | `UnexpectedEof` |
| `read_offset(data, pos, offset_size)` | 2/4/8 | `InvalidOffsetSize` |
| `read_length(data, pos, length_size)` | 2/4/8 | `InvalidLengthSize` |
| `read_uint_width(data, pos, width)` | 1/2/4/8 | `InvalidOffsetSize` |
| `is_undefined_at(data, pos, offset_size)` | 2/4/8 | `false` |

`is_undefined_at` reads the address and defers to the existing `convert::is_undefined_addr`. The seven copies it replaces were of two shapes: three already took a `u64` and map directly onto `is_undefined_addr`; four tested "all bytes are `0xFF`" over a slice, which is identical to the numeric comparison for widths 2/4/8. For other widths those four returned `true` where this returns `false` — meaning "there is an address here", leaving the read that follows to report the truncation. Unreachable either way, since the width comes from a superblock field `validate_sizes` constrains.

`ensure_len` keeps the `checked_add` formulation, so a file-derived offset near `usize::MAX` reports the truncation instead of wrapping into a valid-looking range (issue #140).

## `source.rs`

Its migration plan described this collapse as future work, named the `parallel_read` module deleted in #280, and claimed opening a file still buffers it — all three now false. It has been rewritten to describe what exists, including why the `Cursor` it specified arrived as a buffer decoder instead: what the duplicated copies shared was the *decoding*, not the fetching, so the collapse did not need a cursor over the source to happen.

## `read_le` decodes with a match, not a loop

Worth flagging because the obvious spelling is wrong here. A loop over `width` bytes keeps its per-byte bounds check and a live panic edge: LLVM cannot use the `ensure_len` that ran immediately above, because the loop index is not a constant. An 8-byte address compiles to eight loads and eight branches where the sixteen `from_le_bytes` calls this replaces compiled to a single `ldr`. Each match arm hands `from_le_bytes` a constant-length array instead, and the four wrappers are `#[inline]` — the module-local copies were freely inlinable, and these would otherwise be cross-CGU calls in release.

Strictly less work than the loop, so per `CLAUDE.md` it is gated on the tests rather than on a benchmark.

## Verification

Full gate green: **2054 tests** (2043 + 11 new), 45 doctests, `cargo fmt --check`, clippy and rustdoc under `-D warnings`.

The new tests are mutation-verified, each mutation failing exactly one test:

| mutation | fails |
| --- | --- |
| `read_le` ignores `pos` | `each_supported_width_reads_little_endian` |
| `read_offset` checks the bound before the width | `width_is_validated_before_the_bound_is_checked` |
| `ensure_len` reports `expected: 0` | `the_eof_payload_reports_what_was_wanted_and_what_was_there` |

That last one exists because the first revision asserted only the error *variant*, so the payload — the thing three differently-written copies had to agree on, and what a caller debugging a truncated file actually reads — was free to drift.

No changelog entry: this is an internal collapse with no capability change and, as set out above, no reachable behavior difference.
