### PR TITLE
Create empty chunked and extensible datasets in an open_rw session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- A `File::open_rw` session can create an empty (zero-element) chunked or extensible dataset, so a schema-first writer declares its resizable datasets up front and grows them with `Dataset::append_staged`; explicit `with_chunks` dimensions are required ([#284](https://github.com/stephenberry/hdf5-pure/issues/284)).
+
 ### Fixed
+
+- Reading a chunked dataset the reference C library created but never wrote to returns an empty result instead of failing with `no address for chunked layout`, for the zero-element case ([#284](https://github.com/stephenberry/hdf5-pure/issues/284)).
 
 - An empty **filtered** chunked dataset declared a chunk-index element too narrow for its own chunks, so filling it through the reference C library produced a file this crate read as truncated compressed data, and filling it through `Dataset::append` was refused outright. Datasets with at least one chunk are byte-identical to before ([#284](https://github.com/stephenberry/hdf5-pure/issues/284)).
 - An empty **fixed-shape** chunked dataset is written with no chunk index, matching the C library, where the zero-entry Fixed Array it used to write made `H5Dget_num_chunks` fail on the dataset ([#284](https://github.com/stephenberry/hdf5-pure/issues/284)).

--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -98,6 +98,20 @@ root.create_dataset("run2/signal", |b| {
 .unwrap();
 ```
 
+A new dataset may be created **empty** — zero elements, chunked, with or without an unlimited maximum — which is how a schema-first writer declares its columns before any data has arrived and then grows each one with [`append_staged`](#appending-to-an-unlimited-dataset) as batches come in:
+
+```rust
+root.create_dataset("col", |b| {
+    b.with_f64_data(&[])
+        .with_shape(&[0])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[512]);
+})
+.unwrap();
+```
+
+The chunk dimensions have to be given: auto-chunking derives them from the shape, and a zero-element shape has none to derive from.
+
 `set_attr` needs a group that already resolves, so a group staged in this same batch is not reachable through it — stage those attributes with `create_group_with` instead. A staged object is not resolvable by name until `commit`, so `File::group`/`File::dataset` will not find it before then.
 
 The `create_group_with`/`create_dataset`/`write_staged`/`append_staged` closures configure a builder rather than the file itself, so a closure may read the same `File` — staging a dataset whose contents depend on one already there works. What it reads is the file as it was before the call, since nothing staged resolves until `commit`.

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -550,6 +550,31 @@ fn ensure_chunk_bytes_representable(
     }
 }
 
+/// Resolve a chunked layout's index address, distinguishing "no storage because
+/// there is nothing to store" from "no storage where data must be".
+///
+/// A chunked dataset's index is allocated lazily — the reference C library
+/// leaves the layout message's address undefined until the first chunk is
+/// written — so a zero-element dataset, which is the shape an extensible one is
+/// created at before anything is appended, legitimately names no index. It owns
+/// no elements, so its read is the empty buffer; `Ok(None)` says so, and each
+/// caller returns that buffer.
+///
+/// A dataset that *does* own elements and still names no index is a different
+/// thing, and stays an error here.
+fn chunk_index_address(
+    addr: Option<u64>,
+    dataspace: &Dataspace,
+) -> Result<Option<u64>, FormatError> {
+    match addr {
+        Some(a) => Ok(Some(a)),
+        None if dataspace.num_elements() == 0 => Ok(None),
+        None => Err(FormatError::ChunkedReadError(
+            "no address for chunked layout".into(),
+        )),
+    }
+}
+
 /// Read a chunked dataset from a [`Source`], reading the chunk index and
 /// each chunk's bytes on demand via `read_at`.
 ///
@@ -597,8 +622,9 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
         }
     };
 
-    let addr = addr_opt
-        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
+    let Some(addr) = chunk_index_address(addr_opt, dataspace)? else {
+        return Ok(Vec::new());
+    };
 
     let elem_size = datatype.element_size_usize()?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
@@ -785,8 +811,14 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
 
     // Unallocated chunk index: a non-empty window has no storage to read. Match
     // the whole-dataset reader, which errors here, so `read_raw_rows` stays
-    // consistent with `read_raw` rather than fabricating a window of zeros. (An
-    // empty window has already returned above.)
+    // consistent with `read_raw` rather than fabricating a window of zeros.
+    //
+    // The zero-element case that `chunk_index_address` answers with an empty
+    // buffer does not reach this line, but note *why*: not because the shape
+    // makes `total_bytes` zero (for `[0]` or `[0, 4]` the inner product is
+    // non-zero, so a `num_rows > 0` call would fall straight through to here),
+    // but because the sole caller, `Dataset::read_raw_rows`, clamps the window
+    // to the leading dimension first.
     let Some(addr) = *btree_address else {
         return Err(FormatError::ChunkedReadError(
             "no address for chunked layout".into(),
@@ -1021,8 +1053,9 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
         }
     };
 
-    let addr = addr_opt
-        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
+    let Some(addr) = chunk_index_address(addr_opt, dataspace)? else {
+        return Ok(Vec::new());
+    };
 
     let elem_size = datatype.element_size_usize()?;
     let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
@@ -1669,8 +1702,9 @@ pub fn read_chunked_data_cached(
         }
     };
 
-    let addr = addr_opt
-        .ok_or_else(|| FormatError::ChunkedReadError("no address for chunked layout".into()))?;
+    let Some(addr) = chunk_index_address(addr_opt, dataspace)? else {
+        return Ok(Vec::new());
+    };
 
     // Taken once as a proven-non-zero width; see the buffered reader above.
     let elem_width = datatype.element_size()?;
@@ -1996,6 +2030,142 @@ mod tests {
         // A geometry whose product overflows u64 is refused, not wrapped.
         assert!(
             ensure_chunk_bytes_representable(&[usize::MAX, usize::MAX], nz(usize::MAX)).is_err()
+        );
+    }
+
+    /// A chunked layout naming no index means one of two things, and the reader
+    /// has to tell them apart. The reference C library allocates the index
+    /// lazily, so a zero-element dataset — the shape an extensible one is
+    /// created at — legitimately names none and reads as the empty buffer. A
+    /// dataset that owns elements and names none stays an error, since an empty
+    /// buffer for it would be a wrong answer rather than a missing one.
+    #[test]
+    fn a_missing_chunk_index_is_empty_only_when_the_dataset_is() {
+        fn simple(dims: Vec<u64>) -> Dataspace {
+            Dataspace {
+                space_type: DataspaceType::Simple,
+                rank: dims.len() as u8,
+                dimensions: dims,
+                max_dimensions: None,
+            }
+        }
+
+        for dims in [vec![0], vec![4, 0], vec![0, 4]] {
+            assert_eq!(
+                chunk_index_address(None, &simple(dims.clone())).unwrap(),
+                None
+            );
+        }
+        for dims in [vec![1], vec![10], vec![2, 3]] {
+            assert!(
+                chunk_index_address(None, &simple(dims.clone())).is_err(),
+                "{dims:?}"
+            );
+        }
+        assert_eq!(
+            chunk_index_address(Some(0x400), &simple(vec![0])).unwrap(),
+            Some(0x400)
+        );
+        assert_eq!(
+            chunk_index_address(Some(0x400), &simple(vec![10])).unwrap(),
+            Some(0x400)
+        );
+    }
+
+    /// All three whole-dataset readers answer a chunk-less, unallocated layout
+    /// the same way, which is what [`chunk_index_address`] claims of them.
+    ///
+    /// Exercised directly rather than through `Dataset::read_raw`, because the
+    /// buffered entry point short-circuits `num_elements == 0` in
+    /// `read_raw_data_full_from_source` before it dispatches on the layout at
+    /// all — so one of these three call sites is unreachable from there, and a
+    /// test that went in by the front door would leave it untested while looking
+    /// like coverage.
+    #[test]
+    fn every_whole_dataset_reader_returns_empty_for_an_unallocated_empty_dataset() {
+        let layout = DataLayout::Chunked {
+            chunk_dimensions: vec![4, 8],
+            btree_address: None,
+            version: 4,
+            chunk_index_type: Some(3),
+            single_chunk_filtered_size: None,
+            single_chunk_filter_mask: None,
+        };
+        let dataspace = Dataspace {
+            space_type: DataspaceType::Simple,
+            rank: 1,
+            dimensions: vec![0],
+            max_dimensions: None,
+        };
+        let datatype = Datatype::FixedPoint {
+            size: 8,
+            signed: true,
+            byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+            bit_offset: 0,
+            bit_precision: 64,
+        };
+        let file_data: Vec<u8> = Vec::new();
+
+        assert!(
+            read_chunked_data_from_source(
+                &BytesSource::new(&file_data),
+                &layout,
+                &dataspace,
+                &datatype,
+                None,
+                8,
+                8,
+            )
+            .unwrap()
+            .is_empty()
+        );
+        assert!(
+            read_chunked_data_cached_from_source(
+                &BytesSource::new(&file_data),
+                &layout,
+                &dataspace,
+                &datatype,
+                None,
+                8,
+                8,
+                &ChunkCache::new(),
+            )
+            .unwrap()
+            .is_empty()
+        );
+        assert!(
+            read_chunked_data_cached(
+                &file_data,
+                &layout,
+                &dataspace,
+                &datatype,
+                None,
+                8,
+                8,
+                &ChunkCache::new(),
+            )
+            .unwrap()
+            .is_empty()
+        );
+
+        let populated = Dataspace {
+            space_type: DataspaceType::Simple,
+            rank: 1,
+            dimensions: vec![10],
+            max_dimensions: None,
+        };
+        assert!(
+            read_chunked_data_cached(
+                &file_data,
+                &layout,
+                &populated,
+                &datatype,
+                None,
+                8,
+                8,
+                &ChunkCache::new(),
+            )
+            .is_err()
         );
     }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -88,8 +88,11 @@
 //!   dimensions. A chunked dataset's data and index — and any filtered chunks —
 //!   are produced by the same builder the whole-file writer uses and appended at
 //!   end-of-file, so its object header is byte-identical to a freshly written
-//!   one. A contiguous dataset may be empty (zero-element); chunking an empty
-//!   shape is not supported. A provenance dataset (`with_provenance`) is
+//!   one. A dataset may be empty (zero-element) under either storage, which is
+//!   how an extensible dataset is created before the first
+//!   [`append_staged`](crate::Dataset::append_staged) fills it: a contiguous one
+//!   gets the undefined data address, a chunked one an index over zero chunks.
+//!   A provenance dataset (`with_provenance`) is
 //!   supported, its attributes computed the same way the whole-file writer
 //!   computes them. A contiguous dataset may carry a variable-length-string
 //!   payload (`with_vlen_strings`) or per-element object-reference targets
@@ -1736,8 +1739,8 @@ impl WriteEngine {
     /// The dataset may be contiguous or chunked, and chunked datasets may be
     /// filtered (`with_deflate`, `with_shuffle`, `with_fletcher32`,
     /// `with_scale_offset`, `with_zfp`) and/or extensible (`with_maxshape`). An
-    /// empty (zero-element) contiguous dataset is supported (chunking one is
-    /// not), a provenance dataset (`with_provenance`) is supported, and a
+    /// empty (zero-element) dataset is supported under either storage, a
+    /// provenance dataset (`with_provenance`) is supported, and a
     /// contiguous dataset may carry variable-length attributes, a
     /// variable-length-string payload (`with_vlen_strings`), or path-resolved
     /// object-reference elements (`with_path_references`; chunking any of
@@ -7175,10 +7178,12 @@ fn meta_spans(spans: Vec<(u64, u64)>) -> impl Iterator<Item = (u64, u64, PageTyp
 /// unfiltered datasets are emitted as such; chunked, filtered, or extensible
 /// datasets carry their [`ChunkOptions`] and maxshape through to the commit,
 /// where [`WriteEngine::build_chunked_dataset`] lays out their chunk data and
-/// index. An
-/// empty (zero-element) shape is allowed for contiguous storage (mirroring the
-/// whole-file writer, its data address is `HADDR_UNDEF` — see the apply loop),
-/// but chunking one stays refused via the geometry validation below. A
+/// index. An empty (zero-element) shape is allowed under either storage,
+/// mirroring the whole-file writer: a contiguous one takes the `HADDR_UNDEF`
+/// data address (see the apply loop) and a chunked one an index over zero
+/// chunks, which is what an extensible dataset is created as before the first
+/// append fills it. The geometry validation below still requires explicit chunk
+/// dimensions for it — auto-chunking has no shape to derive them from. A
 /// `provenance` dataset has its SHA-256/creator/timestamp/source attributes
 /// computed here from `raw`, exactly as the whole-file writer does. A
 /// variable-length attribute's global heap collection is built here (it is
@@ -7205,11 +7210,6 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         .ok_or(Error::EditUnsupported("dataset has no shape"))?;
     let is_empty = shape.contains(&0);
     let chunked = db.chunk_options.is_chunked() || db.maxshape.is_some();
-    if is_empty && chunked {
-        return Err(Error::EditUnsupported(
-            "chunked or extensible empty (zero-element) datasets cannot be added in place yet",
-        ));
-    }
     // Variable-length string element references live in the global heap, whose
     // address is only known once the apply loop places the collection. For
     // chunked/filtered/resizable storage the references sit inside chunks

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -1956,45 +1956,79 @@ fn add_zfp_dataset() {
 }
 
 /// Malformed chunked-dataset requests are refused before any byte is written,
-/// rather than panicking or producing a silently-corrupt dataset: an empty
-/// (zero-element) shape, chunk dims whose rank disagrees with the shape, a zero
-/// chunk dimension, and a maxshape whose rank disagrees with the shape.
+/// rather than panicking or producing a silently-corrupt dataset: chunk dims
+/// whose rank disagrees with the shape, a zero chunk dimension, a maxshape whose
+/// rank disagrees with the shape or falls below it, a chunked scalar, and a
+/// zero-element shape left to auto-chunking (which would resolve to a zero
+/// chunk dimension and divide by zero in the splitter — an *explicitly* chunked
+/// zero-element shape is legal, see
+/// `add_empty_extensible_chunked_dataset_and_grow_it`).
+///
+/// Each case names the substring its own refusal must carry: without that, a
+/// case refused for some unrelated reason still passes, and the guard under test
+/// is never reached.
 #[test]
 fn malformed_chunked_requests_are_rejected_without_writing() {
     // A no-capture configurator per malformed case; `fn` pointers keep the case
     // table a simple type.
     type Configure = fn(&mut hdf5_pure::DatasetBuilder);
-    let bad: &[(&str, Configure)] = &[
-        ("empty shape", |b| {
-            b.with_f64_data(&[]).with_shape(&[0]).with_chunks(&[4]);
-        }),
-        ("chunk rank mismatch", |b| {
-            b.with_i32_data(&[1, 2, 3, 4, 5, 6])
-                .with_shape(&[2, 3])
-                .with_chunks(&[2]);
-        }),
-        ("zero chunk dim", |b| {
-            b.with_i32_data(&[1, 2, 3, 4])
-                .with_shape(&[4])
-                .with_chunks(&[0]);
-        }),
-        ("maxshape rank mismatch", |b| {
-            b.with_i32_data(&[1, 2, 3, 4])
-                .with_shape(&[4])
-                .with_maxshape(&[u64::MAX, u64::MAX])
-                .with_chunks(&[2]);
-        }),
-        ("scalar with chunks", |b| {
-            b.with_f64_data(&[1.0]).with_shape(&[]).with_chunks(&[1]);
-        }),
-        ("maxshape below shape", |b| {
-            b.with_i32_data(&[1, 2, 3, 4])
-                .with_shape(&[4])
-                .with_maxshape(&[2]);
-        }),
+    let bad: &[(&str, Configure, &str)] = &[
+        (
+            "auto-chunked empty shape",
+            |b| {
+                b.with_f64_data(&[])
+                    .with_shape(&[0])
+                    .with_maxshape(&[u64::MAX]);
+            },
+            "explicit chunk dimensions",
+        ),
+        (
+            "chunk rank mismatch",
+            |b| {
+                b.with_i32_data(&[1, 2, 3, 4, 5, 6])
+                    .with_shape(&[2, 3])
+                    .with_chunks(&[2]);
+            },
+            "chunk dimensions must have the same rank",
+        ),
+        (
+            "zero chunk dim",
+            |b| {
+                b.with_i32_data(&[1, 2, 3, 4])
+                    .with_shape(&[4])
+                    .with_chunks(&[0]);
+            },
+            "chunk dimensions must all be non-zero",
+        ),
+        (
+            "maxshape rank mismatch",
+            |b| {
+                b.with_i32_data(&[1, 2, 3, 4])
+                    .with_shape(&[4])
+                    .with_maxshape(&[u64::MAX, u64::MAX])
+                    .with_chunks(&[2]);
+            },
+            "maxshape must have the same rank",
+        ),
+        (
+            "scalar with chunks",
+            |b| {
+                b.with_f64_data(&[1.0]).with_shape(&[]).with_chunks(&[1]);
+            },
+            "a scalar dataset cannot be chunked",
+        ),
+        (
+            "maxshape below shape",
+            |b| {
+                b.with_i32_data(&[1, 2, 3, 4])
+                    .with_shape(&[4])
+                    .with_maxshape(&[2]);
+            },
+            "maxshape must be at least the current shape",
+        ),
     ];
 
-    for (label, configure) in bad {
+    for (label, configure, expected) in bad {
         let path = std::env::temp_dir().join(format!(
             "hdf5_pure_edit_reject_{}.h5",
             label.replace(' ', "_")
@@ -2005,9 +2039,14 @@ fn malformed_chunked_requests_are_rejected_without_writing() {
             let session = File::open_rw(&path).unwrap();
             session.root().create_dataset("bad", configure).unwrap();
             let err = session.commit().unwrap_err();
+            let text = err.to_string();
             assert!(
-                err.to_string().contains("in-place edit"),
+                text.contains("in-place edit"),
                 "[{label}] expected an EditUnsupported refusal, got: {err}"
+            );
+            assert!(
+                text.contains(expected),
+                "[{label}] refusal must name {expected:?}, got: {err}"
             );
         }
         // The guard runs before any write, so the file is untouched.
@@ -2755,36 +2794,6 @@ fn add_empty_dataset_via_edit_session() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
-}
-
-/// Chunking a zero-element shape stays refused in place (it's a distinct,
-/// separately-tracked capability from the plain contiguous empty dataset
-/// above): `malformed_chunked_requests_are_rejected_without_writing` already
-/// covers the whole-file-writer-equivalent geometry refusal; this confirms
-/// `File::open_rw` refuses it too, cleanly, without writing anything.
-#[test]
-fn add_chunked_empty_dataset_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked_empty.h5");
-    write_starter(&path);
-    let before = std::fs::read(&path).unwrap();
-
-    {
-        let session = File::open_rw(&path).unwrap();
-        session
-            .root()
-            .create_dataset("stream", |b| {
-                b.with_i32_data(&[])
-                    .with_shape(&[0])
-                    .with_maxshape(&[u64::MAX])
-                    .with_chunks(&[16]);
-            })
-            .unwrap();
-        let err = session.commit().unwrap_err();
-        assert!(err.to_string().contains("empty"), "got: {err}");
-    }
-
-    assert_eq!(std::fs::read(&path).unwrap(), before);
     std::fs::remove_file(&path).ok();
 }
 
@@ -3694,6 +3703,195 @@ fn a_zero_width_element_type_is_refused_by_a_staged_write() {
     assert_eq!(
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+/// An empty (zero-element) chunked, unlimited dataset added in place: the shape
+/// an incremental writer declares its schema at before any data has arrived
+/// (issue #284). The edit engine used to refuse it outright, so a schema-first
+/// writer had to rewrite the whole file to declare one column.
+///
+/// The dataset that comes out has to be the same one the whole-file writer
+/// makes, which means growable: the append in the second session is what proves
+/// the index over zero chunks is a real Extensible Array and not a placeholder.
+#[test]
+fn add_empty_extensible_chunked_dataset_and_grow_it() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_empty_chunked.h5");
+    write_starter(&path);
+
+    {
+        let session = File::open_rw(&path).unwrap();
+        session
+            .root()
+            .create_dataset("col", |b| {
+                b.with_i64_data(&[])
+                    .with_shape(&[0])
+                    .with_maxshape(&[u64::MAX])
+                    .with_chunks(&[2]);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+
+    {
+        let file = File::open(&path).unwrap();
+        let ds = file.dataset("col").unwrap();
+        assert_eq!(ds.shape().unwrap(), vec![0]);
+        assert_eq!(ds.read_i64().unwrap(), Vec::<i64>::new());
+        // Chunked storage with the growable index, not a contiguous fallback.
+        assert!(
+            matches!(
+                ds.layout().unwrap(),
+                hdf5_pure::Layout::Chunked {
+                    index: hdf5_pure::ChunkIndex::ExtensibleArray,
+                    ..
+                }
+            ),
+            "expected an extensible-array chunked layout, got {:?}",
+            ds.layout().unwrap()
+        );
+    }
+
+    // Two appends of two whole chunks each (the chunk is 2 elements wide), so
+    // the second grows an index that already holds chunks rather than one built
+    // empty. A chunk wide enough to swallow both batches would exercise the
+    // first case twice and never the second.
+    for batch in [[1i64, 2, 3, 4].as_slice(), [5i64, 6, 7, 8].as_slice()] {
+        let session = File::open_rw(&path).unwrap();
+        session
+            .dataset("col")
+            .unwrap()
+            .append_staged(|a| {
+                a.append_i64(batch);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("col").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![8]);
+    assert_eq!(ds.read_i64().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    // Four chunks of two, so the index really did grow past what it was built
+    // holding.
+    assert_eq!(ds.chunks().unwrap().len(), 4);
+    // The file the edits were appended into is untouched.
+    assert_eq!(
+        file.dataset("original").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+/// The other empty-chunked shapes the same lifted refusal now admits: a
+/// fixed-shape (non-extensible) one, a multi-dimensional one, and a filtered
+/// one. Each has zero chunks, so each exercises a different index built over
+/// nothing — a fixed array, and the filtered pipeline that never runs.
+#[test]
+fn add_empty_chunked_datasets_of_every_flavor() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_empty_chunked_flavors.h5");
+    write_starter(&path);
+
+    {
+        let session = File::open_rw(&path).unwrap();
+        let root = session.root();
+        root.create_dataset("fixed", |b| {
+            b.with_i32_data(&[]).with_shape(&[0]).with_chunks(&[8]);
+        })
+        .unwrap();
+        root.create_dataset("two_d", |b| {
+            b.with_f64_data(&[])
+                .with_shape(&[0, 3])
+                .with_maxshape(&[u64::MAX, 3])
+                .with_chunks(&[4, 3]);
+        })
+        .unwrap();
+        // The issue's own repro shape: a datatype and a shape, no data at all.
+        // `with_i64_data(&[])` reaches the same place by a different route, and
+        // only this one covers a builder whose `data` is `None`.
+        root.create_dataset("declared", |b| {
+            b.with_dtype(hdf5_pure::make_u64_type())
+                .with_shape(&[0])
+                .with_maxshape(&[u64::MAX])
+                .with_chunks(&[512]);
+        })
+        .unwrap();
+        root.create_dataset("filtered", |b| {
+            b.with_i32_data(&[])
+                .with_shape(&[0])
+                .with_maxshape(&[u64::MAX])
+                .with_chunks(&[16])
+                .with_deflate(6)
+                .with_shuffle();
+        })
+        .unwrap();
+        session.commit().unwrap();
+    }
+
+    // Every flavor asserts its chunk index, not just its shape and an empty
+    // read: a contiguous dataset satisfies those two just as well, so on their
+    // own they cannot tell whether chunked storage was emitted at all.
+    let index_of = |name: &str| match File::open(&path).unwrap().dataset(name).unwrap().layout() {
+        Ok(hdf5_pure::Layout::Chunked { index, .. }) => format!("{index:?}"),
+        other => panic!("[{name}] expected chunked storage, got {other:?}"),
+    };
+    assert_eq!(index_of("fixed"), "FixedArray");
+    assert_eq!(index_of("two_d"), "ExtensibleArray");
+    assert_eq!(index_of("declared"), "ExtensibleArray");
+    assert_eq!(index_of("filtered"), "ExtensibleArray");
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(file.dataset("fixed").unwrap().shape().unwrap(), vec![0]);
+    assert_eq!(
+        file.dataset("fixed").unwrap().read_i32().unwrap(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(file.dataset("two_d").unwrap().shape().unwrap(), vec![0, 3]);
+    assert_eq!(
+        file.dataset("two_d").unwrap().read_f64().unwrap(),
+        Vec::<f64>::new()
+    );
+    assert_eq!(file.dataset("declared").unwrap().shape().unwrap(), vec![0]);
+    assert_eq!(
+        file.dataset("declared").unwrap().read_u64().unwrap(),
+        Vec::<u64>::new()
+    );
+    assert_eq!(file.dataset("filtered").unwrap().shape().unwrap(), vec![0]);
+    assert_eq!(
+        file.dataset("filtered").unwrap().read_i32().unwrap(),
+        Vec::<i32>::new()
+    );
+    // The filter pipeline is recorded even though no chunk was ever encoded, so
+    // the first append compresses rather than silently writing raw chunks.
+    assert!(
+        !file
+            .dataset("filtered")
+            .unwrap()
+            .filter_pipeline()
+            .is_empty(),
+        "the filter pipeline must survive a dataset with no chunks"
+    );
+
+    // Growing the filtered one is the case an incremental writer actually runs.
+    drop(file);
+    {
+        let session = File::open_rw(&path).unwrap();
+        session
+            .dataset("filtered")
+            .unwrap()
+            .append_staged(|a| {
+                a.append_i32(&(0..40).collect::<Vec<_>>());
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("filtered").unwrap().read_i32().unwrap(),
+        (0..40).collect::<Vec<i32>>()
     );
     drop(file);
     std::fs::remove_file(&path).ok();

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -227,6 +227,82 @@ fn userblock_add_empty_dataset_roundtrip() {
     std::fs::remove_file(&path).ok();
 }
 
+/// The chunked counterpart of the test above: an empty chunked dataset added on
+/// a userblock file, then grown.
+///
+/// A userblock file is the only backing that forces the *mirrored* engine, and
+/// it is the only one where a base-relative address arithmetic slip is visible —
+/// at `base_address == 0` a missing or spurious `- base` is numerically
+/// invisible. An empty chunked dataset places a chunk index and nothing else, so
+/// the index address is the whole of what the layout message has to get right,
+/// and the append that follows proves the C library and this crate agree on
+/// where it landed.
+#[test]
+fn userblock_add_empty_chunked_dataset_and_grow_it() {
+    let path = std::env::temp_dir().join("hdf5_pure_ub_add_empty_chunked.h5");
+    let userblock = build_userblock_file(&path);
+
+    {
+        let s = File::open_rw(&path).unwrap();
+        let root = s.root();
+        root.create_dataset("col", |b| {
+            b.with_i64_data(&[])
+                .with_shape(&[0])
+                .with_maxshape(&[u64::MAX])
+                .with_chunks(&[4]);
+        })
+        .unwrap();
+        // The fixed-shape flavor too: it is the one that carries no index at
+        // all, so its layout message names the undefined address rather than a
+        // base-relative one — the case a blanket `- base` would corrupt.
+        root.create_dataset("fixed", |b| {
+            b.with_i64_data(&[]).with_shape(&[0]).with_chunks(&[4]);
+        })
+        .unwrap();
+        s.commit().unwrap();
+    }
+
+    {
+        let file = File::open(&path).unwrap();
+        assert_eq!(file.dataset("col").unwrap().shape().unwrap(), vec![0]);
+        assert_eq!(
+            file.dataset("col").unwrap().read_i64().unwrap(),
+            Vec::<i64>::new()
+        );
+        assert_eq!(
+            file.dataset("fixed").unwrap().read_i64().unwrap(),
+            Vec::<i64>::new()
+        );
+    }
+
+    // Grow it across several chunks, so the index the empty dataset placed is
+    // read back at its base-relative address and extended.
+    {
+        let s = File::open_rw(&path).unwrap();
+        s.dataset("col")
+            .unwrap()
+            .append_staged(|a| {
+                a.append_i64(&(0..10).collect::<Vec<i64>>());
+            })
+            .unwrap();
+        s.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("col").unwrap().read_i64().unwrap(),
+        (0..10).collect::<Vec<i64>>()
+    );
+    // Untouched original still reads correctly, and the userblock is intact.
+    assert_eq!(
+        file.dataset("alpha").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+    assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
+
+    std::fs::remove_file(&path).ok();
+}
+
 /// A provenance-tagged dataset added on a userblock file must round-trip
 /// correctly, exercising the same base-relative address arithmetic as the
 /// non-userblock case above but where a `- base` bug would actually be

--- a/tests/empty_chunked_crosscheck.rs
+++ b/tests/empty_chunked_crosscheck.rs
@@ -12,7 +12,14 @@
 //! was built from information a chunk-less dataset does not have: an index
 //! element sized from a chunk that was never written, and a Fixed Array
 //! declaring zero entries where the C library writes no index at all.
+//!
+//! The in-place edit engine's empty chunked datasets are held to the same
+//! standard here: they have to be indistinguishable from the whole-file
+//! writer's, which means the C library reads, opens the index of, and grows
+//! them.
 
+use hdf5::Extent;
+use hdf5::file::LibraryVersion;
 use hdf5_pure::{File, FileBuilder};
 use tempfile::tempdir;
 
@@ -204,4 +211,146 @@ fn an_empty_filtered_dataset_accepts_an_append_that_fills_its_chunk() {
         file.dataset("col").unwrap().read_raw::<i32>().unwrap(),
         data
     );
+}
+
+/// Write a starter file and add one empty chunked dataset to it through the
+/// in-place edit engine, the path issue #284 refused.
+fn edit_in_an_empty_chunked_dataset(path: &std::path::Path, unlimited: bool) {
+    let mut b = FileBuilder::new();
+    b.create_dataset("existing").with_f64_data(&[1.0, 2.0]);
+    b.write(path).unwrap();
+
+    let session = File::open_rw(path).unwrap();
+    session
+        .root()
+        .create_dataset("col", |b| {
+            b.with_i64_data(&[]).with_shape(&[0]).with_chunks(&[512]);
+            if unlimited {
+                b.with_maxshape(&[u64::MAX]);
+            }
+        })
+        .unwrap();
+    session.commit().unwrap();
+}
+
+/// The issue's round trip: the edit engine declares the column empty, then the C
+/// library reads it, extends it, and writes into it — and this crate reads back
+/// what the C library wrote. An index built over zero chunks that the C library
+/// could read but not grow would pass a read-only check and fail here.
+#[test]
+fn c_grows_an_empty_chunked_dataset_added_in_place() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("edited.h5");
+    edit_in_an_empty_chunked_dataset(&path, true);
+
+    {
+        let file = hdf5::File::open_rw(&path).unwrap();
+        let ds = file.dataset("col").unwrap();
+        assert_eq!(ds.shape(), vec![0]);
+        assert!(ds.read_raw::<i64>().unwrap().is_empty());
+        ds.resize((4,)).unwrap();
+        ds.write(&[10i64, 20, 30, 40]).unwrap();
+        drop(ds);
+        file.close().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("col").unwrap().read_i64().unwrap(),
+        vec![10, 20, 30, 40]
+    );
+    // The pre-existing dataset the edit appended past is untouched.
+    assert_eq!(
+        file.dataset("existing").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0]
+    );
+}
+
+/// The same dataset without `maxshape`: a fixed-shape empty chunked dataset,
+/// whose index is a fixed array over zero chunks rather than an extensible one.
+/// The C library has to accept that too, or the edit engine is emitting a
+/// structure only its own reader understands.
+#[test]
+fn c_reads_a_fixed_shape_empty_chunked_dataset_added_in_place() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("edited_fixed.h5");
+    edit_in_an_empty_chunked_dataset(&path, false);
+
+    let file = hdf5::File::open(&path).unwrap();
+    let ds = file.dataset("col").unwrap();
+    assert_eq!(ds.shape(), vec![0]);
+    assert!(ds.read_raw::<i64>().unwrap().is_empty());
+    // Shape and an empty read are equally true of a *contiguous* dataset, so
+    // they cannot tell whether the edit engine emitted chunked storage at all.
+    // These reach the C library's own view of the chunk index, which is the
+    // thing under test.
+    assert!(ds.is_chunked(), "the C library must see chunked storage");
+    assert_eq!(ds.chunk(), Some(vec![512]));
+    // `num_chunks` opens the index. A Fixed Array declaring zero entries — what
+    // this crate wrote before it adopted the C library's convention of leaving a
+    // chunk-less fixed-shape dataset unallocated — makes this call *fail*, while
+    // reads and `shape` keep working. It is the only assertion here that can see
+    // the difference.
+    assert_eq!(
+        ds.num_chunks(),
+        Some(0),
+        "the C library must be able to open the chunk index"
+    );
+}
+
+/// The other direction, and the one this crate used to fail: the C library
+/// allocates a chunked dataset's index lazily, so an empty one carries the
+/// undefined address. Reading it is the empty buffer — `read_raw` errored with
+/// "no address for chunked layout" until the reader learned to tell "nothing
+/// stored because there is nothing to store" from "nothing stored where data
+/// must be".
+#[test]
+fn pure_reads_the_c_librarys_unallocated_empty_chunked_datasets() {
+    for unlimited in [false, true] {
+        for latest in [false, true] {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("c.h5");
+            {
+                let mut opts = hdf5::File::with_options();
+                if latest {
+                    opts.with_fapl(|p| {
+                        p.libver_bounds(LibraryVersion::V110, LibraryVersion::latest())
+                    });
+                }
+                let file = opts.create(&path).unwrap();
+                let builder = file.new_dataset::<i64>().chunk((512,));
+                let ds = if unlimited {
+                    builder.shape((Extent::resizable(0),)).create("col")
+                } else {
+                    builder.shape((0,)).create("col")
+                }
+                .unwrap();
+                drop(ds);
+                file.close().unwrap();
+            }
+
+            let label = format!("unlimited={unlimited} latest={latest}");
+            // Both readers: the buffered one and the streaming one reach
+            // different functions, and only one of them was covered when this
+            // was written.
+            let file = File::open(&path).unwrap();
+            let ds = file.dataset("col").unwrap();
+            assert_eq!(ds.shape().unwrap(), vec![0], "[{label}] buffered");
+            assert_eq!(
+                ds.read_i64().unwrap(),
+                Vec::<i64>::new(),
+                "[{label}] buffered"
+            );
+            drop(file);
+
+            let file = File::open_streaming(&path).unwrap();
+            let ds = file.dataset("col").unwrap();
+            assert_eq!(ds.shape().unwrap(), vec![0], "[{label}] streaming");
+            assert_eq!(
+                ds.read_i64().unwrap(),
+                Vec::<i64>::new(),
+                "[{label}] streaming"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #284.

Stacked on #290 — review that first; this diff is only the feature.

## The refusal

`File::open_rw`'s edit engine refused a zero-element shape combined with chunked or extensible storage:

```
EditUnsupported("chunked or extensible empty (zero-element) datasets cannot be added in place yet")
```

It came from #133, which scoped itself to contiguous empty datasets. Nothing downstream needed it: `build_chunked_dataset` lays out a chunk-less dataset exactly as the whole-file writer does, so deleting the check is the whole change. The result is a dataset the C library reads, opens the index of, extends, and writes into — and this crate reads back what the C library wrote.

The reporter's use case is the point of it: declare one resizable dataset per column up front, then grow each with `append_staged` as batches arrive. Before, adding a column meant rewriting the whole file.

```rust
let session = File::open_rw(&path)?;
session.root().create_dataset("col", |b| {
    b.with_dtype(make_u64_type())
     .with_shape(&[0])
     .with_maxshape(&[u64::MAX])
     .with_chunks(&[512]);
})?;
session.commit()?;
```

Explicit `with_chunks` dimensions are required, since auto-chunking derives the chunk from the shape and a zero-element shape has none to derive from. That case is refused in #290 rather than divided by zero.

## The reading half

The C library allocates a chunk index lazily, so *its* empty chunked dataset names no index at all — which this crate reported as `no address for chunked layout`, making an ordinary C-written file unreadable. A layout with no index over a zero-element dataspace now reads as the empty buffer. One over a dataspace that owns elements stays an error here; the next PR in the stack handles that case properly.

## While in there

`malformed_chunked_requests_are_rejected_without_writing` gained a per-case expected substring. Its "empty shape" case was being replaced anyway, and the loop only checked the generic `EditUnsupported` wrapper text — so a case refused for an unrelated reason passed without ever reaching the guard under test.

## Testing

Covers the extensible, fixed-shape, multi-dimensional, filtered, and no-data-at-all (`with_dtype` + `with_shape`, the issue's own spelling) flavors, each asserting its **chunk index** rather than just shape and an empty read — a contiguous dataset satisfies those two equally well. Plus a userblock case, since that is the only backing that forces the mirrored engine and the only one where base-relative address arithmetic is observable. C-library crosschecks confirm it reads, opens the index of, and grows what the edit engine writes.