### PR TITLE
Bundle the raw-read parameters, then decode a typed whole read a window at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- The typed whole-dataset readers (`Dataset::read_f64` and its eight siblings) decode a row window at a time instead of the whole dataset at once, so peak memory is the values they return plus about a mebibyte rather than twice the dataset: an 8 MiB `f64` dataset peaked at 16.8 MB and now peaks at 10.1 MB ([#289](https://github.com/stephenberry/hdf5-pure/issues/289)).
+- A row window takes only its own chunks out of the cached chunk index rather than the whole index, so reading a dataset window by window costs a constant per chunk instead of one allocation per chunk of the dataset per window ([#289](https://github.com/stephenberry/hdf5-pure/issues/289)).
+
 ### Fixed
 
 - A paged file (`FileSpaceStrategy::Page`) stops growing under delete-and-recreate churn: the free-space managers a commit rewrites are placed in free space rather than in a fresh page whose remainder nothing recorded, which cost a page per commit. A wholly free page can also be reopened for the other page type, so space a delete released is no longer stranded for the kind of data that released it ([#286](https://github.com/stephenberry/hdf5-pure/issues/286)).

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -122,6 +122,8 @@ let file = File::open("output.h5").unwrap();
 let values = file.dataset("temperature").unwrap().read_f64().unwrap();
 ```
 
+A typed read costs about what its result costs. The numeric readers decode the dataset a row window at a time, so what stands beside the returned `Vec<T>` is one window of stored bytes — roughly a mebibyte — rather than a second copy of the whole dataset. `read_u8` and `read_raw` hand back the stored bytes themselves and have nothing to decode.
+
 ### Generic reads
 
 `Dataset::read::<T>()` is the generic counterpart to the typed `read_*` methods, bounded by the sealed `H5Element` trait (implemented for `f32`/`f64` and the 8/16/32/64-bit signed and unsigned integers). It lets you write code generic over the element type. Like `read_f64`, it requests delivery as `T` and coerces, so pick `T` to match the stored type for a lossless read.

--- a/src/chunk_cache.rs
+++ b/src/chunk_cache.rs
@@ -191,11 +191,17 @@ struct CachedChunk {
 ///
 /// A read of a whole dataset does not want it: a caller who reads it again
 /// starts at the beginning, so a retained prefix is worth at least as much as a
-/// retained suffix, and it costs a fraction as much to keep. A *row window* does
-/// want it, because its successor is the adjacent window and the chunk they share
-/// is the one this read finished on — which is why
-/// [`read_chunked_rows_from_source`](crate::chunked_read::read_chunked_rows_from_source)
-/// passes `LRU` and the two whole-dataset loops pass a real pass.
+/// retained suffix, and it costs a fraction as much to keep. A *lone* row window
+/// does want it, because its successor is the adjacent window and the chunk they
+/// share is the one this read finished on — which is why
+/// [`Dataset::read_raw_rows`](crate::Dataset::read_raw_rows) asks for `LRU` while
+/// the two whole-dataset loops open a real pass.
+///
+/// The windowed reader itself takes the pass from its caller rather than
+/// choosing, because the same window means different things to different
+/// callers: a sweep of a whole dataset in windows opens one real pass for all of
+/// them, since it asks for each chunk exactly once and has no more use for the
+/// last window's chunks than for the first's.
 ///
 /// Across passes nothing changes either way: a later read still evicts what an
 /// earlier one left, so the cache goes on tracking the most recent access
@@ -338,8 +344,28 @@ impl ChunkCache {
 
     /// Return all indexed chunks as a `Vec<ChunkInfo>` (order unspecified).
     pub fn all_indexed_chunks(&self) -> Option<Vec<ChunkInfo>> {
+        self.indexed_chunks_matching(|_| true)
+    }
+
+    /// Return the indexed chunks `keep` accepts, as a `Vec<ChunkInfo>` (order
+    /// unspecified).
+    ///
+    /// A row window wants the chunks its rows overlap and nothing else, and the
+    /// difference is not a nicety: each [`ChunkInfo`] owns a coordinate `Vec`, so
+    /// taking the whole index and discarding most of it costs an allocation per
+    /// chunk *of the dataset* per window. A sweep of a dataset in windows paid
+    /// that as a product — 8 windows over 2,048 chunks, 16,384 allocations to
+    /// visit 2,048 chunks (issue #289). The filter runs while the lock is held,
+    /// over borrowed entries, so a rejected chunk costs no allocation at all.
+    pub fn indexed_chunks_matching(
+        &self,
+        keep: impl Fn(&ChunkInfo) -> bool,
+    ) -> Option<Vec<ChunkInfo>> {
         let inner = self.inner.lock().unwrap();
-        inner.index.as_ref().map(|m| m.values().cloned().collect())
+        inner
+            .index
+            .as_ref()
+            .map(|m| m.values().filter(|ci| keep(ci)).cloned().collect())
     }
 
     // ----- Decompressed data cache (LRU) -----

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -12,7 +12,7 @@ use core::num::NonZeroUsize;
 
 use crate::btree_v1::btree_v1_node_header_size;
 use crate::bytes::read_offset;
-use crate::chunk_cache::ChunkCache;
+use crate::chunk_cache::{CachePass, ChunkCache};
 use crate::chunk_grid::{ChunkGrid, GridOrder};
 use crate::chunk_span::ChunkSpanReader;
 use crate::convert::{TryToUsize, nonzero_usize_from, slice_range, u32_from};
@@ -749,12 +749,21 @@ fn plan_chunk_spans(
 /// are returned. Returns `Ok(None)` only for a rank-0 (scalar) chunked layout — a
 /// crafted-file corner with no leading dimension to window — so the caller falls
 /// back to a whole read. The caller clamps the window to the dataset.
+///
+/// `pass` decides which chunks the cache keeps, and the answer differs by caller.
+/// A lone window wants [`CachePass::LRU`], so that what it retains is the chunks
+/// it *finished* on: its successor is the adjacent window, and the chunk they
+/// share is that last one. A window that is one step of a sweep across the whole
+/// dataset wants a real pass, shared by every step — the sweep never asks for a
+/// chunk twice, so offering each one to a cache already full is a copy and an
+/// eviction with no reader on the other side. See [`CachePass`].
 pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     source: &S,
     spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
+    pass: CachePass,
     row_start: u64,
     num_rows: u64,
 ) -> Result<Option<Vec<u8>>, FormatError> {
@@ -845,8 +854,31 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
         return Ok(Some(output));
     };
 
-    // Walk the index once, then reuse it for later windows on this handle.
-    let mut chunks = if let Some(chunks) = cache.all_indexed_chunks() {
+    let row_lo = row_start.to_usize()?;
+    let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
+    let cd0 = chunk_dims[0];
+
+    // A chunk contributes to the window when its rows meet `[row_lo, row_hi)`.
+    // Every list this function builds and every walk over one applies this test,
+    // so it is written once.
+    let overlaps = |c0: usize| c0 < row_hi && c0.saturating_add(cd0) > row_lo;
+    let chunk_overlaps = |chunk: &ChunkInfo| {
+        match chunk.offsets.first().copied().unwrap_or(0).to_usize() {
+            Ok(c0) => overlaps(c0),
+            // A leading offset too large for `usize` — a 32-bit target reading a
+            // crafted file. Kept rather than dropped: the walk below converts it
+            // again and reports the failure, and a filter that swallowed it here
+            // would turn that error into silence.
+            Err(_) => true,
+        }
+    };
+
+    // Walk the index once, then reuse it for later windows on this handle —
+    // keeping only this window's chunks, since each `ChunkInfo` taken out of the
+    // index owns a coordinate `Vec` and the rest would be allocated and dropped
+    // unread. Sweeping a dataset window by window makes that a product rather
+    // than a sum (issue #289).
+    let mut chunks = if let Some(chunks) = cache.indexed_chunks_matching(chunk_overlaps) {
         chunks
     } else {
         let chunks = collect_chunks_for_layout_from_source(
@@ -863,41 +895,19 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
             length_size,
         )?;
         cache.populate_index(&chunks, rank);
-        chunks
+        chunks.into_iter().filter(chunk_overlaps).collect()
     };
     sort_chunks_by_address(&mut chunks);
 
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
 
-    let row_lo = row_start.to_usize()?;
-    let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
-    let cd0 = chunk_dims[0];
-
-    // A chunk contributes to the window when its rows meet `[row_lo, row_hi)`.
-    // The span plan and the walk below have to agree on which chunks those are,
-    // so the test is written once.
-    let overlaps = |c0: usize| c0 < row_hi && c0.saturating_add(cd0) > row_lo;
-
     // Coalesce over the window's own chunks. A plan built over the dataset's
     // whole chunk list would put the rows on either side of the window inside a
     // span and read them for nothing — an eight-row window measured 32 KB where
     // it needed 64 bytes.
-    let mut spans = plan_chunk_spans(&chunks, rank, cache, |chunk| {
-        chunk
-            .offsets
-            .first()
-            .copied()
-            .unwrap_or(0)
-            .to_usize()
-            .is_ok_and(&overlaps)
-    });
+    let mut spans = plan_chunk_spans(&chunks, rank, cache, chunk_overlaps);
 
-    // Plain LRU rather than a fill-once pass, so the chunks this window finishes
-    // on are the ones retained. That is the reuse the doc above promises: the
-    // next window straddles this one's *last* chunk, and a window wide enough to
-    // fill the cache would otherwise drop exactly it. See [`CachePass`].
-    let pass = crate::chunk_cache::CachePass::LRU;
     // One decoder for the whole window; see `FilterScratch`.
     let mut scratch = FilterScratch::new();
 
@@ -3089,6 +3099,7 @@ mod tests {
             8,
             8,
             &cache,
+            CachePass::LRU,
             0,
             1,
         )
@@ -3128,6 +3139,7 @@ mod tests {
             8,
             8,
             &cache,
+            CachePass::LRU,
             0,
             1,
         )
@@ -3168,6 +3180,7 @@ mod tests {
             8,
             8,
             &cache,
+            CachePass::LRU,
             0,
             1,
         )
@@ -3219,15 +3232,31 @@ mod tests {
                     .expect("an unallocated dataset reads as fill");
             assert_eq!(whole.len(), 80);
 
-            let window =
-                read_chunked_rows_from_source(&BytesSource::new(b""), spec, 8, 8, &cache, 2, 4)
-                    .expect("a window over an unallocated index reads as fill")
-                    .expect("rank-1 windows are supported");
+            let window = read_chunked_rows_from_source(
+                &BytesSource::new(b""),
+                spec,
+                8,
+                8,
+                &cache,
+                CachePass::LRU,
+                2,
+                4,
+            )
+            .expect("a window over an unallocated index reads as fill")
+            .expect("rank-1 windows are supported");
             assert_eq!(window, whole[16..48], "the window must match those rows");
 
-            let empty =
-                read_chunked_rows_from_source(&BytesSource::new(b""), spec, 8, 8, &cache, 0, 0)
-                    .expect("empty window must still be Ok");
+            let empty = read_chunked_rows_from_source(
+                &BytesSource::new(b""),
+                spec,
+                8,
+                8,
+                &cache,
+                CachePass::LRU,
+                0,
+                0,
+            )
+            .expect("empty window must still be Ok");
             assert_eq!(empty, Some(Vec::new()));
         }
     }

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -18,7 +18,6 @@ use crate::chunk_span::ChunkSpanReader;
 use crate::convert::{TryToUsize, nonzero_usize_from, slice_range, u32_from};
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
-use crate::datatype::Datatype;
 use crate::error::FormatError;
 use crate::extensible_array::{
     ExtensibleArrayHeader, read_extensible_array_chunks, read_extensible_array_chunks_from_source,
@@ -29,6 +28,7 @@ use crate::filters::{ChunkContext, FilterScratch, decompress_chunk_with};
 use crate::fixed_array::{
     FixedArrayHeader, read_fixed_array_chunks, read_fixed_array_chunks_from_source,
 };
+use crate::read_spec::RawReadSpec;
 use crate::source::Source;
 
 /// Decompress all chunks, reading each chunk's bytes from a [`Source`].
@@ -568,13 +568,17 @@ fn ensure_chunk_bytes_representable(
 /// failure (an element count that cannot be addressed on this target).
 fn chunk_index_address(
     addr: Option<u64>,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
 ) -> Result<Result<u64, Vec<u8>>, FormatError> {
     if let Some(a) = addr {
         return Ok(Ok(a));
     }
+    let RawReadSpec {
+        dataspace,
+        datatype,
+        fill,
+        ..
+    } = spec;
     let elem_size = datatype.element_size_usize()?;
     let total = dataspace
         .num_elements()
@@ -597,14 +601,17 @@ fn chunk_index_address(
 /// The decompression is sequential.
 pub fn read_chunked_data_from_source<S: Source + ?Sized>(
     source: &S,
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        pipeline,
+        fill,
+    } = spec;
     let (
         chunk_dimensions,
         version,
@@ -635,7 +642,7 @@ pub fn read_chunked_data_from_source<S: Source + ?Sized>(
         }
     };
 
-    let addr = match chunk_index_address(addr_opt, dataspace, datatype, fill)? {
+    let addr = match chunk_index_address(addr_opt, spec)? {
         Ok(addr) => addr,
         Err(unallocated) => return Ok(unallocated),
     };
@@ -742,20 +749,22 @@ fn plan_chunk_spans(
 /// are returned. Returns `Ok(None)` only for a rank-0 (scalar) chunked layout — a
 /// crafted-file corner with no leading dimension to window — so the caller falls
 /// back to a whole read. The caller clamps the window to the dataset.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     source: &S,
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
     row_start: u64,
     num_rows: u64,
 ) -> Result<Option<Vec<u8>>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        pipeline,
+        fill,
+    } = spec;
     let DataLayout::Chunked {
         chunk_dimensions,
         btree_address,
@@ -1023,18 +1032,20 @@ fn row_major_strides(dims: &[usize]) -> Result<Vec<usize>, FormatError> {
 /// decompressed-chunk caching.
 ///
 /// This is the streaming counterpart of [`read_chunked_data_cached`].
-#[allow(clippy::too_many_arguments)]
 pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
     source: &S,
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        pipeline,
+        fill,
+    } = spec;
     let (
         chunk_dimensions,
         version,
@@ -1065,7 +1076,7 @@ pub fn read_chunked_data_cached_from_source<S: Source + ?Sized>(
         }
     };
 
-    let addr = match chunk_index_address(addr_opt, dataspace, datatype, fill)? {
+    let addr = match chunk_index_address(addr_opt, spec)? {
         Ok(addr) => addr,
         Err(unallocated) => return Ok(unallocated),
     };
@@ -1703,15 +1714,18 @@ fn assemble_chunks(
 /// entirely.  Decompressed chunk data is also cached with LRU eviction.
 pub fn read_chunked_data_cached(
     file_data: &[u8],
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        pipeline,
+        fill,
+    } = spec;
     let (
         chunk_dimensions,
         version,
@@ -1742,7 +1756,7 @@ pub fn read_chunked_data_cached(
         }
     };
 
-    let addr = match chunk_index_address(addr_opt, dataspace, datatype, fill)? {
+    let addr = match chunk_index_address(addr_opt, spec)? {
         Ok(addr) => addr,
         Err(unallocated) => return Ok(unallocated),
     };
@@ -2133,11 +2147,13 @@ mod tests {
         let fill_bytes = fill.to_le_bytes();
         let out = read_chunked_data_from_source(
             &BytesSource::new(&file_data),
-            &layout,
-            &dataspace,
-            &make_f64_type(),
-            None,
-            FillPattern::new(Some(&fill_bytes), nz(8)),
+            RawReadSpec {
+                layout: &layout,
+                dataspace: &dataspace,
+                datatype: &make_f64_type(),
+                pipeline: None,
+                fill: FillPattern::new(Some(&fill_bytes), nz(8)),
+            },
             8,
             8,
         )
@@ -2202,41 +2218,25 @@ mod tests {
             ),
         ] {
             let ds = simple(dims.clone());
-            let from_source = read_chunked_data_from_source(
-                &BytesSource::new(&file_data),
-                &layout,
-                &ds,
-                &datatype,
-                None,
+            let spec = RawReadSpec {
+                layout: &layout,
+                dataspace: &ds,
+                datatype: &datatype,
+                pipeline: None,
                 fill,
-                8,
-                8,
-            )
-            .unwrap();
+            };
+            let from_source =
+                read_chunked_data_from_source(&BytesSource::new(&file_data), spec, 8, 8).unwrap();
             let cached_from_source = read_chunked_data_cached_from_source(
                 &BytesSource::new(&file_data),
-                &layout,
-                &ds,
-                &datatype,
-                None,
-                fill,
+                spec,
                 8,
                 8,
                 &ChunkCache::new(),
             )
             .unwrap();
-            let cached = read_chunked_data_cached(
-                &file_data,
-                &layout,
-                &ds,
-                &datatype,
-                None,
-                fill,
-                8,
-                8,
-                &ChunkCache::new(),
-            )
-            .unwrap();
+            let cached =
+                read_chunked_data_cached(&file_data, spec, 8, 8, &ChunkCache::new()).unwrap();
             assert_eq!(from_source, expected, "dims {dims:?}");
             assert_eq!(cached_from_source, expected, "dims {dims:?}");
             assert_eq!(cached, expected, "dims {dims:?}");
@@ -2605,11 +2605,7 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &ChunkCache::new(),
@@ -2633,11 +2629,7 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &ChunkCache::new(),
@@ -2662,36 +2654,19 @@ mod tests {
         pipeline: Option<&FilterPipeline>,
     ) {
         use crate::source::ReadSeekSource;
-        let buffered = read_chunked_data_cached(
-            file_data,
+        let spec = RawReadSpec {
             layout,
             dataspace,
             datatype,
             pipeline,
-            FillPattern::ZERO,
-            8,
-            8,
-            &ChunkCache::new(),
-        )
-        .unwrap();
-        let from_mem = read_chunked_data_from_source(
-            &BytesSource::new(file_data),
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            FillPattern::ZERO,
-            8,
-            8,
-        )
-        .unwrap();
+            fill: FillPattern::ZERO,
+        };
+        let buffered = read_chunked_data_cached(file_data, spec, 8, 8, &ChunkCache::new()).unwrap();
+        let from_mem =
+            read_chunked_data_from_source(&BytesSource::new(file_data), spec, 8, 8).unwrap();
         let from_seek = read_chunked_data_from_source(
             &ReadSeekSource::new(std::io::Cursor::new(file_data.to_vec())).unwrap(),
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            FillPattern::ZERO,
+            spec,
             8,
             8,
         )
@@ -2779,11 +2754,13 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            Some(&pipeline),
-            FillPattern::ZERO,
+            RawReadSpec {
+                layout: &layout,
+                dataspace: &dataspace,
+                datatype: &datatype,
+                pipeline: Some(&pipeline),
+                fill: FillPattern::ZERO,
+            },
             8,
             8,
             &ChunkCache::new(),
@@ -2866,11 +2843,7 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &ChunkCache::new(),
@@ -2993,11 +2966,7 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &ChunkCache::new(),
@@ -3024,11 +2993,7 @@ mod tests {
         assert!(!cache.stats().index_loaded());
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &cache,
@@ -3052,11 +3017,7 @@ mod tests {
         // First read — populates index + decompressed cache
         let raw1 = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &cache,
@@ -3068,11 +3029,7 @@ mod tests {
         // Second read — should hit the decompressed cache
         let raw2 = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &cache,
@@ -3090,11 +3047,7 @@ mod tests {
 
         let raw = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &cache,
@@ -3132,11 +3085,7 @@ mod tests {
         let cache = ChunkCache::new();
         let out = read_chunked_rows_from_source(
             &BytesSource::new(b""),
-            &layout,
-            &dataspace,
-            &make_f64_type(),
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
@@ -3175,11 +3124,7 @@ mod tests {
         let cache = ChunkCache::new();
         let err = read_chunked_rows_from_source(
             &BytesSource::new(b""),
-            &layout,
-            &dataspace,
-            &make_f64_type(),
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
@@ -3219,11 +3164,7 @@ mod tests {
         let cache = ChunkCache::new();
         let err = read_chunked_rows_from_source(
             &BytesSource::new(b""),
-            &layout,
-            &dataspace,
-            &make_f64_type(),
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
@@ -3263,53 +3204,30 @@ mod tests {
             max_dimensions: None,
         };
         let seven = 7.0f64.to_le_bytes();
+        let datatype = make_f64_type();
         for fill in [FillPattern::ZERO, FillPattern::new(Some(&seven), nz(8))] {
             let cache = ChunkCache::new();
-            let whole = read_chunked_data_cached_from_source(
-                &BytesSource::new(b""),
-                &layout,
-                &dataspace,
-                &make_f64_type(),
-                None,
+            let spec = RawReadSpec {
+                layout: &layout,
+                dataspace: &dataspace,
+                datatype: &datatype,
+                pipeline: None,
                 fill,
-                8,
-                8,
-                &cache,
-            )
-            .expect("an unallocated dataset reads as fill");
+            };
+            let whole =
+                read_chunked_data_cached_from_source(&BytesSource::new(b""), spec, 8, 8, &cache)
+                    .expect("an unallocated dataset reads as fill");
             assert_eq!(whole.len(), 80);
 
-            let window = read_chunked_rows_from_source(
-                &BytesSource::new(b""),
-                &layout,
-                &dataspace,
-                &make_f64_type(),
-                None,
-                fill,
-                8,
-                8,
-                &cache,
-                2,
-                4,
-            )
-            .expect("a window over an unallocated index reads as fill")
-            .expect("rank-1 windows are supported");
+            let window =
+                read_chunked_rows_from_source(&BytesSource::new(b""), spec, 8, 8, &cache, 2, 4)
+                    .expect("a window over an unallocated index reads as fill")
+                    .expect("rank-1 windows are supported");
             assert_eq!(window, whole[16..48], "the window must match those rows");
 
-            let empty = read_chunked_rows_from_source(
-                &BytesSource::new(b""),
-                &layout,
-                &dataspace,
-                &make_f64_type(),
-                None,
-                fill,
-                8,
-                8,
-                &cache,
-                0,
-                0,
-            )
-            .expect("empty window must still be Ok");
+            let empty =
+                read_chunked_rows_from_source(&BytesSource::new(b""), spec, 8, 8, &cache, 0, 0)
+                    .expect("empty window must still be Ok");
             assert_eq!(empty, Some(Vec::new()));
         }
     }

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -3106,6 +3106,7 @@ mod tests {
     use crate::dataspace::{Dataspace, DataspaceType};
     use crate::datatype::{Datatype, DatatypeByteOrder};
     use crate::fill_value::FillPattern;
+    use crate::read_spec::RawReadSpec;
 
     fn make_f64_type() -> Datatype {
         Datatype::FloatingPoint {
@@ -3445,11 +3446,13 @@ mod tests {
 
         let output = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            pipeline.as_ref(),
-            FillPattern::ZERO,
+            RawReadSpec {
+                layout: &layout,
+                dataspace: &dataspace,
+                datatype: &datatype,
+                pipeline: pipeline.as_ref(),
+                fill: FillPattern::ZERO,
+            },
             8,
             8,
             &ChunkCache::new(),
@@ -4202,11 +4205,7 @@ mod tests {
 
         let output = read_chunked_data_cached(
             &file_data,
-            &layout,
-            &dataspace,
-            &datatype,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&layout, &dataspace, &datatype),
             8,
             8,
             &ChunkCache::new(),

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -9,7 +9,7 @@ use crate::chunk_cache::ChunkCache;
 use crate::chunked_read::{
     read_chunked_data_cached, read_chunked_data_cached_from_source, read_chunked_data_from_source,
 };
-use crate::convert::{TryToUsize, slice_range};
+use crate::convert::slice_range;
 use crate::data_layout::DataLayout;
 #[cfg(test)]
 use crate::dataspace::Dataspace;
@@ -48,34 +48,20 @@ pub fn read_raw_data_full(
     let RawReadSpec {
         layout,
         dataspace,
-        datatype,
         fill,
         ..
     } = spec;
-    let num_elements = dataspace.num_elements().to_usize()?;
-    let elem_size = datatype.type_size() as usize;
-    let expected_size = num_elements
-        .checked_mul(elem_size)
-        .ok_or(FormatError::OffsetOverflow {
-            offset: num_elements as u64,
-            length: elem_size as u64,
-        })?;
+    // The one definition of "these bytes are the dataset the dataspace
+    // describes"; the windowed readers make the same check through it.
+    let expected_size = spec.stored_byte_len()?;
 
     // Zero-element datasets have no data to read.
-    if num_elements == 0 {
+    if dataspace.num_elements() == 0 {
         return Ok(Vec::new());
     }
 
     match layout {
-        DataLayout::Compact { data } => {
-            if data.len() != expected_size {
-                return Err(FormatError::DataSizeMismatch {
-                    expected: expected_size,
-                    actual: data.len(),
-                });
-            }
-            Ok(data.clone())
-        }
+        DataLayout::Compact { data } => Ok(data.clone()),
         DataLayout::Contiguous { address, size } => {
             // No address means the storage was never allocated — the same lazy
             // allocation a chunked dataset gets, and the reference C library
@@ -84,13 +70,6 @@ pub fn read_raw_data_full(
                 return fill.buffer(expected_size);
             };
             let r = slice_range(addr, *size)?;
-            let sz = r.end - r.start;
-            if sz != expected_size {
-                return Err(FormatError::DataSizeMismatch {
-                    expected: expected_size,
-                    actual: sz,
-                });
-            }
             if r.end > file_data.len() {
                 return Err(FormatError::UnexpectedEof {
                     expected: r.end,
@@ -156,49 +135,27 @@ pub fn read_raw_data_full_from_source<S: Source + ?Sized>(
     let RawReadSpec {
         layout,
         dataspace,
-        datatype,
         fill,
         ..
     } = spec;
-    let num_elements = dataspace.num_elements().to_usize()?;
-    let elem_size = datatype.type_size() as usize;
-    let expected_size = num_elements
-        .checked_mul(elem_size)
-        .ok_or(FormatError::OffsetOverflow {
-            offset: num_elements as u64,
-            length: elem_size as u64,
-        })?;
+    // See the buffered reader: one definition, shared with the windowed ones.
+    let expected_size = spec.stored_byte_len()?;
 
-    if num_elements == 0 {
+    if dataspace.num_elements() == 0 {
         return Ok(Vec::new());
     }
 
     match layout {
-        DataLayout::Compact { data } => {
-            if data.len() != expected_size {
-                return Err(FormatError::DataSizeMismatch {
-                    expected: expected_size,
-                    actual: data.len(),
-                });
-            }
-            Ok(data.clone())
-        }
-        DataLayout::Contiguous { address, size } => {
+        DataLayout::Compact { data } => Ok(data.clone()),
+        DataLayout::Contiguous { address, .. } => {
             // Unallocated contiguous storage reads as the fill value; see the
             // buffered reader's matching arm.
             let Some(addr) = *address else {
                 return fill.buffer(expected_size);
             };
-            let sz = (*size).to_usize()?;
-            if sz != expected_size {
-                return Err(FormatError::DataSizeMismatch {
-                    expected: expected_size,
-                    actual: sz,
-                });
-            }
             // The single point of I/O; `read_exact_at` bounds-checks against the
             // source length (in u64) and errors instead of truncating.
-            source.read_exact_at(addr, sz)
+            source.read_exact_at(addr, expected_size)
         }
         DataLayout::Chunked { .. } => {
             read_chunked_data_from_source(source, spec, offset_size, length_size)
@@ -300,19 +257,19 @@ fn is_standard_layout(
 }
 
 /// Bulk-decode `$raw` — already validated as a whole multiple of the storage
-/// width — into a `Vec<$out>` for a standard-layout numeric type. `$store` is the
-/// width-matched storage scalar (e.g. `i32` for a 4-byte signed integer, `f64`
-/// for an 8-byte float). Each element is decoded with the correct endianness via
-/// `from_le_bytes`/`from_be_bytes` and converted to the requested `$out` element
-/// type with `as`, which reproduces the per-element slow path exactly for the
-/// full-width case: integer storage is bit-reinterpreted then sign/zero-extended
-/// or narrowed; float storage is value-converted. `chunks_exact` yields
-/// guaranteed `$store`-sized slices, so `try_into` never fails and the bounds
-/// check is hoisted out of the loop.
+/// width — appending to `$dst`, a `Vec<$out>` the caller has already reserved
+/// room in. `$store` is the width-matched storage scalar (e.g. `i32` for a
+/// 4-byte signed integer, `f64` for an 8-byte float). Each element is decoded
+/// with the correct endianness via `from_le_bytes`/`from_be_bytes` and converted
+/// to the requested `$out` element type with `as`, which reproduces the
+/// per-element slow path exactly for the full-width case: integer storage is
+/// bit-reinterpreted then sign/zero-extended or narrowed; float storage is
+/// value-converted. `chunks_exact` yields guaranteed `$store`-sized slices, so
+/// `try_into` never fails and the bounds check is hoisted out of the loop.
 macro_rules! bulk_decode {
-    ($raw:expr, $count:expr, $order:expr, $store:ty, $out:ty) => {{
+    ($dst:expr, $raw:expr, $order:expr, $store:ty, $out:ty) => {{
         const W: usize = core::mem::size_of::<$store>();
-        let mut result: Vec<$out> = Vec::with_capacity($count);
+        let dst: &mut Vec<$out> = $dst;
         match $order {
             DatatypeByteOrder::BigEndian => {
                 for c in $raw.chunks_exact(W) {
@@ -322,7 +279,7 @@ macro_rules! bulk_decode {
                         clippy::cast_possible_wrap,
                         clippy::unnecessary_cast
                     )]
-                    result.push(<$store>::from_be_bytes(a) as $out);
+                    dst.push(<$store>::from_be_bytes(a) as $out);
                 }
             }
             // LittleEndian here (Vax is excluded by `is_standard_layout`).
@@ -334,16 +291,35 @@ macro_rules! bulk_decode {
                         clippy::cast_possible_wrap,
                         clippy::unnecessary_cast
                     )]
-                    result.push(<$store>::from_le_bytes(a) as $out);
+                    dst.push(<$store>::from_le_bytes(a) as $out);
                 }
             }
         }
-        result
     }};
 }
 
 /// Convert raw bytes to `f64` values.
 pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatError> {
+    let mut out = Vec::new();
+    read_as_f64_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_f64`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_f64_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<f64>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint or FixedPoint")?;
     let elem_size = get_size(datatype)?;
@@ -356,33 +332,38 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
-                return Ok(bulk_decode!(raw, count, order, f32, f64));
+                bulk_decode!(out, raw, order, f32, f64);
+                return Ok(());
             }
             Datatype::FloatingPoint { size: 8, .. } => {
-                return Ok(bulk_decode!(raw, count, order, f64, f64));
+                bulk_decode!(out, raw, order, f64, f64);
+                return Ok(());
             }
             Datatype::FixedPoint { signed: true, .. } => {
-                return Ok(match elem_size.get() {
-                    1 => bulk_decode!(raw, count, order, i8, f64),
-                    2 => bulk_decode!(raw, count, order, i16, f64),
-                    4 => bulk_decode!(raw, count, order, i32, f64),
-                    8 => bulk_decode!(raw, count, order, i64, f64),
+                match elem_size.get() {
+                    1 => bulk_decode!(out, raw, order, i8, f64),
+                    2 => bulk_decode!(out, raw, order, i16, f64),
+                    4 => bulk_decode!(out, raw, order, i32, f64),
+                    8 => bulk_decode!(out, raw, order, i64, f64),
                     _ => unreachable!(),
-                });
+                }
+                return Ok(());
             }
             Datatype::FixedPoint { signed: false, .. } => {
-                return Ok(match elem_size.get() {
-                    1 => bulk_decode!(raw, count, order, u8, f64),
-                    2 => bulk_decode!(raw, count, order, u16, f64),
-                    4 => bulk_decode!(raw, count, order, u32, f64),
-                    8 => bulk_decode!(raw, count, order, u64, f64),
+                match elem_size.get() {
+                    1 => bulk_decode!(out, raw, order, u8, f64),
+                    2 => bulk_decode!(out, raw, order, u16, f64),
+                    4 => bulk_decode!(out, raw, order, u32, f64),
+                    8 => bulk_decode!(out, raw, order, u64, f64),
                     _ => unreachable!(),
-                });
+                }
+                return Ok(());
             }
             // Other classes (e.g. a 2-byte float, with no `f16`) fall through to
             // the slow path, which errors exactly as before.
@@ -390,13 +371,12 @@ pub fn read_as_f64(raw: &[u8], datatype: &Datatype) -> Result<Vec<f64>, FormatEr
         }
     }
 
-    let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         let val = convert_to_f64(chunk, datatype, &order)?;
-        result.push(val);
+        out.push(val);
     }
-    Ok(result)
+    Ok(())
 }
 
 fn convert_to_f64(
@@ -441,6 +421,26 @@ fn convert_to_f64(
 
 /// Convert raw bytes to `i64` values.
 pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatError> {
+    let mut out = Vec::new();
+    read_as_i64_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_i64`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_i64_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<i64>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (signed)")?;
     let elem_size = get_size(datatype)?;
@@ -453,31 +453,52 @@ pub fn read_as_i64(raw: &[u8], datatype: &Datatype) -> Result<Vec<i64>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     // Fast path: standard full-width layout, bulk-decoded then sign-extended.
     // Signed storage types reproduce `read_signed_int`'s sign-extension for the
     // full-width case (and a float read as i64 bit-reinterprets identically).
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, i8, i64),
-            2 => bulk_decode!(raw, count, order, i16, i64),
-            4 => bulk_decode!(raw, count, order, i32, i64),
-            8 => bulk_decode!(raw, count, order, i64, i64),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, i8, i64),
+            2 => bulk_decode!(out, raw, order, i16, i64),
+            4 => bulk_decode!(out, raw, order, i32, i64),
+            8 => bulk_decode!(out, raw, order, i64, i64),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
-    let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         let v = read_signed_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
-        result.push(v);
+        out.push(v);
     }
-    Ok(result)
+    Ok(())
 }
 
 /// Convert raw bytes to `u64` values.
 pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatError> {
+    let mut out = Vec::new();
+    read_as_u64_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_u64`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_u64_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<u64>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype)?;
@@ -490,30 +511,51 @@ pub fn read_as_u64(raw: &[u8], datatype: &Datatype) -> Result<Vec<u64>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     // Fast path: standard full-width layout, bulk-decoded with zero-extension
     // (unsigned storage types reproduce `read_unsigned_int`'s magnitude).
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, u8, u64),
-            2 => bulk_decode!(raw, count, order, u16, u64),
-            4 => bulk_decode!(raw, count, order, u32, u64),
-            8 => bulk_decode!(raw, count, order, u64, u64),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, u8, u64),
+            2 => bulk_decode!(out, raw, order, u16, u64),
+            4 => bulk_decode!(out, raw, order, u32, u64),
+            8 => bulk_decode!(out, raw, order, u64, u64),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
-    let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         let v = read_unsigned_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
-        result.push(v);
+        out.push(v);
     }
-    Ok(result)
+    Ok(())
 }
 
 /// Convert raw bytes to `f32` values.
 pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatError> {
+    let mut out = Vec::new();
+    read_as_f32_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_f32`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_f32_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<f32>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FloatingPoint")?;
     let elem_size = get_size(datatype)?;
@@ -526,51 +568,55 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     // Fast path: standard full-width layout, bulk-decoded with `from_*_bytes`.
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
-                return Ok(bulk_decode!(raw, count, order, f32, f32));
+                bulk_decode!(out, raw, order, f32, f32);
+                return Ok(());
             }
             Datatype::FloatingPoint { size: 8, .. } => {
-                return Ok(bulk_decode!(raw, count, order, f64, f32));
+                bulk_decode!(out, raw, order, f64, f32);
+                return Ok(());
             }
             Datatype::FixedPoint { signed: true, .. } => {
-                return Ok(match elem_size.get() {
-                    1 => bulk_decode!(raw, count, order, i8, f32),
-                    2 => bulk_decode!(raw, count, order, i16, f32),
-                    4 => bulk_decode!(raw, count, order, i32, f32),
-                    8 => bulk_decode!(raw, count, order, i64, f32),
+                match elem_size.get() {
+                    1 => bulk_decode!(out, raw, order, i8, f32),
+                    2 => bulk_decode!(out, raw, order, i16, f32),
+                    4 => bulk_decode!(out, raw, order, i32, f32),
+                    8 => bulk_decode!(out, raw, order, i64, f32),
                     _ => unreachable!(),
-                });
+                }
+                return Ok(());
             }
             Datatype::FixedPoint { signed: false, .. } => {
-                return Ok(match elem_size.get() {
-                    1 => bulk_decode!(raw, count, order, u8, f32),
-                    2 => bulk_decode!(raw, count, order, u16, f32),
-                    4 => bulk_decode!(raw, count, order, u32, f32),
-                    8 => bulk_decode!(raw, count, order, u64, f32),
+                match elem_size.get() {
+                    1 => bulk_decode!(out, raw, order, u8, f32),
+                    2 => bulk_decode!(out, raw, order, u16, f32),
+                    4 => bulk_decode!(out, raw, order, u32, f32),
+                    8 => bulk_decode!(out, raw, order, u64, f32),
                     _ => unreachable!(),
-                });
+                }
+                return Ok(());
             }
             _ => {}
         }
     }
 
-    let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         match datatype {
             Datatype::FloatingPoint { size: 4, .. } => {
-                result.push(read_f32_bytes(chunk, &order));
+                out.push(read_f32_bytes(chunk, &order));
             }
             Datatype::FloatingPoint { size: 8, .. } => {
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "read_as_f32 narrows stored f64 values to the requested f32"
                 )]
-                result.push(read_f64_bytes(chunk, &order) as f32);
+                out.push(read_f64_bytes(chunk, &order) as f32);
             }
             Datatype::FixedPoint {
                 signed: true,
@@ -579,13 +625,10 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
                 bit_precision,
                 ..
             } => {
-                result.push(read_signed_int(
-                    chunk,
-                    *size as usize,
-                    &order,
-                    *bit_offset,
-                    *bit_precision,
-                ) as f32);
+                out.push(
+                    read_signed_int(chunk, *size as usize, &order, *bit_offset, *bit_precision)
+                        as f32,
+                );
             }
             Datatype::FixedPoint {
                 signed: false,
@@ -594,7 +637,7 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
                 bit_precision,
                 ..
             } => {
-                result.push(read_unsigned_int(
+                out.push(read_unsigned_int(
                     chunk,
                     *size as usize,
                     &order,
@@ -610,11 +653,31 @@ pub fn read_as_f32(raw: &[u8], datatype: &Datatype) -> Result<Vec<f32>, FormatEr
             }
         }
     }
-    Ok(result)
+    Ok(())
 }
 
 /// Convert raw bytes to `i32` values.
 pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatError> {
+    let mut out = Vec::new();
+    read_as_i32_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_i32`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_i32_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<i32>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
     let elem_size = get_size(datatype)?;
@@ -627,20 +690,21 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     // Fast path: standard full-width layout, bulk-decoded then narrowed to i32
     // (matches `read_signed_int(..) as i32` for the full-width case).
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, i8, i32),
-            2 => bulk_decode!(raw, count, order, i16, i32),
-            4 => bulk_decode!(raw, count, order, i32, i32),
-            8 => bulk_decode!(raw, count, order, i64, i32),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, i8, i32),
+            2 => bulk_decode!(out, raw, order, i16, i32),
+            4 => bulk_decode!(out, raw, order, i32, i32),
+            8 => bulk_decode!(out, raw, order, i64, i32),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
-    let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let chunk = &raw[i * elem_size.get()..(i + 1) * elem_size.get()];
         let v = read_signed_int(chunk, elem_size.get(), &order, bit_offset, bit_precision);
@@ -648,14 +712,34 @@ pub fn read_as_i32(raw: &[u8], datatype: &Datatype) -> Result<Vec<i32>, FormatEr
             clippy::cast_possible_truncation,
             reason = "read_as_i32 narrows each stored signed value to the requested i32"
         )]
-        result.push(v as i32);
+        out.push(v as i32);
     }
-    Ok(result)
+    Ok(())
 }
 
 /// Convert raw bytes to `i16` values (counterpart of [`read_as_i32`] for the
 /// narrower element type, used by [`crate::Dataset::read_i16`]).
 pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatError> {
+    let mut out = Vec::new();
+    read_as_i16_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_i16`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_i16_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<i16>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint")?;
     let elem_size = get_size(datatype)?;
@@ -668,15 +752,17 @@ pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, i8, i16),
-            2 => bulk_decode!(raw, count, order, i16, i16),
-            4 => bulk_decode!(raw, count, order, i32, i16),
-            8 => bulk_decode!(raw, count, order, i64, i16),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, i8, i16),
+            2 => bulk_decode!(out, raw, order, i16, i16),
+            4 => bulk_decode!(out, raw, order, i32, i16),
+            8 => bulk_decode!(out, raw, order, i64, i16),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
     // Slow path: decode wide, then narrow (matches the prior `read_i16` route
@@ -685,15 +771,33 @@ pub fn read_as_i16(raw: &[u8], datatype: &Datatype) -> Result<Vec<i16>, FormatEr
         clippy::cast_possible_truncation,
         reason = "read_as_i16 narrows each stored value to the requested i16"
     )]
-    Ok(read_as_i32(raw, datatype)?
-        .into_iter()
-        .map(|v| v as i16)
-        .collect())
+    out.extend(read_as_i32(raw, datatype)?.into_iter().map(|v| v as i16));
+    Ok(())
 }
 
 /// Convert raw bytes to `u32` values (counterpart of [`read_as_u64`] for the
 /// narrower element type, used by [`crate::Dataset::read_u32`]).
 pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatError> {
+    let mut out = Vec::new();
+    read_as_u32_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_u32`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_u32_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<u32>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype)?;
@@ -706,30 +810,50 @@ pub fn read_as_u32(raw: &[u8], datatype: &Datatype) -> Result<Vec<u32>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, u8, u32),
-            2 => bulk_decode!(raw, count, order, u16, u32),
-            4 => bulk_decode!(raw, count, order, u32, u32),
-            8 => bulk_decode!(raw, count, order, u64, u32),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, u8, u32),
+            2 => bulk_decode!(out, raw, order, u16, u32),
+            4 => bulk_decode!(out, raw, order, u32, u32),
+            8 => bulk_decode!(out, raw, order, u64, u32),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
     #[expect(
         clippy::cast_possible_truncation,
         reason = "read_as_u32 narrows each stored value to the requested u32"
     )]
-    Ok(read_as_u64(raw, datatype)?
-        .into_iter()
-        .map(|v| v as u32)
-        .collect())
+    out.extend(read_as_u64(raw, datatype)?.into_iter().map(|v| v as u32));
+    Ok(())
 }
 
 /// Convert raw bytes to `u16` values (counterpart of [`read_as_u64`] for the
 /// narrower element type, used by [`crate::Dataset::read_u16`]).
 pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatError> {
+    let mut out = Vec::new();
+    read_as_u16_into(raw, datatype, &mut out)?;
+    Ok(out)
+}
+
+/// Decode `raw` and **append** the values to `out`, the appending form of
+/// [`read_as_u16`].
+///
+/// A whole-dataset typed read sweeps its dataset in row windows and decodes
+/// each window into one output buffer, so the decoders must add to a buffer
+/// rather than each produce one (issue #289).
+///
+/// On error `out` holds an unspecified prefix of this call's values: every
+/// caller abandons the buffer, and nothing else is worth the copy that
+/// avoiding it would cost.
+pub fn read_as_u16_into(
+    raw: &[u8],
+    datatype: &Datatype,
+    out: &mut Vec<u16>,
+) -> Result<(), FormatError> {
     let datatype = effective_numeric(datatype);
     ensure_numeric(datatype, "FixedPoint (unsigned)")?;
     let elem_size = get_size(datatype)?;
@@ -742,25 +866,25 @@ pub fn read_as_u16(raw: &[u8], datatype: &Datatype) -> Result<Vec<u16>, FormatEr
     let count = raw.len() / elem_size;
     let order = get_byte_order(datatype);
     let (bit_offset, bit_precision) = int_bits(datatype);
+    out.reserve(count);
 
     if is_standard_layout(elem_size.get(), &order, bit_offset, bit_precision) {
-        return Ok(match elem_size.get() {
-            1 => bulk_decode!(raw, count, order, u8, u16),
-            2 => bulk_decode!(raw, count, order, u16, u16),
-            4 => bulk_decode!(raw, count, order, u32, u16),
-            8 => bulk_decode!(raw, count, order, u64, u16),
+        match elem_size.get() {
+            1 => bulk_decode!(out, raw, order, u8, u16),
+            2 => bulk_decode!(out, raw, order, u16, u16),
+            4 => bulk_decode!(out, raw, order, u32, u16),
+            8 => bulk_decode!(out, raw, order, u64, u16),
             _ => unreachable!(),
-        });
+        }
+        return Ok(());
     }
 
     #[expect(
         clippy::cast_possible_truncation,
         reason = "read_as_u16 narrows each stored value to the requested u16"
     )]
-    Ok(read_as_u64(raw, datatype)?
-        .into_iter()
-        .map(|v| v as u16)
-        .collect())
+    out.extend(read_as_u64(raw, datatype)?.into_iter().map(|v| v as u16));
+    Ok(())
 }
 
 /// Read fixed-length strings from raw bytes.

--- a/src/data_read.rs
+++ b/src/data_read.rs
@@ -11,11 +11,11 @@ use crate::chunked_read::{
 };
 use crate::convert::{TryToUsize, slice_range};
 use crate::data_layout::DataLayout;
+#[cfg(test)]
 use crate::dataspace::Dataspace;
 use crate::datatype::{Datatype, DatatypeByteOrder};
 use crate::error::FormatError;
-use crate::fill_value::FillPattern;
-use crate::filter_pipeline::FilterPipeline;
+use crate::read_spec::RawReadSpec;
 use crate::source::Source;
 
 /// Read raw bytes for a dataset given its layout and the file data buffer,
@@ -32,11 +32,7 @@ pub fn read_raw_data(
 ) -> Result<Vec<u8>, FormatError> {
     read_raw_data_full(
         file_data,
-        layout,
-        dataspace,
-        datatype,
-        None,
-        FillPattern::ZERO,
+        RawReadSpec::plain(layout, dataspace, datatype),
         8,
         8,
     )
@@ -45,14 +41,17 @@ pub fn read_raw_data(
 /// Read raw bytes with full parameters including filter pipeline and sizes.
 pub fn read_raw_data_full(
     file_data: &[u8],
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        fill,
+        ..
+    } = spec;
     let num_elements = dataspace.num_elements().to_usize()?;
     let elem_size = datatype.type_size() as usize;
     let expected_size = num_elements
@@ -105,11 +104,7 @@ pub fn read_raw_data_full(
         // callers, at the cost of a cache that lives only for the call.
         DataLayout::Chunked { .. } => read_chunked_data_cached(
             file_data,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
+            spec,
             offset_size,
             length_size,
             &ChunkCache::new(),
@@ -125,37 +120,16 @@ pub fn read_raw_data_full(
 /// contiguous layouts this behaves identically to [`read_raw_data_full`].
 pub fn read_raw_data_cached(
     file_data: &[u8],
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
-    match layout {
-        DataLayout::Chunked { .. } => read_chunked_data_cached(
-            file_data,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
-            offset_size,
-            length_size,
-            cache,
-        ),
-        _ => read_raw_data_full(
-            file_data,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
-            offset_size,
-            length_size,
-        ),
+    match spec.layout {
+        DataLayout::Chunked { .. } => {
+            read_chunked_data_cached(file_data, spec, offset_size, length_size, cache)
+        }
+        _ => read_raw_data_full(file_data, spec, offset_size, length_size),
     }
 }
 
@@ -175,14 +149,17 @@ pub fn read_raw_data_cached(
 /// [`read_raw_data_full`]).
 pub fn read_raw_data_full_from_source<S: Source + ?Sized>(
     source: &S,
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
 ) -> Result<Vec<u8>, FormatError> {
+    let RawReadSpec {
+        layout,
+        dataspace,
+        datatype,
+        fill,
+        ..
+    } = spec;
     let num_elements = dataspace.num_elements().to_usize()?;
     let elem_size = datatype.type_size() as usize;
     let expected_size = num_elements
@@ -223,55 +200,26 @@ pub fn read_raw_data_full_from_source<S: Source + ?Sized>(
             // source length (in u64) and errors instead of truncating.
             source.read_exact_at(addr, sz)
         }
-        DataLayout::Chunked { .. } => read_chunked_data_from_source(
-            source,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
-            offset_size,
-            length_size,
-        ),
+        DataLayout::Chunked { .. } => {
+            read_chunked_data_from_source(source, spec, offset_size, length_size)
+        }
         DataLayout::Virtual { .. } => Err(FormatError::UnsupportedVirtualLayout),
     }
 }
 
 /// Streaming counterpart of [`read_raw_data_cached`].
-#[allow(clippy::too_many_arguments)]
 pub fn read_raw_data_cached_from_source<S: Source + ?Sized>(
     source: &S,
-    layout: &DataLayout,
-    dataspace: &Dataspace,
-    datatype: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
 ) -> Result<Vec<u8>, FormatError> {
-    match layout {
-        DataLayout::Chunked { .. } => read_chunked_data_cached_from_source(
-            source,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
-            offset_size,
-            length_size,
-            cache,
-        ),
-        _ => read_raw_data_full_from_source(
-            source,
-            layout,
-            dataspace,
-            datatype,
-            pipeline,
-            fill,
-            offset_size,
-            length_size,
-        ),
+    match spec.layout {
+        DataLayout::Chunked { .. } => {
+            read_chunked_data_cached_from_source(source, spec, offset_size, length_size, cache)
+        }
+        _ => read_raw_data_full_from_source(source, spec, offset_size, length_size),
     }
 }
 
@@ -986,6 +934,7 @@ mod tests {
     use crate::convert::nz;
     use crate::dataspace::{Dataspace, DataspaceType};
     use crate::datatype::{CharacterSet, StringPadding};
+    use crate::fill_value::FillPattern;
     #[cfg(not(feature = "std"))]
     use alloc::vec;
 
@@ -1223,11 +1172,13 @@ mod tests {
         let seven = 7.0f64.to_le_bytes();
         let filled = read_raw_data_full(
             &[],
-            &layout,
-            &ds,
-            &dt,
-            None,
-            FillPattern::new(Some(&seven), nz(8)),
+            RawReadSpec {
+                layout: &layout,
+                dataspace: &ds,
+                datatype: &dt,
+                pipeline: None,
+                fill: FillPattern::new(Some(&seven), nz(8)),
+            },
             8,
             8,
         )
@@ -1294,27 +1245,13 @@ mod tests {
             size: 24,
         };
 
-        let buffered =
-            read_raw_data_full(&file_data, &layout, &ds, &dt, None, FillPattern::ZERO, 8, 8)
-                .unwrap();
-        let from_mem = read_raw_data_full_from_source(
-            &BytesSource::new(&file_data),
-            &layout,
-            &ds,
-            &dt,
-            None,
-            FillPattern::ZERO,
-            8,
-            8,
-        )
-        .unwrap();
+        let spec = RawReadSpec::plain(&layout, &ds, &dt);
+        let buffered = read_raw_data_full(&file_data, spec, 8, 8).unwrap();
+        let from_mem =
+            read_raw_data_full_from_source(&BytesSource::new(&file_data), spec, 8, 8).unwrap();
         let from_seek = read_raw_data_full_from_source(
             &ReadSeekSource::new(std::io::Cursor::new(file_data)).unwrap(),
-            &layout,
-            &ds,
-            &dt,
-            None,
-            FillPattern::ZERO,
+            spec,
             8,
             8,
         )
@@ -1336,19 +1273,10 @@ mod tests {
             data.extend_from_slice(&v.to_le_bytes());
         }
         let layout = DataLayout::Compact { data };
-        let buffered =
-            read_raw_data_full(&[], &layout, &ds, &dt, None, FillPattern::ZERO, 8, 8).unwrap();
-        let streamed = read_raw_data_full_from_source(
-            &BytesSource::new(Vec::new()),
-            &layout,
-            &ds,
-            &dt,
-            None,
-            FillPattern::ZERO,
-            8,
-            8,
-        )
-        .unwrap();
+        let spec = RawReadSpec::plain(&layout, &ds, &dt);
+        let buffered = read_raw_data_full(&[], spec, 8, 8).unwrap();
+        let streamed =
+            read_raw_data_full_from_source(&BytesSource::new(Vec::new()), spec, 8, 8).unwrap();
         assert_eq!(buffered, streamed);
     }
 
@@ -1368,18 +1296,16 @@ mod tests {
         };
         let seven = 7.0f64.to_le_bytes();
         for fill in [FillPattern::ZERO, FillPattern::new(Some(&seven), nz(8))] {
-            let buffered = read_raw_data_full(&[], &layout, &ds, &dt, None, fill, 8, 8).unwrap();
-            let streamed = read_raw_data_full_from_source(
-                &BytesSource::new(Vec::new()),
-                &layout,
-                &ds,
-                &dt,
-                None,
+            let spec = RawReadSpec {
+                layout: &layout,
+                dataspace: &ds,
+                datatype: &dt,
+                pipeline: None,
                 fill,
-                8,
-                8,
-            )
-            .unwrap();
+            };
+            let buffered = read_raw_data_full(&[], spec, 8, 8).unwrap();
+            let streamed =
+                read_raw_data_full_from_source(&BytesSource::new(Vec::new()), spec, 8, 8).unwrap();
             assert_eq!(buffered, streamed);
             assert_eq!(buffered.len(), 24);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@ pub(crate) mod lzf;
 pub(crate) mod message_type;
 pub(crate) mod object_header;
 pub(crate) mod object_header_writer;
+pub(crate) mod read_spec;
 pub(crate) mod scaleoffset;
 pub(crate) mod shared_message;
 pub(crate) mod signature;

--- a/src/read_spec.rs
+++ b/src/read_spec.rs
@@ -16,9 +16,14 @@
 //! layer at once, and the sites that must decide what it is are the few that
 //! build the spec.
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
+use crate::error::FormatError;
 use crate::fill_value::FillPattern;
 use crate::filter_pipeline::FilterPipeline;
 
@@ -46,6 +51,51 @@ pub struct RawReadSpec<'a> {
 }
 
 impl<'a> RawReadSpec<'a> {
+    /// The byte length this dataset's elements occupy, checked against what its
+    /// layout says it stores.
+    ///
+    /// A compact or contiguous layout names its own size, and a disagreement
+    /// with the dataspace is a corrupt or crafted file rather than a short read.
+    /// The check lives here because two kinds of read have to make it and make
+    /// it the same way: a whole read, and a read that takes the dataset a row
+    /// window at a time. A check only one of them made would fire or not
+    /// depending on the dataset's *size* — the windowed readers read a small
+    /// dataset whole — which is worse than no check at all (issue #289).
+    ///
+    /// A zero-element dataset is exempt, as it is in the readers: it has no
+    /// bytes to disagree about, and its layout may say anything.
+    ///
+    /// Chunked storage names no total size, and a chunk the file does not hold
+    /// reads as the fill value rather than as an error, so there is nothing here
+    /// to check for it.
+    pub fn stored_byte_len(&self) -> Result<usize, FormatError> {
+        let num_elements = self.dataspace.num_elements().to_usize()?;
+        let elem_size = self.datatype.type_size() as usize;
+        let expected = num_elements
+            .checked_mul(elem_size)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: num_elements as u64,
+                length: elem_size as u64,
+            })?;
+        if num_elements == 0 {
+            return Ok(expected);
+        }
+        let actual = match self.layout {
+            DataLayout::Compact { data } => data.len(),
+            // No address means storage that was never allocated, which reads as
+            // the fill value and has no size to disagree with.
+            DataLayout::Contiguous {
+                address: Some(_),
+                size,
+            } => (*size).to_usize()?,
+            _ => return Ok(expected),
+        };
+        if actual != expected {
+            return Err(FormatError::DataSizeMismatch { expected, actual });
+        }
+        Ok(expected)
+    }
+
     /// A spec for an unfiltered dataset whose unallocated storage reads as
     /// zeros — the shape a test fixture wants, and never the shape a real read
     /// wants, which is why the live paths build the struct literally.

--- a/src/read_spec.rs
+++ b/src/read_spec.rs
@@ -1,0 +1,62 @@
+//! The per-dataset properties every raw read is performed against.
+//!
+//! Reading a dataset's element bytes takes five facts about the dataset — where
+//! its storage is, what shape it has, what an element is, what filters its bytes
+//! passed through, and what unallocated storage reads as — and the call chain
+//! that does it is four layers deep: the reader picks a backend, `data_read`
+//! dispatches on the layout, `chunked_read` walks the chunk index, and the
+//! assembly kernel places what it decoded. Every layer needs all five, so before
+//! this type they were threaded through as five positional parameters and the
+//! signatures reached twelve arguments.
+//!
+//! The cost of that shape was not the width; it was that adding a property meant
+//! editing roughly thirty call sites, several of them mechanically across test
+//! fixtures, where a default inserted in place of a real value compiles and
+//! passes (issue #294). A property added to [`RawReadSpec`] instead reaches every
+//! layer at once, and the sites that must decide what it is are the few that
+//! build the spec.
+
+use crate::data_layout::DataLayout;
+use crate::dataspace::Dataspace;
+use crate::datatype::Datatype;
+use crate::fill_value::FillPattern;
+use crate::filter_pipeline::FilterPipeline;
+
+/// What a raw read needs to know about the dataset it is reading.
+///
+/// These are properties of the *dataset*. The file-level address widths
+/// (`offset_size`, `length_size`) travel beside a spec rather than in it: they
+/// are the same for every dataset in a file, and the rest of the crate already
+/// passes them as a pair.
+///
+/// `Copy`, so a spec is handed down the call chain the way the five borrows it
+/// replaced were, with no clone and no lifetime beyond the borrows themselves.
+#[derive(Clone, Copy)]
+pub struct RawReadSpec<'a> {
+    /// Where the dataset's bytes live: compact, contiguous, or chunked.
+    pub layout: &'a DataLayout,
+    /// The dataset's shape, which fixes how many elements the read produces.
+    pub dataspace: &'a Dataspace,
+    /// The stored element type, which fixes each element's width.
+    pub datatype: &'a Datatype,
+    /// The filter pipeline stored bytes passed through, if any.
+    pub pipeline: Option<&'a FilterPipeline>,
+    /// What storage that was never allocated reads as.
+    pub fill: FillPattern<'a>,
+}
+
+impl<'a> RawReadSpec<'a> {
+    /// A spec for an unfiltered dataset whose unallocated storage reads as
+    /// zeros — the shape a test fixture wants, and never the shape a real read
+    /// wants, which is why the live paths build the struct literally.
+    #[cfg(test)]
+    pub fn plain(layout: &'a DataLayout, dataspace: &'a Dataspace, datatype: &'a Datatype) -> Self {
+        Self {
+            layout,
+            dataspace,
+            datatype,
+            pipeline: None,
+            fill: FillPattern::ZERO,
+        }
+    }
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -15,7 +16,7 @@ use crate::type_builders::{DatasetBuilder, VL_REF_SIZE};
 
 use crate::appender::BufferedAppender;
 use crate::attribute::{extract_attributes_full, extract_attributes_full_from_source};
-use crate::chunk_cache::{ChunkCache, ChunkCacheConfig, ChunkCacheStats};
+use crate::chunk_cache::{CachePass, ChunkCache, ChunkCacheConfig, ChunkCacheStats};
 use crate::compound::CompoundType;
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
@@ -1384,6 +1385,7 @@ impl FileInner {
         &self,
         spec: RawReadSpec<'_>,
         cache: &ChunkCache,
+        pass: CachePass,
         start_row: u64,
         num_rows: u64,
     ) -> Result<Vec<u8>, FormatError> {
@@ -1449,6 +1451,7 @@ impl FileInner {
                     os,
                     ls,
                     cache,
+                    pass,
                     start_row,
                     num_rows,
                     row_bytes,
@@ -1460,6 +1463,7 @@ impl FileInner {
                 os,
                 ls,
                 cache,
+                pass,
                 start_row,
                 num_rows,
                 row_bytes,
@@ -1469,7 +1473,9 @@ impl FileInner {
                     inner: s.as_ref(),
                     base,
                 };
-                read_rows_framed(&framed, spec, os, ls, cache, start_row, num_rows, row_bytes)
+                read_rows_framed(
+                    &framed, spec, os, ls, cache, pass, start_row, num_rows, row_bytes,
+                )
             }
             Backend::Edit(m) => Self::with_engine(
                 m,
@@ -1489,6 +1495,7 @@ impl FileInner {
                         os,
                         ls,
                         cache,
+                        pass,
                         start_row,
                         num_rows,
                         row_bytes,
@@ -1496,7 +1503,9 @@ impl FileInner {
                 },
                 |s| {
                     let framed = BaseOffsetSource { inner: s, base };
-                    read_rows_framed(&framed, spec, os, ls, cache, start_row, num_rows, row_bytes)
+                    read_rows_framed(
+                        &framed, spec, os, ls, cache, pass, start_row, num_rows, row_bytes,
+                    )
                 },
             ),
         }
@@ -1513,6 +1522,7 @@ fn read_rows_framed<S: Source + ?Sized>(
     os: u8,
     ls: u8,
     cache: &ChunkCache,
+    pass: CachePass,
     start_row: u64,
     num_rows: u64,
     row_bytes: usize,
@@ -1563,7 +1573,7 @@ fn read_rows_framed<S: Source + ?Sized>(
         }
         DataLayout::Chunked { .. } => {
             match crate::chunked_read::read_chunked_rows_from_source(
-                source, spec, os, ls, cache, start_row, num_rows,
+                source, spec, os, ls, cache, pass, start_row, num_rows,
             )? {
                 Some(bytes) => Ok(bytes),
                 // Rank-0 chunked (a crafted-file corner): fall back to a whole
@@ -2998,6 +3008,87 @@ impl std::fmt::Debug for Dataset {
     }
 }
 
+/// How many stored bytes a typed whole-dataset read holds beside its output,
+/// before rounding the window up to whole chunk bands.
+///
+/// The decoded values are the caller's and there is no bound to put on them;
+/// what this bounds is the *stored* copy standing next to them, which used to be
+/// the whole dataset over again (issue #289). A mebibyte is small against any
+/// dataset large enough for that to matter, and large enough that a sweep costs
+/// reads in the tens rather than the thousands. A dataset that fits inside one
+/// window is read whole, exactly as before.
+const TYPED_READ_WINDOW_BYTES: u64 = 1 << 20;
+
+/// How many values of the requested type a whole-dataset read produces per
+/// stored element, which is what its output buffer is reserved at.
+#[derive(Clone, Copy)]
+enum OutputSize {
+    /// One value per stored element — every numeric decoder.
+    PerElement,
+    /// One value per stored *byte* — [`Dataset::read_i8`], which reinterprets
+    /// bytes rather than decoding elements, and so yields one per byte of a
+    /// dataset whose elements are wider than one.
+    PerByte,
+}
+
+/// How many leading-dimension rows a typed whole-dataset read decodes at a time.
+///
+/// [`TYPED_READ_WINDOW_BYTES`] of stored bytes, rounded *down* to whole chunk
+/// bands so that no chunk is ever decoded for two windows, and never fewer than
+/// one row — or one band, when a single band is already over budget, since a
+/// window narrower than that would decode the same chunks again.
+///
+/// A dataset whose rows have no bytes (a zero inner dimension) has no elements
+/// to read at all: it answers `NonZeroU64::MAX`, which the caller reads as "one
+/// window covers it".
+///
+/// The answer is a `NonZeroU64` because the sweep advances by it: a window of no
+/// rows would leave that loop running forever rather than returning something
+/// wrong, and a test cannot report the difference.
+fn typed_window_rows(
+    dl: &DataLayout,
+    ds: &Dataspace,
+    elem_size: NonZeroUsize,
+) -> Result<NonZeroU64, FormatError> {
+    let mut row_bytes = elem_size.get() as u64;
+    for &d in ds.dimensions.iter().skip(1) {
+        row_bytes = row_bytes
+            .checked_mul(d)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: row_bytes,
+                length: d,
+            })?;
+    }
+    if row_bytes == 0 {
+        return Ok(NonZeroU64::MAX);
+    }
+
+    let mut rows = (TYPED_READ_WINDOW_BYTES / row_bytes).max(1);
+    if let DataLayout::Chunked {
+        chunk_dimensions, ..
+    } = dl
+    {
+        // A chunked layout message carries rank + 1 dimensions, the last being
+        // the element size, so the first is the leading dimension's chunk extent
+        // for every layout version this crate parses.
+        if let Some(band) = chunk_dimensions
+            .first()
+            .map(|&d| u64::from(d))
+            .filter(|&d| d > 0)
+        {
+            rows = if rows < band {
+                band
+            } else {
+                rows - rows % band
+            };
+        }
+    }
+    // At least one row always, and at least one whole band when a band applied:
+    // that arm runs only when `rows >= band`, so the remainder it subtracts
+    // leaves a band standing.
+    Ok(NonZeroU64::new(rows).unwrap_or(NonZeroU64::MIN))
+}
+
 impl Dataset {
     /// Address of this dataset's object header (base-adjusted, file-absolute).
     /// Used to resolve object references that point at this dataset.
@@ -3721,39 +3812,144 @@ impl Dataset {
         )?)
     }
 
-    /// Read all data as `f64` values.
-    pub fn read_f64(&self) -> Result<Vec<f64>, Error> {
-        let raw = self.read_raw()?;
+    /// Read the whole dataset with `decode`, sweeping it a row window at a time.
+    ///
+    /// A typed whole-dataset read used to be [`read_raw`](Self::read_raw)
+    /// followed by a decode of the entire buffer, which held the stored bytes
+    /// and the decoded values at the same time and so peaked at twice the
+    /// dataset — a caller reading a 4 GiB array needed 8 GiB (issue #289).
+    /// Decoding a window at a time leaves one window of stored bytes beside the
+    /// output instead of a whole second copy of it, and the bytes are identical
+    /// either way: a window returns exactly the rows [`read_raw`](Self::read_raw)
+    /// would have put there.
+    ///
+    /// The output buffer is reserved once, at the size the whole dataset decodes
+    /// to, so no window reallocates it — a growth step would put a second copy of
+    /// the output alongside the first and give back what the windowing saved.
+    ///
+    /// A dataset that fits in one window — including one with no rows at all — is
+    /// read whole. The empty case still runs `decode`, because a decoder is also
+    /// what reports a datatype it cannot read, and a zero-element string dataset
+    /// must go on failing a numeric read rather than answering with an empty
+    /// vector.
+    fn read_whole_typed<T, F>(&self, out_size: OutputSize, decode: F) -> Result<Vec<T>, Error>
+    where
+        F: Fn(&[u8], &Datatype, &mut Vec<T>) -> Result<(), FormatError>,
+    {
         let dt = self.datatype()?;
-        Ok(data_read::read_as_f64(&raw, &dt)?)
+        let ds = self.dataspace()?;
+        let dl = self.data_layout()?;
+        let pipeline = self.filter_pipeline_parsed();
+        // See `read_raw`: an unparseable fill value message is carried into the
+        // read rather than failing it up front.
+        let fill_bytes = self.fill_bytes();
+        let elem_size = dt.element_size_usize()?;
+        let fill = match &fill_bytes {
+            Ok(b) => FillPattern::new(b.as_deref(), elem_size),
+            Err(_) => FillPattern::UNKNOWN,
+        };
+        let spec = RawReadSpec {
+            layout: &dl,
+            dataspace: &ds,
+            datatype: &dt,
+            pipeline: pipeline.as_ref(),
+            fill,
+        };
+
+        // What a whole read checks before it reads a byte, and what a sweep would
+        // otherwise skip: a compact or contiguous layout whose declared size
+        // disagrees with the dataspace is refused. Reading in windows must not
+        // turn that into a check that fires only on datasets small enough to be
+        // read whole.
+        let stored = spec.stored_byte_len()?;
+
+        // A window is cut by the *stored* element width, while a decoder slices
+        // what it is handed by the width of the type it decodes — the base type,
+        // for an enumeration. Those are the same width for every valid file, an
+        // enumeration's size being its base's. A crafted file where they differ
+        // must not get one verdict from a sweep and another from a whole read, so
+        // it is read whole.
+        let decoded_width = data_read::effective_numeric(&dt).type_size();
+
+        let mut out = Vec::new();
+        let n0 = ds.dimensions.first().copied().unwrap_or(1);
+        let rows = typed_window_rows(&dl, &ds, elem_size)?.get();
+        if n0 <= rows || decoded_width != dt.type_size() {
+            // No reservation here: `decode` sizes the output from the bytes it
+            // was handed, which is exact.
+            let raw = self.file.read_dataset_raw(spec, &self.chunk_cache)?;
+            decode(&raw, &dt, &mut out)?;
+            return Ok(out);
+        }
+
+        let values = match out_size {
+            OutputSize::PerElement => ds.num_elements().to_usize()?,
+            OutputSize::PerByte => stored,
+        };
+
+        // One pass for the whole sweep, not one per window: the sweep visits each
+        // chunk exactly once, so a window that offered its chunks to a cache
+        // already full would copy and evict with no later reader for either. The
+        // cache ends up holding what a whole read would have left it — the
+        // chunks reached first. See [`CachePass`].
+        let pass = self.chunk_cache.begin_pass();
+        let mut start = 0;
+        while start < n0 {
+            let count = rows.min(n0 - start);
+            let raw =
+                self.file
+                    .read_dataset_raw_rows(spec, &self.chunk_cache, pass, start, count)?;
+            if start == 0 {
+                // Reserved once, and only after a window has come back. This size
+                // comes from the file: sizing an allocation from it before
+                // reading anything lets a dataspace claiming a terabyte ask for a
+                // terabyte over a file that cannot serve one row. `try_reserve`
+                // for the same reason — a file-derived capacity that cannot be
+                // had is an answer this reader owes its caller, not a panic.
+                out.try_reserve(values)
+                    .map_err(|_| FormatError::ValueTooLargeForPlatform {
+                        value: values as u64,
+                        target: "one allocation",
+                    })?;
+            }
+            decode(&raw, &dt, &mut out)?;
+            start += count;
+        }
+        Ok(out)
+    }
+
+    /// Read all data as `f64` values.
+    ///
+    /// This and the other typed whole-dataset readers decode a row window at a
+    /// time, so the memory standing beside the returned `Vec` is one window of
+    /// stored bytes — on the order of a mebibyte — rather than a second copy of
+    /// the dataset. Reading a 4 GiB array costs about 4 GiB, not 8.
+    ///
+    /// The values are what [`read_raw`](Self::read_raw) returns, decoded: a
+    /// dataset stored as a narrower or wider type is converted, so pick the
+    /// reader that matches the stored type for a lossless read.
+    pub fn read_f64(&self) -> Result<Vec<f64>, Error> {
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_f64_into)
     }
 
     /// Read all data as `f32` values.
     pub fn read_f32(&self) -> Result<Vec<f32>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_f32(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_f32_into)
     }
 
     /// Read all data as `i32` values.
     pub fn read_i32(&self) -> Result<Vec<i32>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_i32(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_i32_into)
     }
 
     /// Read all data as `i64` values.
     pub fn read_i64(&self) -> Result<Vec<i64>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_i64(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_i64_into)
     }
 
     /// Read all data as `u64` values.
     pub fn read_u64(&self) -> Result<Vec<u64>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_u64(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_u64_into)
     }
 
     /// Read all data as `u8` values.
@@ -3762,34 +3958,30 @@ impl Dataset {
     }
 
     /// Read all data as `i8` values.
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "read_i8 reinterprets each stored byte as the signed i8 the caller requested"
-    )]
     pub fn read_i8(&self) -> Result<Vec<i8>, Error> {
-        let raw = self.read_raw()?;
-        Ok(raw.iter().map(|&b| b as i8).collect())
+        self.read_whole_typed(OutputSize::PerByte, |raw, _dt, out| {
+            #[expect(
+                clippy::cast_possible_wrap,
+                reason = "read_i8 reinterprets each stored byte as the signed i8 the caller requested"
+            )]
+            out.extend(raw.iter().map(|&b| b as i8));
+            Ok(())
+        })
     }
 
     /// Read all data as `i16` values.
     pub fn read_i16(&self) -> Result<Vec<i16>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_i16(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_i16_into)
     }
 
     /// Read all data as `u16` values.
     pub fn read_u16(&self) -> Result<Vec<u16>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_u16(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_u16_into)
     }
 
     /// Read all data as `u32` values.
     pub fn read_u32(&self) -> Result<Vec<u32>, Error> {
-        let raw = self.read_raw()?;
-        let dt = self.datatype()?;
-        Ok(data_read::read_as_u32(&raw, &dt)?)
+        self.read_whole_typed(OutputSize::PerElement, data_read::read_as_u32_into)
     }
 
     /// Read all data as `String` values.
@@ -4339,9 +4531,15 @@ impl Dataset {
             return Ok(self.file.read_dataset_raw(spec, &self.chunk_cache)?);
         }
 
-        Ok(self
-            .file
-            .read_dataset_raw_rows(spec, &self.chunk_cache, start, count)?)
+        // A lone window's successor is the adjacent one, and the chunk they share
+        // is the one this read finishes on; `CachePass::LRU` is what retains it.
+        Ok(self.file.read_dataset_raw_rows(
+            spec,
+            &self.chunk_cache,
+            CachePass::LRU,
+            start,
+            count,
+        )?)
     }
 
     /// Windowed [`read_f64`](Self::read_f64) — decodes only the row window.
@@ -4880,6 +5078,112 @@ mod tests {
         }
     }
 
+    /// Recompute a version-2 object header's checksum over its chunk 0, after a
+    /// test has edited a message inside it.
+    ///
+    /// A crafted file a reader must survive carries a *valid* checksum — an
+    /// attacker recomputes it — so a test that edits a header and leaves the old
+    /// one measures the checksum rather than the thing it meant to.
+    #[cfg(feature = "checksum")]
+    fn refresh_v2_header_checksum(bytes: &mut [u8], header_addr: usize) -> std::ops::Range<usize> {
+        assert_eq!(&bytes[header_addr..header_addr + 4], b"OHDR");
+        let flags = bytes[header_addr + 5];
+        let mut pos = header_addr + 6;
+        if flags & 0x20 != 0 {
+            pos += 16;
+        }
+        if flags & 0x10 != 0 {
+            pos += 4;
+        }
+        let width = 1usize << (flags & 0x03);
+        let chunk0 = (0..width).fold(0usize, |acc, i| {
+            acc | ((bytes[pos + i] as usize) << (8 * i))
+        });
+        pos += width;
+        let chunk0_end = pos + chunk0;
+        let cs = crate::checksum::jenkins_lookup3(&bytes[header_addr..chunk0_end]);
+        bytes[chunk0_end..chunk0_end + 4].copy_from_slice(&cs.to_le_bytes());
+        header_addr..chunk0_end
+    }
+
+    /// A contiguous layout whose declared size disagrees with its dataspace is
+    /// refused, whatever the dataset's size and whichever read asks.
+    ///
+    /// The whole-dataset readers have always refused it. A typed read now takes a
+    /// large dataset a row window at a time, and a window only ever checks that
+    /// its *own* rows are inside the declared storage — so without the shared
+    /// check this refusal would have applied to small datasets, which are still
+    /// read whole, and not to large ones. A validation that fires depending on
+    /// the size of the input is the kind that surfaces years later as an
+    /// inconsistent bug report, which is why both sizes are here.
+    #[cfg(feature = "checksum")]
+    #[test]
+    fn a_layout_size_disagreeing_with_the_dataspace_is_refused_at_every_dataset_size() {
+        // One dataset below the typed read's window budget and read whole; one
+        // above it and swept.
+        for n in [1000usize, 200_000] {
+            let data: Vec<f64> = (0..n).map(|i| i as f64).collect();
+            let mut b = crate::writer::FileBuilder::new();
+            b.create_dataset("t")
+                .with_f64_data(&data)
+                .with_shape(&[n as u64]);
+            let mut bytes = b.finish().unwrap();
+            // Taken before the edit: an edited header fails its checksum, and the
+            // address is needed to recompute it.
+            let header_addr = {
+                let file = File::from_bytes(bytes.clone()).unwrap();
+                file.dataset("t").unwrap().header_address() as usize
+            };
+
+            // The layout message's size field: the dataset's byte length, which
+            // appears once in the file. The assertion is the fixture's own guard —
+            // patching some other field would test nothing in particular.
+            let declared = (n * 8) as u64;
+            let needle = declared.to_le_bytes();
+            let at: Vec<usize> = bytes
+                .windows(8)
+                .enumerate()
+                .filter(|(_, w)| *w == needle)
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(
+                at.len(),
+                1,
+                "the stored size {declared} was not uniquely locatable in a {n}-element file: {at:?}"
+            );
+            bytes[at[0]..at[0] + 8].copy_from_slice(&(declared * 2).to_le_bytes());
+
+            let chunk0 = refresh_v2_header_checksum(&mut bytes, header_addr);
+            assert!(
+                chunk0.contains(&at[0]),
+                "the patched size is outside the header chunk whose checksum was refreshed"
+            );
+
+            let file = File::from_bytes(bytes).unwrap();
+            let ds = file.dataset("t").unwrap();
+            let expected = FormatError::DataSizeMismatch {
+                expected: n * 8,
+                actual: n * 16,
+            };
+            for (what, err) in [
+                ("read_raw", ds.read_raw().unwrap_err()),
+                ("read_f64", ds.read_f64().unwrap_err()),
+                ("read_i32", ds.read_i32().unwrap_err()),
+            ] {
+                match err {
+                    Error::Format(got) => assert_eq!(
+                        format!("{got:?}"),
+                        format!("{expected:?}"),
+                        "{what} over {n} elements reported the wrong mismatch"
+                    ),
+                    other => {
+                        panic!("{what} over {n} elements: expected a format error, got {other:?}")
+                    }
+                }
+            }
+        }
+    }
+
     /// A zero-row window returns `Ok(empty)` uniformly across layouts, including
     /// over unallocated storage. Unallocated storage now reads as the fill value
     /// rather than erroring, so this no longer guards a cross-layout divergence
@@ -4912,6 +5216,7 @@ mod tests {
             8,
             8,
             &cache,
+            CachePass::LRU,
             0,
             0,
             8,
@@ -4929,6 +5234,7 @@ mod tests {
             8,
             8,
             &cache,
+            CachePass::LRU,
             0,
             0,
             8,
@@ -4937,6 +5243,108 @@ mod tests {
         assert!(
             matches!(err, FormatError::UnsupportedVirtualLayout),
             "expected UnsupportedVirtualLayout, got {err:?}"
+        );
+    }
+
+    /// The window a typed whole-dataset read sweeps in is a budget in *stored
+    /// bytes* resolved against the dataset's own geometry, and a chunked dataset
+    /// adds a second rule on top: whole chunk bands.
+    ///
+    /// A window that ended mid-band would make the next window decode the band
+    /// again — the cost windowing exists to avoid — so the budget is rounded down
+    /// to a multiple of the band, and *up* to one whole band when even one band
+    /// is over budget. The three ways a window can come out are one rule with
+    /// different inputs, which is why they are asserted together.
+    #[test]
+    fn a_typed_read_windows_in_whole_chunk_bands() {
+        const BUDGET: u64 = TYPED_READ_WINDOW_BYTES;
+        let ds1 = |dims: &[u64]| Dataspace {
+            space_type: crate::dataspace::DataspaceType::Simple,
+            rank: dims.len() as u8,
+            dimensions: dims.to_vec(),
+            max_dimensions: None,
+        };
+        let contiguous = DataLayout::Contiguous {
+            address: Some(0),
+            size: 0,
+        };
+        let chunked = |band: u32| DataLayout::Chunked {
+            chunk_dimensions: vec![band, 8],
+            btree_address: Some(0),
+            version: 3,
+            chunk_index_type: None,
+            single_chunk_filtered_size: None,
+            single_chunk_filter_mask: None,
+        };
+        let elem = NonZeroUsize::new(8).unwrap();
+
+        // Unchunked: the budget, divided by the row width, exactly.
+        assert_eq!(
+            typed_window_rows(&contiguous, &ds1(&[1 << 20]), elem)
+                .unwrap()
+                .get(),
+            BUDGET / 8
+        );
+
+        // A band that divides the budget takes it unchanged; one that does not
+        // is rounded down to a whole number of bands, never up.
+        assert_eq!(
+            typed_window_rows(&chunked(512), &ds1(&[1 << 20]), elem)
+                .unwrap()
+                .get(),
+            BUDGET / 8
+        );
+        let rows = typed_window_rows(&chunked(300), &ds1(&[1 << 20]), elem)
+            .unwrap()
+            .get();
+        assert_eq!(rows % 300, 0, "a window must end on a chunk band");
+        assert!(
+            rows <= BUDGET / 8 && rows > BUDGET / 8 - 300,
+            "a window must be the largest whole number of bands within the \
+             budget, not a smaller one: {rows} rows against {} in budget",
+            BUDGET / 8
+        );
+
+        // One band over budget: the window is that band, since a narrower one
+        // would decode it twice.
+        assert_eq!(
+            typed_window_rows(&chunked(1 << 20), &ds1(&[1 << 21]), elem)
+                .unwrap()
+                .get(),
+            1 << 20
+        );
+
+        // Rows wider than the whole budget: one row, which is the least a window
+        // can be and still make progress.
+        assert_eq!(
+            typed_window_rows(&contiguous, &ds1(&[4, 1 << 20]), elem)
+                .unwrap()
+                .get(),
+            1
+        );
+
+        // Rank 0. A chunked layout message carries rank + 1 dimensions, so a
+        // scalar's only entry is the element-size trailer and the "band" read
+        // out of it is not a band at all. Nothing rests on it: a scalar has one
+        // row, so `n0 <= rows` sends it to the whole read whatever this says.
+        // Asserted so that a later reading of `first()` as the leading extent
+        // has to account for this case rather than discover it.
+        let scalar = Dataspace {
+            space_type: crate::dataspace::DataspaceType::Scalar,
+            rank: 0,
+            dimensions: Vec::new(),
+            max_dimensions: None,
+        };
+        assert!(typed_window_rows(&chunked(8), &scalar, elem).unwrap().get() >= 1);
+
+        // A zero inner dimension makes a row zero bytes wide, and the dataset
+        // has no elements at all: one window covers it, and nothing divides by
+        // zero on the way there.
+        assert_eq!(
+            typed_window_rows(&contiguous, &ds1(&[4, 0]), elem)
+                .unwrap()
+                .get(),
+            u64::MAX
         );
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -35,6 +35,7 @@ use crate::layout_info::{Chunk, ChunkIndex, Filter, Layout};
 use crate::libver::LibVer;
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
+use crate::read_spec::RawReadSpec;
 use crate::shared_message::{self, BufferedResolver, SharedResolver, SourceResolver};
 use crate::signature;
 use crate::source::{
@@ -1326,11 +1327,7 @@ impl FileInner {
     /// Read a dataset's raw bytes for the given layout, dispatching on the backend.
     fn read_dataset_raw(
         &self,
-        dl: &DataLayout,
-        ds: &Dataspace,
-        dt: &Datatype,
-        pipeline: Option<&FilterPipeline>,
-        fill: FillPattern<'_>,
+        spec: RawReadSpec<'_>,
         cache: &ChunkCache,
     ) -> Result<Vec<u8>, FormatError> {
         let (os, ls) = (self.offset_size(), self.length_size());
@@ -1343,36 +1340,18 @@ impl FileInner {
         // read. For a plain file (`base == 0`) this is the identity.
         let base = self.addr_offset;
         match &self.backend {
-            Backend::InMemory(v) => data_read::read_raw_data_cached(
-                frame(v, base)?,
-                dl,
-                ds,
-                dt,
-                pipeline,
-                fill,
-                os,
-                ls,
-                cache,
-            ),
-            Backend::Streaming(s) if base == 0 => data_read::read_raw_data_cached_from_source(
-                s.as_ref(),
-                dl,
-                ds,
-                dt,
-                pipeline,
-                fill,
-                os,
-                ls,
-                cache,
-            ),
+            Backend::InMemory(v) => {
+                data_read::read_raw_data_cached(frame(v, base)?, spec, os, ls, cache)
+            }
+            Backend::Streaming(s) if base == 0 => {
+                data_read::read_raw_data_cached_from_source(s.as_ref(), spec, os, ls, cache)
+            }
             Backend::Streaming(s) => {
                 let framed = BaseOffsetSource {
                     inner: s.as_ref(),
                     base,
                 };
-                data_read::read_raw_data_cached_from_source(
-                    &framed, dl, ds, dt, pipeline, fill, os, ls, cache,
-                )
+                data_read::read_raw_data_cached_from_source(&framed, spec, os, ls, cache)
             }
             Backend::Edit(m) => Self::with_engine(
                 m,
@@ -1386,15 +1365,11 @@ impl FileInner {
                             available: data.len(),
                         })?
                     };
-                    data_read::read_raw_data_cached(
-                        frame, dl, ds, dt, pipeline, fill, os, ls, cache,
-                    )
+                    data_read::read_raw_data_cached(frame, spec, os, ls, cache)
                 },
                 |s| {
                     let framed = BaseOffsetSource { inner: s, base };
-                    data_read::read_raw_data_cached_from_source(
-                        &framed, dl, ds, dt, pipeline, fill, os, ls, cache,
-                    )
+                    data_read::read_raw_data_cached_from_source(&framed, spec, os, ls, cache)
                 },
             ),
         }
@@ -1405,19 +1380,15 @@ impl FileInner {
     /// touching only the storage it overlaps. Reads through the same base-framed
     /// `Source`, so on-disk addresses resolve the same way. The caller clamps
     /// the window to the dataset.
-    #[allow(clippy::too_many_arguments)]
     fn read_dataset_raw_rows(
         &self,
-        dl: &DataLayout,
-        ds: &Dataspace,
-        dt: &Datatype,
-        pipeline: Option<&FilterPipeline>,
-        fill: FillPattern<'_>,
+        spec: RawReadSpec<'_>,
         cache: &ChunkCache,
         start_row: u64,
         num_rows: u64,
     ) -> Result<Vec<u8>, FormatError> {
         let (os, ls) = (self.offset_size(), self.length_size());
+        let (dl, ds, dt) = (spec.layout, spec.dataspace, spec.datatype);
         let elem_size = dt.element_size_usize()?;
         // Elements per row (product of inner dims; 1 when 0-D or 1-D). Checked so
         // a crafted dataspace whose inner dims overflow `usize` errors instead of
@@ -1474,11 +1445,7 @@ impl FileInner {
                 };
                 read_rows_framed(
                     &BytesSource::new(frame),
-                    dl,
-                    ds,
-                    dt,
-                    pipeline,
-                    fill,
+                    spec,
                     os,
                     ls,
                     cache,
@@ -1489,11 +1456,7 @@ impl FileInner {
             }
             Backend::Streaming(s) if base == 0 => read_rows_framed(
                 s.as_ref(),
-                dl,
-                ds,
-                dt,
-                pipeline,
-                fill,
+                spec,
                 os,
                 ls,
                 cache,
@@ -1506,10 +1469,7 @@ impl FileInner {
                     inner: s.as_ref(),
                     base,
                 };
-                read_rows_framed(
-                    &framed, dl, ds, dt, pipeline, fill, os, ls, cache, start_row, num_rows,
-                    row_bytes,
-                )
+                read_rows_framed(&framed, spec, os, ls, cache, start_row, num_rows, row_bytes)
             }
             Backend::Edit(m) => Self::with_engine(
                 m,
@@ -1525,11 +1485,7 @@ impl FileInner {
                     };
                     read_rows_framed(
                         &BytesSource::new(frame),
-                        dl,
-                        ds,
-                        dt,
-                        pipeline,
-                        fill,
+                        spec,
                         os,
                         ls,
                         cache,
@@ -1540,10 +1496,7 @@ impl FileInner {
                 },
                 |s| {
                     let framed = BaseOffsetSource { inner: s, base };
-                    read_rows_framed(
-                        &framed, dl, ds, dt, pipeline, fill, os, ls, cache, start_row, num_rows,
-                        row_bytes,
-                    )
+                    read_rows_framed(&framed, spec, os, ls, cache, start_row, num_rows, row_bytes)
                 },
             ),
         }
@@ -1554,14 +1507,9 @@ impl FileInner {
 /// layouts are one bounded sub-read; chunked layouts use the windowed chunk
 /// reader (only the rank-0 crafted-file corner falls back to a whole read
 /// plus slice).
-#[allow(clippy::too_many_arguments)]
 fn read_rows_framed<S: Source + ?Sized>(
     source: &S,
-    dl: &DataLayout,
-    ds: &Dataspace,
-    dt: &Datatype,
-    pipeline: Option<&FilterPipeline>,
-    fill: FillPattern<'_>,
+    spec: RawReadSpec<'_>,
     os: u8,
     ls: u8,
     cache: &ChunkCache,
@@ -1569,6 +1517,7 @@ fn read_rows_framed<S: Source + ?Sized>(
     num_rows: u64,
     row_bytes: usize,
 ) -> Result<Vec<u8>, FormatError> {
+    let (dl, fill) = (spec.layout, spec.fill);
     // A zero-row window reads nothing, uniformly across the *supported* layouts.
     // A `Virtual` layout is unsupported and must still error like `read_raw`
     // does, so it is excluded here and falls through to the match.
@@ -1614,15 +1563,14 @@ fn read_rows_framed<S: Source + ?Sized>(
         }
         DataLayout::Chunked { .. } => {
             match crate::chunked_read::read_chunked_rows_from_source(
-                source, dl, ds, dt, pipeline, fill, os, ls, cache, start_row, num_rows,
+                source, spec, os, ls, cache, start_row, num_rows,
             )? {
                 Some(bytes) => Ok(bytes),
                 // Rank-0 chunked (a crafted-file corner): fall back to a whole
                 // read, then slice.
                 None => {
-                    let full = data_read::read_raw_data_cached_from_source(
-                        source, dl, ds, dt, pipeline, fill, os, ls, cache,
-                    )?;
+                    let full =
+                        data_read::read_raw_data_cached_from_source(source, spec, os, ls, cache)?;
                     let start = start_row.to_usize()? * row_bytes;
                     let len = num_rows.to_usize()? * row_bytes;
                     full.get(start..start + len).map(<[u8]>::to_vec).ok_or(
@@ -4331,9 +4279,14 @@ impl Dataset {
             Ok(b) => FillPattern::new(b.as_deref(), dt.element_size_usize()?),
             Err(_) => FillPattern::UNKNOWN,
         };
-        Ok(self
-            .file
-            .read_dataset_raw(&dl, &ds, &dt, pipeline.as_ref(), fill, &self.chunk_cache)?)
+        let spec = RawReadSpec {
+            layout: &dl,
+            dataspace: &ds,
+            datatype: &dt,
+            pipeline: pipeline.as_ref(),
+            fill,
+        };
+        Ok(self.file.read_dataset_raw(spec, &self.chunk_cache)?)
     }
 
     /// Read the raw element bytes of the row window `[start_row, start_row + num_rows)`
@@ -4373,28 +4326,22 @@ impl Dataset {
             Err(_) => FillPattern::UNKNOWN,
         };
 
+        let pipeline = self.filter_pipeline_parsed();
+        let spec = RawReadSpec {
+            layout: &dl,
+            dataspace: &ds,
+            datatype: &dt,
+            pipeline: pipeline.as_ref(),
+            fill,
+        };
+
         if start == 0 && count == n0 {
-            let pipeline = self.filter_pipeline_parsed();
-            return Ok(self.file.read_dataset_raw(
-                &dl,
-                &ds,
-                &dt,
-                pipeline.as_ref(),
-                fill,
-                &self.chunk_cache,
-            )?);
+            return Ok(self.file.read_dataset_raw(spec, &self.chunk_cache)?);
         }
 
-        Ok(self.file.read_dataset_raw_rows(
-            &dl,
-            &ds,
-            &dt,
-            self.filter_pipeline_parsed().as_ref(),
-            fill,
-            &self.chunk_cache,
-            start,
-            count,
-        )?)
+        Ok(self
+            .file
+            .read_dataset_raw_rows(spec, &self.chunk_cache, start, count)?)
     }
 
     /// Windowed [`read_f64`](Self::read_f64) — decodes only the row window.
@@ -4961,11 +4908,7 @@ mod tests {
         let cache = ChunkCache::new();
         let out = read_rows_framed(
             &BytesSource::new(b""),
-            &dl,
-            &ds,
-            &dt,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&dl, &ds, &dt),
             8,
             8,
             &cache,
@@ -4982,11 +4925,7 @@ mod tests {
         let virtual_dl = DataLayout::Virtual { version: 4 };
         let err = read_rows_framed(
             &BytesSource::new(b""),
-            &virtual_dl,
-            &ds,
-            &dt,
-            None,
-            FillPattern::ZERO,
+            RawReadSpec::plain(&virtual_dl, &ds, &dt),
             8,
             8,
             &cache,

--- a/tests/allocation_bounds.rs
+++ b/tests/allocation_bounds.rs
@@ -262,6 +262,100 @@ fn whole_read_of_adjacent_chunks_costs_a_constant_per_chunk() {
     );
 }
 
+/// A typed whole-dataset read costs its output, not its output *and* a whole
+/// copy of the stored bytes beside it.
+///
+/// Decoding used to be a `read_raw` followed by a conversion of the entire
+/// buffer, so both were live at once and the peak was twice the dataset: a
+/// caller reading a 4 GiB array needed 8 GiB (issue #289). What replaced it
+/// sweeps row windows, and both figures below say so — the peak because only one
+/// window of stored bytes stands beside the output, and the byte total because
+/// each window is decoded straight into that output rather than into a buffer
+/// that is then copied into it.
+///
+/// The fixture is the one [`whole_read_of_adjacent_chunks_costs_a_constant_per_chunk`]
+/// reads raw, at the same stored width as the requested type, so "the dataset"
+/// is one figure for both the stored bytes and the decoded values and the two
+/// tests are directly comparable. The margin is a quarter of the dataset against
+/// a window of one mebibyte — an eighth of it — so a window budget that grew
+/// with the dataset instead of staying constant would fail this, and so would a
+/// return to reading whole.
+#[test]
+fn typed_whole_read_costs_its_output_and_a_window() {
+    // 8 MiB of f64 in 4 KiB chunks, read as `f64`: output and stored bytes are
+    // the same size, so one constant names both.
+    const N0: usize = 1024 * 1024;
+    const DATASET_BYTES: usize = N0 * 8;
+    const CHUNK_ELEMS: usize = 512;
+
+    let data: Vec<f64> = (0..N0).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64])
+        .with_chunks(&[CHUNK_ELEMS as u64]);
+    builder.write(&path).unwrap();
+    drop(data);
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+
+    let (values, measured) = measure("typed_whole_read", || ds.read_f64().unwrap());
+
+    assert!(
+        measured.peak_bytes < (DATASET_BYTES + DATASET_BYTES / 4) as u64,
+        "peak allocation during a typed whole read must be its output plus a \
+         window, not a second copy of the {DATASET_BYTES}-byte dataset; \
+         measured {measured}"
+    );
+
+    // Bytes *ever* allocated, which the peak cannot see: a window decoded into a
+    // fresh `Vec` and then appended to the output, or a chunk copied into a
+    // cache that has no room for it, costs the whole dataset over again without
+    // moving the high-water mark at all. Two copies are what this read is
+    // entitled to — its output, and the stored bytes it sweeps past one window
+    // at a time — plus the span buffer each window refills, so the bound is
+    // placed where a *third* would put it.
+    assert!(
+        measured.bytes < (3 * DATASET_BYTES) as u64,
+        "a typed whole read must allocate its output and one sweep of the \
+         stored bytes, not a third copy of either; measured {measured} against \
+         a {DATASET_BYTES}-byte dataset"
+    );
+
+    // Per-chunk *count*, which neither byte figure can see, and the axis a sweep
+    // is most easily made quadratic on: a window that takes the whole chunk
+    // index out of the cache to find the chunks it overlaps allocates per chunk
+    // of the *dataset* per window, and this read visits each chunk once through
+    // eight windows.
+    const BLOCKS_PER_CHUNK: u64 = 5;
+    const CHUNKS: u64 = (N0 / CHUNK_ELEMS) as u64;
+    assert!(
+        measured.blocks <= BLOCKS_PER_CHUNK * CHUNKS + 256,
+        "a typed whole read must cost a small constant number of allocations \
+         per chunk, not one per chunk per window: measured {measured} over \
+         {CHUNKS} chunks, above the {BLOCKS_PER_CHUNK} per chunk this bound allows"
+    );
+
+    // The values this read returned are in the measurement, so their size is a
+    // floor a measurement of nothing cannot reach.
+    assert!(
+        measured.live_bytes >= DATASET_BYTES as u64,
+        "the values this read returned are not in its own measurement, so the \
+         bounds above are bounding something other than the read: {measured}"
+    );
+
+    // The values must still be the right ones, in the right order — a sweep that
+    // lost or repeated a window would pass every bound above.
+    assert_eq!(values.len(), N0);
+    assert_eq!(values[0], 0.0);
+    assert_eq!(values[N0 / 2], (N0 / 2) as f64);
+    assert_eq!(values[N0 - 1], (N0 - 1) as f64);
+}
+
 /// Writing a chunked dataset costs a constant per chunk, and about one copy of
 /// the data beyond the one the caller handed over.
 ///

--- a/tests/empty_chunked_crosscheck.rs
+++ b/tests/empty_chunked_crosscheck.rs
@@ -604,3 +604,79 @@ fn repack_materializes_a_never_written_dataset() {
         "the destination is larger than the source it came from"
     );
 }
+
+/// A typed whole-dataset read sweeps row windows (issue #289), and a dataset the
+/// C library allocated lazily is where that sweep meets storage that is not
+/// there: no chunk exists at all, or some chunk grid slots hold data and others
+/// never will.
+///
+/// Only the C library can write this file. Both cases have to answer the fill
+/// value for every element no chunk covers, in *every* window and not just the
+/// first — a sweep that carried the fill pattern into its first window and zeros
+/// into the rest would pass a whole-read test and fail here.
+///
+/// The dataset is deliberately larger than the read's window budget: at 1 MiB of
+/// stored bytes to a window rounded down to whole 1,000-row chunk bands, 400,000
+/// `i32` is two windows — 262,000 rows and then 138,000.
+#[test]
+fn a_swept_typed_read_of_lazily_allocated_storage_reads_holes_as_fill() {
+    const N: usize = 400_000;
+    const CHUNK: usize = 1000;
+    const FILL: i32 = -12_345;
+
+    let dir = tempdir().unwrap();
+    let never = dir.path().join("never.h5");
+    let partly = dir.path().join("partly.h5");
+
+    for (path, write_some) in [(&never, false), (&partly, true)] {
+        let file = hdf5::File::create(path).unwrap();
+        let ds = file
+            .new_dataset::<i32>()
+            .shape((N,))
+            .chunk((CHUNK,))
+            .fill_value(FILL)
+            .create("col")
+            .unwrap();
+        if write_some {
+            // Every fourth chunk, so written and unwritten slots fall in every
+            // window of the sweep.
+            let block: Vec<i32> = (0..CHUNK).map(|i| i as i32).collect();
+            let mut start = 0;
+            while start + CHUNK <= N {
+                ds.write_slice(&block, start..start + CHUNK).unwrap();
+                start += 4 * CHUNK;
+            }
+        }
+        drop(ds);
+        file.close().unwrap();
+    }
+
+    let expected_never = vec![FILL; N];
+    let mut expected_partly = vec![FILL; N];
+    let mut start = 0;
+    while start + CHUNK <= N {
+        for (i, slot) in expected_partly[start..start + CHUNK].iter_mut().enumerate() {
+            *slot = i as i32;
+        }
+        start += 4 * CHUNK;
+    }
+
+    for (path, expected) in [(&never, &expected_never), (&partly, &expected_partly)] {
+        let file = File::open_streaming(path).unwrap();
+        let ds = file.dataset("col").unwrap();
+        assert_eq!(
+            &ds.read_i32().unwrap(),
+            expected,
+            "a swept read of {} did not match what the C library stored",
+            path.display()
+        );
+        // The same values the whole-read path answers: a full-range window
+        // delegates to it, which makes this the before-and-after comparison.
+        assert_eq!(
+            ds.read_i32().unwrap(),
+            ds.read_i32_rows(0, N as u64).unwrap(),
+            "the sweep and the whole read disagree over {}",
+            path.display()
+        );
+    }
+}

--- a/tests/typed_whole_read.rs
+++ b/tests/typed_whole_read.rs
@@ -1,0 +1,241 @@
+//! A typed whole-dataset read decodes the same values whether it sweeps the
+//! dataset in row windows or reads it whole (issue #289).
+//!
+//! `Dataset::read_f64` and its eight siblings used to be `read_raw()` followed by
+//! a decode of the entire buffer; they now sweep row windows so the stored bytes
+//! beside the output are one window rather than the whole dataset. The bytes are
+//! supposed to be identical either way, and the reference here says so directly:
+//! **`read_f64_rows(0, n)` over every row is the old code path**, since a
+//! full-range window delegates to the whole read and decodes the result in one
+//! pass. Every assertion below is `sweep == whole`, so a fixture that disagrees
+//! names the sweep as the thing that changed.
+//!
+//! Every fixture is deliberately larger than the one-mebibyte window budget, in
+//! more than one window's worth of rows, and none of them divides evenly: a
+//! dataset whose rows, chunk bands, and window all lined up would exercise the
+//! sweep without exercising its edges.
+//!
+//! One case is missing from here and lives in `tests/empty_chunked_crosscheck.rs`
+//! instead: a chunk grid with holes in it, where a window is answered partly from
+//! storage and partly from the fill value. This crate's writer allocates every
+//! chunk it declares, so only the reference C library can produce that file
+//! (issue #293), and a test of it has to link the library.
+
+use hdf5_pure::{File, FileBuilder};
+
+/// Comfortably more than the read's own window budget, and not a round number of
+/// windows: 2.3 MiB of `f64` against a 1 MiB window.
+const N: usize = 300_007;
+
+/// Assert every typed reader agrees with its full-range windowed form, which is
+/// the whole-read-then-decode path this sweep replaced.
+fn sweep_matches_whole(ds: &hdf5_pure::Dataset, rows: u64) {
+    assert_eq!(ds.read_f64().unwrap(), ds.read_f64_rows(0, rows).unwrap());
+    assert_eq!(ds.read_f32().unwrap(), ds.read_f32_rows(0, rows).unwrap());
+    assert_eq!(ds.read_i8().unwrap(), ds.read_i8_rows(0, rows).unwrap());
+    assert_eq!(ds.read_i16().unwrap(), ds.read_i16_rows(0, rows).unwrap());
+    assert_eq!(ds.read_i32().unwrap(), ds.read_i32_rows(0, rows).unwrap());
+    assert_eq!(ds.read_i64().unwrap(), ds.read_i64_rows(0, rows).unwrap());
+    assert_eq!(ds.read_u8().unwrap(), ds.read_u8_rows(0, rows).unwrap());
+    assert_eq!(ds.read_u16().unwrap(), ds.read_u16_rows(0, rows).unwrap());
+    assert_eq!(ds.read_u32().unwrap(), ds.read_u32_rows(0, rows).unwrap());
+    assert_eq!(ds.read_u64().unwrap(), ds.read_u64_rows(0, rows).unwrap());
+}
+
+#[test]
+fn a_swept_read_of_a_chunked_dataset_matches_a_whole_one() {
+    // A chunk band that divides neither the dataset nor the window, so the last
+    // window is short and the last chunk is ragged.
+    let data: Vec<f64> = (0..N).map(|i| i as f64 * 0.5).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("chunked.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N as u64])
+        .with_chunks(&[1000]);
+    b.write(&path).unwrap();
+
+    for file in [
+        File::open(&path).unwrap(),
+        File::open_streaming(&path).unwrap(),
+    ] {
+        let ds = file.dataset("t").unwrap();
+        let values = ds.read_f64().unwrap();
+        assert_eq!(values.len(), N);
+        assert_eq!(values, data, "the swept read returned the wrong values");
+        sweep_matches_whole(&ds, N as u64);
+    }
+}
+
+#[test]
+fn a_swept_read_of_a_filtered_dataset_matches_a_whole_one() {
+    let data: Vec<f64> = (0..N).map(|i| (i % 977) as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deflate.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N as u64])
+        .with_chunks(&[3000])
+        .with_deflate(4);
+    b.write(&path).unwrap();
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), data);
+    sweep_matches_whole(&ds, N as u64);
+}
+
+#[test]
+fn a_swept_read_of_a_contiguous_dataset_matches_a_whole_one() {
+    // Stored narrower than every type it is read as, so the decode widens rather
+    // than reinterprets — the case that rules out reusing the stored buffer.
+    //
+    // The row count is its own: a window is a budget in *stored* bytes, so `N`
+    // two-byte elements would fit inside one and never sweep at all.
+    const N: usize = 800_003;
+    let data: Vec<i16> = (0..N)
+        .map(|i| (i as i32 % 30_000 - 15_000) as i16)
+        .collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("contiguous.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("t")
+        .with_i16_data(&data)
+        .with_shape(&[N as u64]);
+    b.write(&path).unwrap();
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+    assert_eq!(ds.read_i16().unwrap(), data);
+    assert_eq!(ds.read_f64().unwrap().len(), N);
+    sweep_matches_whole(&ds, N as u64);
+}
+
+#[test]
+fn a_swept_read_of_an_inner_split_chunk_grid_matches_a_whole_one() {
+    // Chunks narrower than the dataset's inner extent, so each one scatters
+    // through the N-D kernel into a window-shaped output rather than copying a
+    // contiguous row band. 4.3 MiB in rows of 2 KiB: 512 rows to a window, and a
+    // final window of 152 rows that ends mid-band.
+    const N0: usize = 2200;
+    const ROW: usize = 32 * 8;
+    let data: Vec<f64> = (0..N0 * ROW).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("grid.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64, 32, 8])
+        .with_chunks(&[64, 16, 4]);
+    b.write(&path).unwrap();
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), data);
+    sweep_matches_whole(&ds, N0 as u64);
+}
+
+/// A dataset with no elements at all still reports a datatype it cannot decode.
+///
+/// The decoders are what raise `TypeMismatch`, so a sweep that ran zero windows
+/// over a zero-row dataset would never call one, and a numeric read of a string
+/// dataset would come back as an empty vector instead of an error. The empty case
+/// is read whole for exactly this reason.
+#[test]
+fn a_numeric_read_of_an_empty_string_dataset_still_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty_strings.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("s").with_vlen_strings(&[]);
+    b.write(&path).unwrap();
+
+    let file = File::open(&path).unwrap();
+    let ds = file.dataset("s").unwrap();
+    assert_eq!(ds.shape().unwrap(), vec![0]);
+    let err = ds
+        .read_f64()
+        .expect_err("a string dataset must not decode as f64, empty or not");
+    assert!(
+        format!("{err}").contains("mismatch") || format!("{err:?}").contains("TypeMismatch"),
+        "expected a type mismatch, got {err:?}"
+    );
+}
+
+/// The sweep reads through the same three backends the whole read does, and
+/// through a file whose objects sit past a userblock.
+///
+/// Every address in a layout message is stored relative to the file's base
+/// address, and the reader frames the file at that base before the payload read
+/// begins. A sweep issues that read once per window instead of once per dataset,
+/// so a framing that were applied per read rather than per byte-range would
+/// still come out right on the first window and wrong on the rest — which is the
+/// shape of the base-address bugs this crate has had before.
+#[test]
+fn a_swept_read_agrees_across_backends_and_past_a_userblock() {
+    let data: Vec<f64> = (0..N).map(|i| i as f64 * 0.25).collect();
+    let dir = tempfile::tempdir().unwrap();
+
+    for userblock in [0u64, 512, 2048] {
+        let path = dir.path().join(format!("ub{userblock}.h5"));
+        let mut b = FileBuilder::new();
+        if userblock > 0 {
+            b.with_userblock(userblock);
+        }
+        b.create_dataset("t")
+            .with_f64_data(&data)
+            .with_shape(&[N as u64])
+            .with_chunks(&[1000]);
+        b.write(&path).unwrap();
+
+        // Buffered, streaming, and the edit session's read path, which serves
+        // reads from a third source again.
+        let buffered = File::open(&path).unwrap();
+        assert_eq!(
+            buffered.dataset("t").unwrap().read_f64().unwrap(),
+            data,
+            "buffered read past a {userblock}-byte userblock"
+        );
+        drop(buffered);
+
+        let streaming = File::open_streaming(&path).unwrap();
+        assert_eq!(
+            streaming.dataset("t").unwrap().read_f64().unwrap(),
+            data,
+            "streaming read past a {userblock}-byte userblock"
+        );
+        drop(streaming);
+
+        let session = File::open_rw(&path).unwrap();
+        assert_eq!(
+            session.root().dataset("t").unwrap().read_f64().unwrap(),
+            data,
+            "edit-session read past a {userblock}-byte userblock"
+        );
+    }
+}
+
+/// A multi-dimensional dataset in *contiguous* storage: the window is a byte
+/// range of the one run, and its rows keep their inner shape.
+///
+/// Every other multi-dimensional fixture here is chunked, where the window is
+/// assembled from chunks rather than sliced out of a single run.
+#[test]
+fn a_swept_read_of_a_two_dimensional_contiguous_dataset_matches_a_whole_one() {
+    const N0: usize = 3001;
+    const ROW: usize = 64;
+    let data: Vec<f64> = (0..N0 * ROW).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("flat2d.h5");
+    let mut b = FileBuilder::new();
+    b.create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64, ROW as u64]);
+    b.write(&path).unwrap();
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+    assert_eq!(ds.read_f64().unwrap(), data);
+    sweep_matches_whole(&ds, N0 as u64);
+}


### PR DESCRIPTION
Closes #294. Closes #289.

Two commits, in the order the second one needed: the parameter bundle first, then the change that would otherwise have paid its call-site cost again.

## Bundle the raw-read parameters into a `RawReadSpec` (#294)

The raw-read chain threaded five per-dataset properties — layout, dataspace, datatype, filter pipeline, fill pattern — through four layers, and the widest signature had reached twelve arguments. The cost was never the width; it was that adding one property meant editing roughly thirty call sites, several of them mechanically across test fixtures, where a default inserted in place of a real value compiles and passes.

`RawReadSpec` is one `Copy` struct of those five, in a new `src/read_spec.rs`. The file-level address widths stay beside it rather than in it: they are the same for every dataset in a file, and the rest of the crate already passes them as a pair. At that commit the four widest signatures take 8, 7, 5 and 4 arguments against 12, 11, 9 and 9, and the redundant `#[allow(clippy::too_many_arguments)]` attributes on them are gone. The second commit gives the two windowed ones a `CachePass` back, for the reason below.

The issue's own acceptance test is the one worth reporting: **not one assertion in the suite moved.** `git diff main...HEAD -- '*.rs' | grep -E '^[-+].*assert'` is empty for that commit.

## Decode a typed whole-dataset read a row window at a time (#289)

`Dataset::read_f64` and its eight siblings were a `read_raw()` followed by a decode of the entire buffer, so the stored bytes and the decoded values were live at once. A caller reading a 4 GiB array needed 8 GiB.

They now sweep row windows and decode each into the one output buffer. The window is a mebibyte of *stored* bytes, rounded down to whole chunk bands so no chunk is ever decoded for two windows; a dataset that fits inside one window is read whole exactly as before. So is a dataset with no rows — the empty case must still run its decoder, since a decoder is what reports a datatype it cannot read, and a numeric read of an empty string dataset has to go on failing rather than answering with an empty vector.

Measured on the 8 MiB `f64` fixture from the issue, read through `File::open_streaming`:

| | peak | bytes allocated | allocations |
| --- | --- | --- | --- |
| `read_raw` (unchanged) | 9.1 MB | 9.3 MB | 6,223 |
| `read_f64` before | 17.1 MB (2.04x) | 17.7 MB | 6,224 |
| `read_f64` after | 10.1 MB (1.21x) | 19.7 MB | 8,290 |

Peak is the figure the issue is about and it falls by 41%. The other two are the honest cost: a sweep materializes each window's stored bytes, which is the same volume the whole read materialized once, plus a 256 KiB span buffer per window. Three things keep it to that rather than more:

- `read_as_*_into` appends to a caller's buffer, so a window is decoded straight into the output instead of into a `Vec` that is then copied in. The public `read_as_*` are now thin wrappers over them.
- The sweep opens one `CachePass` for all of its windows. Each window used to ask for the plain LRU rule, which is right for a lone window whose successor is the adjacent one, but across a sweep it copied every chunk into a full cache and evicted it again — 8 MB of copies with no reader on the other side.
- A window takes only its own chunks out of the cached chunk index. Taking the whole index and discarding most of it is an allocation per chunk *of the dataset* per window: 16,384 of them to visit 2,048 chunks. That one is a fix to the existing public `read_raw_rows` as much as to the sweep, since streaming a dataset window by window is exactly what it is for.

The generic `Dataset::read::<T>()` and the `ndarray` readers delegate to these nine, so they inherit the bound.

### A check the sweep had to inherit

A whole read validates a compact or contiguous layout's declared size against the dataspace before it reads a byte. A window only ever checks that its *own* rows fall inside the declared storage, so the first version of this let `read_f64` accept a file `read_raw` refuses — and only for datasets large enough to be swept, since a small one is still read whole. A validation that fires depending on the size of its input is the kind that surfaces years later as an inconsistent bug report.

`RawReadSpec::stored_byte_len` is now the one definition of that rule and both kinds of read go through it. The output buffer is sized from the same file-derived figure, so it is reserved only after a window has come back, and through `try_reserve`: a dataspace claiming a terabyte over a file that cannot serve one row is an error this reader owes its caller, not a `capacity overflow` panic.

### What is not here

The issue floats a public `read_into(&mut [T])`. It is not in this PR: it removes a copy the sweep already bounds, and it is an API question worth its own review.

### Testing

`tests/typed_whole_read.rs` compares every reader against `read_*_rows(0, n)` over all rows — which *is* the old code path, since a full-range window delegates to the whole read and decodes it in one pass. Fixtures cover chunked, filtered, contiguous, and an inner-split chunk grid, each larger than the window budget and none of them dividing evenly, over both the buffered and streaming backends.

`tests/empty_chunked_crosscheck.rs` covers the case this crate's writer cannot produce: a chunk grid with holes, where a window is answered partly from storage and partly from the fill value. Only the reference C library allocates chunks lazily (#293), so that fixture is written by it.

`tests/allocation_bounds.rs` states the three figures above as rules, and each is load-bearing: reverting the cache pass or the index filter fails it and nothing else.
