### PR TITLE
Collapse the optional-address reads into one `read_optional_offset`

### DIFF
--- a/src/attribute_info.rs
+++ b/src/attribute_info.rs
@@ -3,8 +3,7 @@
 //! The Attribute Info message describes dense attribute storage: a fractal heap
 //! and B-tree v2 indexes for attribute lookup by name or creation order.
 
-use crate::bytes::{ensure_len, read_offset};
-use crate::convert::is_undefined_addr;
+use crate::bytes::{ensure_len, read_optional_offset};
 use crate::error::FormatError;
 
 /// Parsed Attribute Info message from an object header.
@@ -49,29 +48,14 @@ impl AttributeInfoMessage {
             None
         };
 
-        let fh_addr = read_offset(data, pos, offset_size)?;
+        let fractal_heap_address = read_optional_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let fractal_heap_address = if is_undefined_addr(fh_addr, offset_size) {
-            None
-        } else {
-            Some(fh_addr)
-        };
 
-        let btree_addr = read_offset(data, pos, offset_size)?;
+        let btree_name_index_address = read_optional_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let btree_name_index_address = if is_undefined_addr(btree_addr, offset_size) {
-            None
-        } else {
-            Some(btree_addr)
-        };
 
         let btree_creation_order_address = if has_creation_order_index {
-            let addr = read_offset(data, pos, offset_size)?;
-            if is_undefined_addr(addr, offset_size) {
-                None
-            } else {
-                Some(addr)
-            }
+            read_optional_offset(data, pos, offset_size)?
         } else {
             None
         };

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::bytes::{is_undefined_at, read_offset};
+use crate::bytes::{read_offset, read_optional_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -77,17 +77,9 @@ impl BTreeV1Node {
         let entries_used = u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]);
 
         let mut pos = offset + BTREE_V1_NODE_PREFIX_LEN;
-        let left_sibling = if is_undefined_at(file_data, pos, offset_size) {
-            None
-        } else {
-            Some(read_offset(file_data, pos, offset_size)?)
-        };
+        let left_sibling = read_optional_offset(file_data, pos, offset_size)?;
         pos += os;
-        let right_sibling = if is_undefined_at(file_data, pos, offset_size) {
-            None
-        } else {
-            Some(read_offset(file_data, pos, offset_size)?)
-        };
+        let right_sibling = read_optional_offset(file_data, pos, offset_size)?;
         pos += os;
 
         // For type 0: keys are offset_size bytes, children are offset_size bytes

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -140,18 +140,26 @@ pub(crate) fn read_uint_width(data: &[u8], pos: usize, width: u8) -> Result<u64,
     Ok(read_le(data, pos, width))
 }
 
-/// True when the address stored at `pos` is the all-`0xFF` "undefined address"
-/// sentinel for a file whose size-of-offsets is `offset_size`.
+/// Read a file address of `offset_size` bytes at `pos`, as `None` when the file
+/// stored the all-`0xFF` "undefined address" sentinel there.
 ///
-/// Out-of-range or unsupported widths read as "not undefined", matching the
-/// per-module copies this replaces: every caller treats a `false` here as "there
-/// is an address to follow", and the read that follows reports the truncation
-/// with the position it actually failed at.
+/// The two outcomes a caller must not confuse are separated by the return type:
+/// `Ok(None)` is "the file says there is no address here", and an unreadable or
+/// mis-sized address is an `Err` naming the position it failed at. Every field
+/// this reads — a contiguous dataset's data address, a chunk index root, a
+/// B-tree v1 sibling, an array element — is optional in exactly that sense, and
+/// the sentinel is the format's way of writing the `None`.
 #[inline]
-pub(crate) fn is_undefined_at(data: &[u8], pos: usize, offset_size: u8) -> bool {
-    match read_offset(data, pos, offset_size) {
-        Ok(addr) => is_undefined_addr(addr, offset_size),
-        Err(_) => false,
+pub(crate) fn read_optional_offset(
+    data: &[u8],
+    pos: usize,
+    offset_size: u8,
+) -> Result<Option<u64>, FormatError> {
+    let addr = read_offset(data, pos, offset_size)?;
+    if is_undefined_addr(addr, offset_size) {
+        Ok(None)
+    } else {
+        Ok(Some(addr))
     }
 }
 
@@ -290,24 +298,47 @@ mod tests {
     }
 
     #[test]
-    fn the_all_ones_sentinel_is_undefined_at_each_width() {
+    fn the_all_ones_sentinel_reads_as_none_at_each_width() {
         let ones = [0xFFu8; 8];
-        assert!(is_undefined_at(&ones, 0, 2));
-        assert!(is_undefined_at(&ones, 0, 4));
-        assert!(is_undefined_at(&ones, 0, 8));
+        assert_eq!(read_optional_offset(&ones, 0, 2).unwrap(), None);
+        assert_eq!(read_optional_offset(&ones, 0, 4).unwrap(), None);
+        assert_eq!(read_optional_offset(&ones, 0, 8).unwrap(), None);
 
-        // One byte short of the sentinel is a real address.
+        // One byte short of the sentinel is a real address, and it is returned.
         let mut nearly = [0xFFu8; 8];
         nearly[0] = 0xFE;
-        assert!(!is_undefined_at(&nearly, 0, 8));
+        assert_eq!(
+            read_optional_offset(&nearly, 0, 8).unwrap(),
+            Some(0xFFFF_FFFF_FFFF_FFFE)
+        );
     }
 
     #[test]
-    fn an_unreadable_address_is_not_reported_as_undefined() {
-        // Past the end, and an unsupported width: both read as "there is an
-        // address here", leaving the error to the read that follows.
+    fn the_sentinel_is_the_width_the_caller_asked_for() {
+        // `0xFFFF` is the undefined address of a 2-byte file and an ordinary
+        // address in an 8-byte one. A check written against a fixed width would
+        // read the same bytes and disagree with the file it came from.
+        let mut data = [0u8; 8];
+        data[0] = 0xFF;
+        data[1] = 0xFF;
+        assert_eq!(read_optional_offset(&data, 0, 2).unwrap(), None);
+        assert_eq!(read_optional_offset(&data, 0, 8).unwrap(), Some(0xFFFF));
+    }
+
+    #[test]
+    fn an_unreadable_address_is_an_error_rather_than_a_none() {
+        // The distinction the return type exists to hold: `None` is what the
+        // file said, not what could not be read. Past the end and an
+        // unsupported width both report, so neither is silently a "no address
+        // here" that a caller would skip over.
         let ones = [0xFFu8; 8];
-        assert!(!is_undefined_at(&ones, 4, 8));
-        assert!(!is_undefined_at(&ones, 0, 3));
+        assert!(matches!(
+            read_optional_offset(&ones, 4, 8),
+            Err(FormatError::UnexpectedEof { .. })
+        ));
+        assert_eq!(
+            read_optional_offset(&ones, 0, 3).unwrap_err(),
+            FormatError::InvalidOffsetSize(3)
+        );
     }
 }

--- a/src/data_layout.rs
+++ b/src/data_layout.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::bytes::{ensure_len, is_undefined_at, read_length, read_offset};
+use crate::bytes::{ensure_len, read_length, read_optional_offset};
 use crate::error::FormatError;
 
 /// Parsed HDF5 data layout message.
@@ -80,11 +80,7 @@ impl DataLayout {
                 let os = offset_size as usize;
                 let ls = length_size as usize;
                 ensure_len(data, pos, os + ls)?;
-                let address = if is_undefined_at(data, pos, offset_size) {
-                    None
-                } else {
-                    Some(read_offset(data, pos, offset_size)?)
-                };
+                let address = read_optional_offset(data, pos, offset_size)?;
                 let size = read_length(data, pos + os, length_size)?;
                 Ok(DataLayout::Contiguous { address, size })
             }
@@ -96,11 +92,7 @@ impl DataLayout {
                 // btree address first
                 let os = offset_size as usize;
                 ensure_len(data, p, os)?;
-                let btree_address = if is_undefined_at(data, p, offset_size) {
-                    None
-                } else {
-                    Some(read_offset(data, p, offset_size)?)
-                };
+                let btree_address = read_optional_offset(data, p, offset_size)?;
                 p += os;
                 // chunk dim sizes: dimensionality × 4 bytes each
                 ensure_len(data, p, dimensionality * 4)?;
@@ -144,11 +136,7 @@ impl DataLayout {
                 let os = offset_size as usize;
                 let ls = length_size as usize;
                 ensure_len(data, pos, os + ls)?;
-                let address = if is_undefined_at(data, pos, offset_size) {
-                    None
-                } else {
-                    Some(read_offset(data, pos, offset_size)?)
-                };
+                let address = read_optional_offset(data, pos, offset_size)?;
                 let size = read_length(data, pos + os, length_size)?;
                 Ok(DataLayout::Contiguous { address, size })
             }
@@ -210,68 +198,40 @@ impl DataLayout {
                                 data[p + 3],
                             ]));
                             p += 4;
-                            if is_undefined_at(data, p, offset_size) {
-                                None
-                            } else {
-                                Some(read_offset(data, p, offset_size)?)
-                            }
+                            read_optional_offset(data, p, offset_size)?
                         } else {
                             // just address(offset_size)
                             ensure_len(data, p, offset_size as usize)?;
-                            if is_undefined_at(data, p, offset_size) {
-                                None
-                            } else {
-                                Some(read_offset(data, p, offset_size)?)
-                            }
+                            read_optional_offset(data, p, offset_size)?
                         }
                     }
                     2 => {
                         // Implicit: just address
                         ensure_len(data, p, offset_size as usize)?;
-                        if is_undefined_at(data, p, offset_size) {
-                            None
-                        } else {
-                            Some(read_offset(data, p, offset_size)?)
-                        }
+                        read_optional_offset(data, p, offset_size)?
                     }
                     3 => {
                         // Fixed Array: max_dblk_page_nelmts_bits(1) + address(offset_size)
                         ensure_len(data, p, 1 + offset_size as usize)?;
                         p += 1; // skip max_dblk_page_nelmts_bits
-                        if is_undefined_at(data, p, offset_size) {
-                            None
-                        } else {
-                            Some(read_offset(data, p, offset_size)?)
-                        }
+                        read_optional_offset(data, p, offset_size)?
                     }
                     4 => {
                         // Extensible Array: 5 creation params + address(offset_size)
                         ensure_len(data, p, 5 + offset_size as usize)?;
                         p += 5; // skip EA creation parameters
-                        if is_undefined_at(data, p, offset_size) {
-                            None
-                        } else {
-                            Some(read_offset(data, p, offset_size)?)
-                        }
+                        read_optional_offset(data, p, offset_size)?
                     }
                     5 => {
                         // B-tree v2: node_size(4) + split_percent(1) + merge_percent(1) + address
                         ensure_len(data, p, 6 + offset_size as usize)?;
                         p += 6;
-                        if is_undefined_at(data, p, offset_size) {
-                            None
-                        } else {
-                            Some(read_offset(data, p, offset_size)?)
-                        }
+                        read_optional_offset(data, p, offset_size)?
                     }
                     _ => {
                         // Unknown index type: try just address
                         ensure_len(data, p, offset_size as usize)?;
-                        if is_undefined_at(data, p, offset_size) {
-                            None
-                        } else {
-                            Some(read_offset(data, p, offset_size)?)
-                        }
+                        read_optional_offset(data, p, offset_size)?
                     }
                 };
 

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
-use crate::bytes::{is_undefined_at, read_length, read_offset};
+use crate::bytes::{read_length, read_offset, read_optional_offset};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
@@ -254,10 +254,9 @@ fn read_element(
                 available: data.len(),
             });
         }
-        if is_undefined_at(data, pos, offset_size) {
+        let Some(address) = read_optional_offset(data, pos, offset_size)? else {
             return Ok((None, os));
-        }
-        let address = read_offset(data, pos, offset_size)?;
+        };
         let offsets = index_to_chunk_offsets(linear_index, num_chunks_per_dim, chunk_dimensions);
         Ok((
             Some(ChunkInfo {
@@ -284,10 +283,9 @@ fn read_element(
                 available: data.len(),
             });
         }
-        if is_undefined_at(data, pos, offset_size) {
+        let Some(address) = read_optional_offset(data, pos, offset_size)? else {
             return Ok((None, elem_total));
-        }
-        let address = read_offset(data, pos, offset_size)?;
+        };
         let chunk_size = read_variable_length(&data[pos + os..], chunk_size_bytes)?;
         let fm_off = pos + os + chunk_size_bytes;
         let filter_mask = u32::from_le_bytes([

--- a/src/fixed_array.rs
+++ b/src/fixed_array.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
-use crate::bytes::{is_undefined_at, read_length, read_offset};
+use crate::bytes::{read_length, read_offset, read_optional_offset};
 use crate::chunked_read::ChunkInfo;
 use crate::convert::{TryToUsize, is_undefined_addr, u32_from};
 use crate::error::FormatError;
@@ -191,10 +191,9 @@ fn parse_fa_element(
             available: block.len(),
         });
     }
-    if is_undefined_at(block, elem_pos, offset_size) {
+    let Some(address) = read_optional_offset(block, elem_pos, offset_size)? else {
         return Ok(None);
-    }
-    let address = read_offset(block, elem_pos, offset_size)?;
+    };
     let offsets = index_to_chunk_offsets(index, num_chunks_per_dim, chunk_dimensions);
     if client_id == 0 {
         Ok(Some(ChunkInfo {

--- a/src/link_info.rs
+++ b/src/link_info.rs
@@ -1,7 +1,6 @@
 //! HDF5 Link Info message parsing (message type 0x0002).
 
-use crate::bytes::{ensure_len, read_offset};
-use crate::convert::is_undefined_addr;
+use crate::bytes::{ensure_len, read_optional_offset};
 use crate::error::FormatError;
 
 /// Parsed Link Info message from a v2 group object header.
@@ -51,29 +50,14 @@ impl LinkInfoMessage {
             None
         };
 
-        let fh_addr = read_offset(data, pos, offset_size)?;
+        let fractal_heap_address = read_optional_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let fractal_heap_address = if is_undefined_addr(fh_addr, offset_size) {
-            None
-        } else {
-            Some(fh_addr)
-        };
 
-        let btree_addr = read_offset(data, pos, offset_size)?;
+        let btree_name_index_address = read_optional_offset(data, pos, offset_size)?;
         pos += offset_size as usize;
-        let btree_name_index_address = if is_undefined_addr(btree_addr, offset_size) {
-            None
-        } else {
-            Some(btree_addr)
-        };
 
         let btree_creation_order_address = if has_creation_order_index {
-            let addr = read_offset(data, pos, offset_size)?;
-            if is_undefined_addr(addr, offset_size) {
-                None
-            } else {
-                Some(addr)
-            }
+            read_optional_offset(data, pos, offset_size)?
         } else {
             None
         };


### PR DESCRIPTION
Closes #282.

`bytes::read_optional_offset(data, pos, offset_size) -> Result<Option<u64>, FormatError>` replaces `is_undefined_at`, so `bytes` gains no in-crate surface. Net −52 lines across 7 files.

### More sites than the issue counted

The issue named 15, all of the shape `is_undefined_at` followed by `read_offset` of the same position, which decoded the address twice. There are 21. The other six are in `link_info.rs` and `attribute_info.rs`, written in the other order — read the address, then test the value with `convert::is_undefined_addr` — which is why a grep for `is_undefined_at` missed them. Converting those too drops the `is_undefined_addr` import from both files, and leaving them would have made the new helper look half-adopted right beside the pattern it exists for.

### The part worth more than the deduplication

The old shape ran two outcomes together. `is_undefined_at` answered `false` for an address it *could not read*, deferring the error to the read that followed:

```rust
let address = if is_undefined_at(data, pos, offset_size) {
    None
} else {
    Some(read_offset(data, pos, offset_size)?)
};
```

That was safe only because every caller did make that second read. One that did not would have taken a truncated address for a real one. The return type now separates the two: `Ok(None)` is what the file said, and an unreadable or mis-sized address is an `Err` naming the position it failed at.

No call site changes behavior — each already performed the follow-up read, so the same error surfaced before.

### Deliberately out of scope

The `if !is_undefined_addr(addr, ..)` guards in `fractal_heap`, `extensible_array`, and `vl_data` stay. They test an address already in hand inside a loop rather than one at a position, and threading an `Option` through a `continue` would add noise rather than remove it.

### Verification

Three new tests, each mutation-verified. The one worth naming: mutating the helper so an unreadable address silently becomes `None` fails **exactly one test out of 816** — the one added for it. The other 815 are blind to a parser that reads a truncated address as "no address here".

| gate | result |
| --- | --- |
| `cargo test --lib` | 816 pass |
| `cargo nextest run --all-features` | 2055 pass |
| `cargo test --all-features --doc` | 45 pass |
| fmt, clippy `-D warnings`, rustdoc, `no_std` | clean |

No changelog entry: internal only, no public API or behavior change, matching how #281 was handled.
