### PR TITLE
Replay every prefix of what a session put on the disk (#309)

### DIFF
--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -42,6 +42,42 @@ use crate::filters::{ChunkContext, FilterScratch, compress_chunk_with, decompres
 use crate::message_type::MessageType;
 use crate::source::Source;
 
+/// Counts the two index-block allocations, so a test can say whether its fixture
+/// reached them.
+///
+/// Both are rare: with the C library's Extensible-Array defaults a data block is
+/// allocated roughly every sixteen appends and a *super* block twice in the first
+/// five hundred. A crash sweep positioned over the wrong window exercises neither
+/// while looking exactly like one that exercises both, which is how the first
+/// draft of [`crate::crash_replay`] came to pass with both barriers below
+/// deleted.
+#[cfg(test)]
+pub(crate) mod alloc_probe {
+    use core::cell::Cell;
+
+    thread_local! {
+        static DATA_BLOCKS: Cell<usize> = const { Cell::new(0) };
+        static SUPER_BLOCKS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn note_data_block() {
+        DATA_BLOCKS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(crate) fn note_super_block() {
+        SUPER_BLOCKS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Zero both counters and return what they held, so a caller measures one
+    /// window rather than the whole process.
+    pub(crate) fn take() -> (usize, usize) {
+        (
+            DATA_BLOCKS.with(|c| c.replace(0)),
+            SUPER_BLOCKS.with(|c| c.replace(0)),
+        )
+    }
+}
+
 /// The undefined-address sentinel for a given offset size.
 pub(crate) fn undef_addr(offset_size: u8) -> u64 {
     match offset_size {
@@ -668,6 +704,8 @@ impl Located {
             } else {
                 self.alloc_undef_data_block(file, dblk_nelmts, block_offset_rel)?
             };
+            #[cfg(test)]
+            alloc_probe::note_data_block();
             // As in `ensure_super_block`: the fresh block is at end-of-file and
             // its parent pointer is not, so they need a barrier between them or
             // an address-ordered flush names a block that is not there yet.
@@ -770,6 +808,8 @@ impl Located {
             self.client_id,
         );
         let new_addr = file.append_raw(&aesb)?;
+        #[cfg(test)]
+        alloc_probe::note_super_block();
         // The block exists before anything names it. Its bytes are at
         // end-of-file and the slot below is in the index block, near the front,
         // so without this the two are one barrier-free window and a gathering

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -91,7 +91,10 @@ use crate::writer::FileBuilder;
 enum Verdict {
     /// Read back, and the state is one a crash at this point may leave.
     Clean,
-    /// Refused to read. The benign failure: the caller is told.
+    /// Refused to read. Benign in general — the caller is told rather than
+    /// misled — but see [`Expect::EveryPrefixReads`]: the operations swept here
+    /// promise that the previous value stays readable, so for most of them this
+    /// is a failure too.
     Loud(String),
     /// Read back without complaint, and returned something else.
     Silent(String),
@@ -139,6 +142,10 @@ impl Recording {
         work(path);
         let ops = disk_log::take();
         let (data_blocks, super_blocks) = alloc_probe::take();
+        // The recorded order itself, on request. This is what shows the
+        // address-order inversion directly: with a barrier the block at
+        // end-of-file is issued before the pointer naming it, and without one the
+        // same two writes come out the other way round.
         if std::env::var_os("CRASH_REPLAY_OPS").is_some() {
             for (i, op) in ops.iter().enumerate() {
                 std::eprintln!("OP {i} {}", op.describe());
@@ -490,8 +497,12 @@ fn appending_to_a_paged_file_survives_a_crash_at_every_write() {
 /// what catches a state that decodes but whose index no longer describes where
 /// the next element goes.
 ///
-/// Fewer rounds than the sweeps above: each prefix costs a session here rather
-/// than a read.
+/// This is the only sweep that catches the barrier before a fresh **super**
+/// block. That one publishes a pointer into the index block while the block it
+/// names is still in the buffer, and the dimension covering it has not been
+/// written, so no read follows the pointer and every prefix looks perfect. The
+/// next append follows it, reads an address out of bytes that were never
+/// written, and tries to write eight bytes at 4397202087197605906.
 #[test]
 fn a_crashed_append_can_be_reopened_and_appended_to() {
     let dir = tempfile::tempdir().unwrap();
@@ -512,6 +523,7 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
         drop(s);
     });
 
+    rec.assert_allocated(2, 1);
     let hi = WARMUP + RECOVER_ROUNDS * ROUND;
     rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
         // Read it first: a file that will not open is loud, and there is nothing

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -33,24 +33,50 @@
 //! Each prefix is then read back and classified:
 //!
 //! - **clean** — it reads, and returns a state a crash at that point may leave.
-//! - **loud** — it refuses to read. This is the *benign* outcome: the caller is
-//!   told, rather than handed something wrong.
-//! - **silent** — it reads without complaint and returns something else. This is
-//!   the outcome the barriers exist to prevent, and any occurrence fails.
+//! - **loud** — it refuses to read.
+//! - **silent** — it reads without complaint and is wrong anyway: wrong data, or
+//!   a file that cannot be appended to. Always a failure.
+//!
+//! **Loud is not automatically benign here.** For a *read-only* interruption it
+//! would be — the caller is told rather than misled. But these operations promise
+//! more than that: an in-place append leaves the previous value in place until
+//! its last write, and a commit publishes at one superblock write, so the dataset
+//! that was readable before is readable throughout. A prefix that refuses to read
+//! is a window in which a crash destroyed a file that was previously fine, and
+//! [`Expect::EveryPrefixReads`] rejects it.
 //!
 //! # This one can fail
 //!
-//! A crash harness that cannot fail is decoration. Two things keep this one
-//! honest. Deleting either ordering barrier in
-//! [`crate::chunk_index_inplace`] makes
-//! [`appending_survives_a_crash_at_every_write`] report the unreachable block
-//! those barriers exist to prevent. And the driver asserts a floor on how many
-//! prefixes came back **clean**, because a checker that called everything loud,
-//! or a workload that stopped doing any work, would otherwise report no silent
-//! corruption and pass.
+//! A crash harness that cannot fail is decoration, and the first draft of this
+//! one was: it swept five hundred prefixes, called every one of them clean, and
+//! went on doing so with **both** ordering barriers in
+//! [`crate::chunk_index_inplace`] deleted. Three things were wrong, and each is
+//! now something the module states rather than something it happened to get
+//! right:
+//!
+//! 1. **The window was in the wrong place.** Extensible-Array blocks are
+//!    allocated by chunk count, a data block roughly every sixteen chunks and a
+//!    super block at chunk 244 and then not until 500. A window over chunks
+//!    270..340 crosses no super-block allocation at all.
+//!    [`alloc_probe`](crate::chunk_index_inplace::alloc_probe) counts what a
+//!    recorded window really allocated, and every sweep demands its share.
+//! 2. **The chunks were too narrow.** With a one-element chunk the whole file is
+//!    a few kilobytes, so the index block and end-of-file fall in one gathered
+//!    write — and one write is atomic, which hides the missing barrier
+//!    completely. [`CHUNK`] is 64 elements to keep them apart.
+//! 3. **The rule was too weak.** See above: a prefix that refuses to read was
+//!    being counted as the benign outcome.
+//!
+//! With all three fixed, deleting the barrier before a fresh **data** block makes
+//! three of the sweeps report `UnexpectedEof` — an index pointer into bytes past
+//! end-of-file — and deleting the one before a fresh **super** block makes
+//! [`a_crashed_append_can_be_reopened_and_appended_to`] report a file that reads
+//! perfectly and then panics on the next append, at an address read out of bytes
+//! that were never written.
 
 use std::path::Path;
 
+use crate::chunk_index_inplace::alloc_probe;
 use crate::edit::{AppendBuilder, AppendTarget, MemoryStrategy, SyncPolicy, WriteEngine};
 use crate::error::Error;
 use crate::file_lock::FileLocking;
@@ -94,6 +120,10 @@ struct Recording {
     /// has an opinion about it.
     base: Vec<u8>,
     ops: Vec<DiskOp>,
+    /// Fresh Extensible-Array blocks the recorded window allocated, by kind.
+    /// See [`assert_allocated`](Self::assert_allocated).
+    data_blocks: usize,
+    super_blocks: usize,
 }
 
 impl Recording {
@@ -102,9 +132,18 @@ impl Recording {
     /// writes are part of what a crash can interrupt, so they belong in the log.
     fn of(label: &str, path: &Path, work: impl FnOnce(&Path)) -> Self {
         let base = std::fs::read(path).expect("the starting file");
+        // Discard whatever the warm-up allocated, so the counts below describe
+        // the recorded window rather than the whole test.
+        alloc_probe::take();
         disk_log::start();
         work(path);
         let ops = disk_log::take();
+        let (data_blocks, super_blocks) = alloc_probe::take();
+        if std::env::var_os("CRASH_REPLAY_OPS").is_some() {
+            for (i, op) in ops.iter().enumerate() {
+                std::eprintln!("OP {i} {}", op.describe());
+            }
+        }
         assert!(
             !ops.is_empty(),
             "{label}: recorded nothing, so there is no crash point to replay"
@@ -113,7 +152,28 @@ impl Recording {
             label: label.to_string(),
             base,
             ops,
+            data_blocks,
+            super_blocks,
         }
+    }
+
+    /// Require that the recorded window allocated at least this many fresh index
+    /// blocks of each kind — which is the only thing that puts the two ordering
+    /// barriers in [`crate::chunk_index_inplace`] under the sweep at all.
+    ///
+    /// Stated as a demand rather than checked afterwards because a window that
+    /// misses them still sweeps hundreds of prefixes and reports every one of
+    /// them clean, with or without the barriers.
+    fn assert_allocated(&self, data_blocks: usize, super_blocks: usize) {
+        assert!(
+            self.data_blocks >= data_blocks && self.super_blocks >= super_blocks,
+            "{}: the recorded window allocated {} data block(s) and {} super block(s), \
+             short of the {data_blocks} and {super_blocks} it is positioned for. \
+             Nothing below can see a barrier that is not crossed.",
+            self.label,
+            self.data_blocks,
+            self.super_blocks
+        );
     }
 
     /// Apply one operation to an in-memory image of the file, exactly as the
@@ -133,16 +193,12 @@ impl Recording {
         }
     }
 
-    /// Materialize every prefix in turn and hand each to `check`.
-    ///
-    /// `min_clean` is the floor this run must meet, as a fraction of the prefixes
-    /// replayed. It is what makes a vacuous pass fail: a workload that stopped
-    /// doing work, or a checker that called every state loud, would report no
-    /// silent corruption and otherwise sail through.
+    /// Materialize every prefix in turn and hand each to `check`, then hold it to
+    /// `expect`.
     fn replay_every_prefix(
         &self,
         dir: &Path,
-        min_clean: f64,
+        expect: Expect,
         check: impl Fn(&Path) -> Verdict,
     ) -> Tally {
         let path = dir.join(std::format!("{}.replay.h5", self.label));
@@ -189,9 +245,37 @@ impl Recording {
                 tally.silent.len()
             );
         }
-        tally.assert_sound(&self.label, min_clean);
+        tally.assert_sound(&self.label, expect);
         tally
     }
+}
+
+/// What a sweep demands of the states it finds.
+#[derive(Clone, Copy)]
+enum Expect {
+    /// **No prefix may fail to read.**
+    ///
+    /// This is the real promise of an operation the crate calls crash-atomic, and
+    /// it is stronger than "never silently wrong". The dataset was readable before
+    /// the operation began; a crash part-way through must leave it readable, as
+    /// the old value. A prefix that refuses to read is a window in which the file
+    /// went from readable to not, which is a regression a caller experiences even
+    /// though nothing is silently wrong.
+    ///
+    /// It is what the ordering barriers buy. Removing either of the two in
+    /// [`crate::chunk_index_inplace`] breaks it immediately: the pointer to a
+    /// fresh index block is issued before the block, and the prefix between them
+    /// reads `UnexpectedEof`, naming an address past end-of-file.
+    ///
+    /// The rule holds for an object header whose chunk 0 fits inside one gather
+    /// page. Above that, a value and the checksum covering it can land in
+    /// different pages and a crash between them tears the header — issue #307,
+    /// which predates the gathering and is not what these sweeps are about.
+    EveryPrefixReads,
+    /// Some prefixes may refuse to read; at least this fraction must not. For the
+    /// baseline sweeps, which are deliberately run in a mode that does *not*
+    /// provide the rule above.
+    SomeMayRefuse { min_clean: f64 },
 }
 
 /// What one sweep found, kept so a caller can compare two of them.
@@ -206,9 +290,9 @@ struct Tally {
 }
 
 impl Tally {
-    /// Fail on any silent corruption, and on a run too quiet to have proved
-    /// anything.
-    fn assert_sound(&self, label: &str, min_clean: f64) {
+    /// Fail on any silent corruption, and on a run that did not meet what its
+    /// sweep expects of it.
+    fn assert_sound(&self, label: &str, expect: Expect) {
         assert!(
             self.silent.is_empty(),
             "{label}: {} of {} replayed prefixes read cleanly and returned the wrong data:\n  {}",
@@ -216,17 +300,29 @@ impl Tally {
             self.total,
             self.silent.join("\n  ")
         );
-        // Without this a checker that called every state loud, or a workload that
-        // quietly stopped doing work, would report no silent corruption and pass.
-        assert!(
-            self.clean as f64 >= min_clean * self.total as f64,
-            "{label}: only {} of {} prefixes read cleanly, below the {min_clean} floor, \
-             so this run proved nothing. The {} that refused:\n  {}",
-            self.clean,
-            self.total,
-            self.loud.len(),
-            self.loud.join("\n  ")
-        );
+        match expect {
+            Expect::EveryPrefixReads => assert!(
+                self.loud.is_empty(),
+                "{label}: {} of {} replayed prefixes refused to read, though every one \
+                 of them is a crash during an operation that leaves the previous value \
+                 in place and readable:\n  {}",
+                self.loud.len(),
+                self.total,
+                self.loud.join("\n  ")
+            ),
+            // Without a floor, a checker that called every state loud, or a
+            // workload that quietly stopped doing work, would report no silent
+            // corruption and pass.
+            Expect::SomeMayRefuse { min_clean } => assert!(
+                self.clean as f64 >= min_clean * self.total as f64,
+                "{label}: only {} of {} prefixes read cleanly, below the {min_clean} floor, \
+                 so this run proved nothing. The {} that refused:\n  {}",
+                self.clean,
+                self.total,
+                self.loud.len(),
+                self.loud.join("\n  ")
+            ),
+        }
     }
 }
 
@@ -234,16 +330,39 @@ impl Tally {
 // The append workload
 // ---------------------------------------------------------------------------
 
-/// Elements the base file already holds when recording starts.
-const WARMUP: i32 = 270;
-/// Elements each recorded round appends.
-const ROUND: i32 = 4;
+/// Elements per chunk, and per recorded round: one whole chunk per append.
+///
+/// The Extensible Array allocates blocks by *chunk count*, so the chunk width is
+/// free, and it is not free in the one way that matters here. With a
+/// one-element chunk the whole file is a few kilobytes, the index block and
+/// end-of-file share a gathered write, and a missing barrier between them is
+/// **invisible** — the two writes coalesce into one, which is atomic. Widening
+/// the chunk moves end-of-file away from the index without changing which round
+/// allocates what, which is what puts a prefix between the pointer and the block
+/// it names.
+const CHUNK: u64 = 64;
+/// Elements each recorded round appends: exactly one chunk.
+const ROUND: i32 = CHUNK as i32;
+
+/// Rounds the base file already holds when recording starts, and rounds recorded
+/// after it.
+///
+/// The window is positioned, not picked. With the C library's Extensible-Array
+/// defaults a fresh *data* block is allocated at chunk 4, 20, 52, 84, 116, 180,
+/// 244, 308, ..., and a fresh *super* block at 244 and then not again until 500.
+/// Recording chunks 230..=320 therefore crosses two data-block allocations and
+/// the super-block one between them, which are the crate's two barrier sites.
+///
+/// A window at 270 — the obvious round number — crosses no super-block
+/// allocation at all, and a sweep positioned there passes with both barriers
+/// deleted while still replaying five hundred prefixes and calling every one of
+/// them clean. [`crate::chunk_index_inplace::alloc_probe`] is what turns that
+/// into a failure rather than a silently narrower sweep.
+const WARMUP_ROUNDS: i32 = 230;
 /// Recorded rounds.
-const ROUNDS: i32 = 70;
-/// Chunk length, small enough that the warm-up crosses an Extensible-Array data
-/// block *and* the super-block level above it rather than staying in the index
-/// block's inline elements.
-const CHUNK: u64 = 4;
+const ROUNDS: i32 = 90;
+/// Elements the base file holds when recording starts.
+const WARMUP: i32 = WARMUP_ROUNDS * ROUND;
 
 /// Build a chunked, unlimited `i32` dataset holding `0..n`, and append to it
 /// until it holds `WARMUP`. The appends are what matter: a file *written* with
@@ -332,8 +451,9 @@ fn appending_survives_a_crash_at_every_write() {
         drop(s);
     });
 
+    rec.assert_allocated(2, 1);
     let hi = WARMUP + ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
         appended_prefix_is_intact(p, WARMUP, hi)
     });
 }
@@ -358,8 +478,9 @@ fn appending_to_a_paged_file_survives_a_crash_at_every_write() {
         drop(s);
     });
 
+    rec.assert_allocated(2, 1);
     let hi = WARMUP + ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
         appended_prefix_is_intact(p, WARMUP, hi)
     });
 }
@@ -377,7 +498,11 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
     let path = dir.path().join("recover.h5");
     warmed_base(&path, false);
 
-    const RECOVER_ROUNDS: i32 = 8;
+    const RECOVER_ROUNDS: i32 = ROUNDS;
+    // Enough to cross a whole data block (`data_blk_min_elmts` is 16), so the
+    // recovery reaches the region the crashed session was allocating rather than
+    // filling in behind it.
+    const RECOVER_APPEND: i32 = 40;
     let rec = Recording::of("recover", &path, |p| {
         let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
         s.set_sync_policy(SyncPolicy::OnClose);
@@ -388,7 +513,7 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
     });
 
     let hi = WARMUP + RECOVER_ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
         // Read it first: a file that will not open is loud, and there is nothing
         // to recover.
         match appended_prefix_is_intact(p, WARMUP, hi) {
@@ -399,19 +524,48 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
             .and_then(|f| f.dataset("d")?.read_i32())
             .expect("just read it")
             .len() as i32;
-        let reopened = (|| -> Result<(), Error> {
+        // Caught rather than allowed to unwind, because one shape of this defect
+        // panics rather than returning: a super-block pointer published without
+        // the block gives the next append a garbage address read out of bytes
+        // that were never written, and the image asserts on the write rather
+        // than performing it. Letting that abort the sweep would report the
+        // first occurrence and name no prefix; caught, every one is listed with
+        // the write that produced it.
+        let reopened = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled)?;
             s.set_sync_policy(SyncPolicy::OnClose);
             let mut b = AppendBuilder::new();
-            b.append_i32(&(before..before + ROUND).collect::<Vec<_>>());
+            b.append_i32(&(before..before + RECOVER_APPEND).collect::<Vec<_>>());
             s.append_inplace_gathered(AppendTarget::Path("d"), &b, 4)?;
             drop(s);
-            Ok(())
-        })();
-        if let Err(e) = reopened {
-            return Verdict::Loud(std::format!("reopen and append: {e:?}"));
+            Ok::<(), Error>(())
+        }));
+        // A file that read cleanly and then cannot be written to is *not* the
+        // benign outcome, however loudly the append fails. The read said the file
+        // was whole; the failure says an index pointer names a block that is not
+        // there, which no read follows because the dimension covering it was
+        // never published. That is the shape the ordering barriers exist to
+        // prevent, and it is only ever visible from here.
+        match reopened {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                return Verdict::Silent(std::format!(
+                    "reads cleanly at {before} elements, but reopening and appending fails: {e:?}"
+                ));
+            }
+            Err(panic) => {
+                let why = panic
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| panic.downcast_ref::<&str>().copied())
+                    .unwrap_or("(non-string panic)")
+                    .to_string();
+                return Verdict::Silent(std::format!(
+                    "reads cleanly at {before} elements, but reopening and appending panics: {why}"
+                ));
+            }
         }
-        appended_prefix_is_intact(p, before + ROUND, before + ROUND)
+        appended_prefix_is_intact(p, before + RECOVER_APPEND, before + RECOVER_APPEND)
     });
 }
 
@@ -620,7 +774,11 @@ fn committing_survives_a_crash_at_every_write() {
                 drop(s);
             });
 
-            rec.replay_every_prefix(dir.path(), 0.5, commit_state_is_one_or_the_other);
+            rec.replay_every_prefix(
+                dir.path(),
+                Expect::EveryPrefixReads,
+                commit_state_is_one_or_the_other,
+            );
         }
     }
 }
@@ -650,7 +808,7 @@ fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
     const ROUNDS_EACH: i32 = 20;
     let hi = WARMUP + ROUNDS_EACH * ROUND;
 
-    let sweep = |label: &str, mode: Option<WriteBuffering>| -> Tally {
+    let sweep = |label: &str, mode: Option<WriteBuffering>, expect: Expect| -> Tally {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("compare.h5");
         warmed_base(&path, false);
@@ -665,15 +823,21 @@ fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
             }
             drop(s);
         });
-        rec.replay_every_prefix(dir.path(), 0.5, |p| {
+        rec.replay_every_prefix(dir.path(), expect, |p| {
             appended_prefix_is_intact(p, WARMUP, hi)
         })
     };
 
     // `None` keeps the session default, which is the gathering a locked
-    // read-write session takes.
-    let gathered = sweep("compare-gathered", None);
-    let straight = sweep("compare-unbuffered", Some(WriteBuffering::Unbuffered));
+    // read-write session takes, and it is held to the full rule.
+    let gathered = sweep("compare-gathered", None, Expect::EveryPrefixReads);
+    // The unbuffered half is *not*, and that is the finding: straight-through
+    // writing does not provide it.
+    let straight = sweep(
+        "compare-unbuffered",
+        Some(WriteBuffering::Unbuffered),
+        Expect::SomeMayRefuse { min_clean: 0.5 },
+    );
 
     // Neither mode may corrupt silently — `assert_sound` has already said so for
     // both, and that is the guarantee. This is the softer, measured claim on top

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -27,58 +27,74 @@
 //! issued. A [`Recording`] pairs that log with the file's bytes as they were
 //! before the session opened, which makes every prefix of the log a file that
 //! could really have existed: the operations are positioned, so applying the
-//! first *k* of them to the starting bytes is exactly the disk state after *k*
-//! of them completed.
-//!
-//! Each prefix is then read back and classified:
-//!
-//! - **clean** — it reads, and returns a state a crash at that point may leave.
-//! - **loud** — it refuses to read.
-//! - **silent** — it reads without complaint and is wrong anyway: wrong data, or
-//!   a file that cannot be appended to. Always a failure.
-//!
-//! **Loud is not automatically benign here.** For a *read-only* interruption it
-//! would be — the caller is told rather than misled. But these operations promise
-//! more than that: an in-place append leaves the previous value in place until
-//! its last write, and a commit publishes at one superblock write, so the dataset
-//! that was readable before is readable throughout. A prefix that refuses to read
-//! is a window in which a crash destroyed a file that was previously fine, and
-//! [`Expect::EveryPrefixReads`] rejects it.
+//! first *k* of them to the starting bytes is exactly the disk state after *k* of
+//! them completed. Each prefix is written out and read back, and judged as
+//! [`Verdict::Clean`], [`Verdict::Loud`] or [`Verdict::Silent`].
 //!
 //! # This one can fail
 //!
 //! A crash harness that cannot fail is decoration, and the first draft of this
 //! one was: it swept five hundred prefixes, called every one of them clean, and
-//! went on doing so with **both** ordering barriers in
-//! [`crate::chunk_index_inplace`] deleted. Three things were wrong, and each is
-//! now something the module states rather than something it happened to get
-//! right:
+//! went on doing so with **both** of the ordering barriers it was written for
+//! deleted. Nothing about that was visible from the outside — the sweep was wide,
+//! the assertions were real, and the numbers looked healthy.
 //!
-//! 1. **The window was in the wrong place.** Extensible-Array blocks are
-//!    allocated by chunk count, a data block roughly every sixteen chunks and a
-//!    super block at chunk 244 and then not until 500. A window over chunks
-//!    270..340 crosses no super-block allocation at all.
-//!    [`alloc_probe`](crate::chunk_index_inplace::alloc_probe) counts what a
-//!    recorded window really allocated, and every sweep demands its share.
-//! 2. **The chunks were too narrow.** With a one-element chunk the whole file is
-//!    a few kilobytes, so the index block and end-of-file fall in one gathered
-//!    write — and one write is atomic, which hides the missing barrier
-//!    completely. [`CHUNK`] is 64 elements to keep them apart.
-//! 3. **The rule was too weak.** See above: a prefix that refuses to read was
-//!    being counted as the benign outcome.
+//! Three separate things were wrong, and the fix for each is a *demand the code
+//! makes* rather than a value that happens to be right:
 //!
-//! With all three fixed, deleting the barrier before a fresh **data** block makes
-//! three of the sweeps report `UnexpectedEof` — an index pointer into bytes past
-//! end-of-file — and deleting the one before a fresh **super** block makes
-//! [`a_crashed_append_can_be_reopened_and_appended_to`] report a file that reads
-//! perfectly and then panics on the next append, at an address read out of bytes
-//! that were never written.
+//! 1. The window did not cross the allocations that reach the barriers — see
+//!    [`WARMUP_ROUNDS`] and [`Recording::assert_positioned`].
+//! 2. The file was small enough that a publish point and the content it names
+//!    merged into a single write, which is atomic — see [`CHUNK`] and the same
+//!    method's second condition.
+//! 3. A prefix that refused to read was counted as benign — see
+//!    [`Expect::EveryPrefixReads`].
+//!
+//! Each of those is now something a future change trips over rather than
+//! silently loses. [`Recording::replay_every_prefix`] adds two more of the same
+//! kind: replaying the *whole* log must reproduce the file the session really
+//! left, so a write escaping [`disk_log`] cannot pass unnoticed, and the last
+//! prefix must satisfy the workload's finished state, so a session that quietly
+//! stopped doing work cannot either.
+//!
+//! # What it covers, and what it does not
+//!
+//! Measured by deleting each barrier in the Extensible-Array append engine in
+//! turn and running the library:
+//!
+//! | barrier | caught |
+//! | --- | --- |
+//! | before a fresh data-block pointer | yes, and by the pre-existing structural test |
+//! | before a fresh super-block pointer | yes, only by [`a_crashed_append_can_be_reopened_and_appended_to`] |
+//! | `apply_ea_append` phase 1, chunk bytes → superblock end-of-file | yes, by [`recorded_eof_covers_the_file`] |
+//! | `apply_ea_append` phase 1, end-of-file → index writes | **no** |
+//! | `apply_ea_append` phase 2 → 3 | **no** |
+//! | `apply_ea_append` phase 3, header count → dimension | yes |
+//!
+//! The two uncovered ones are not gaps in the sweep, and it is worth knowing why
+//! before adding a workload to chase them. Deleting the first changes **nothing
+//! that reaches the disk** under gathering — the recorded write order is
+//! byte-identical, because the order it enforces is the order address-sorting
+//! already produces. Deleting the second does reorder two metadata writes, but
+//! the state between them is a published element count with a stale block, which
+//! is indistinguishable from a normal in-progress append to a reader bounded by
+//! the dataspace dimension. Both remain load-bearing for the two things this
+//! module does not model: `fsync` durability under
+//! [`SyncPolicy::Always`](crate::SyncPolicy), and the visibility order a *SWMR*
+//! reader follows, which is defined in terms of the header counts rather than the
+//! dimension.
+//!
+//! Outside this engine, nothing is covered: dense attribute heaps, the
+//! Fixed-Array and v2 B-tree chunk indexes, filtered and variable-length chunk
+//! writes, and group link-table growth all publish low-address pointers to
+//! high-address content and have no sweep here. That is the remaining half of
+//! issue #309.
 
 use std::path::Path;
 
 use crate::chunk_index_inplace::alloc_probe;
 use crate::edit::{AppendBuilder, AppendTarget, MemoryStrategy, SyncPolicy, WriteEngine};
-use crate::error::Error;
+use crate::error::{Error, FormatError};
 use crate::file_lock::FileLocking;
 use crate::file_space_info::FileSpaceStrategy;
 use crate::image::disk_log::{self, DiskOp};
@@ -87,7 +103,6 @@ use crate::type_builders::DatasetBuilder;
 use crate::writer::FileBuilder;
 
 /// What reading one replayed prefix made of it.
-#[derive(Debug)]
 enum Verdict {
     /// Read back, and the state is one a crash at this point may leave.
     Clean,
@@ -122,6 +137,9 @@ struct Recording {
     /// session exists rather than alongside it, so no platform's file locking
     /// has an opinion about it.
     base: Vec<u8>,
+    /// The file the recorded session actually wrote, kept so the last prefix can
+    /// be compared against it.
+    real: std::path::PathBuf,
     ops: Vec<DiskOp>,
     /// Fresh Extensible-Array blocks the recorded window allocated, by kind.
     /// See [`assert_allocated`](Self::assert_allocated).
@@ -158,20 +176,30 @@ impl Recording {
         Self {
             label: label.to_string(),
             base,
+            real: path.to_path_buf(),
             ops,
             data_blocks,
             super_blocks,
         }
     }
 
-    /// Require that the recorded window allocated at least this many fresh index
-    /// blocks of each kind — which is the only thing that puts the two ordering
-    /// barriers in [`crate::chunk_index_inplace`] under the sweep at all.
+    /// Require that this fixture is positioned where the defect is visible. Two
+    /// separate conditions, because the first draft of this module satisfied
+    /// neither while sweeping five hundred prefixes and reporting every one
+    /// clean:
     ///
-    /// Stated as a demand rather than checked afterwards because a window that
-    /// misses them still sweeps hundreds of prefixes and reports every one of
-    /// them clean, with or without the barriers.
-    fn assert_allocated(&self, data_blocks: usize, super_blocks: usize) {
+    /// 1. The window **allocated** fresh index blocks of each kind, since the two
+    ///    ordering barriers in [`crate::chunk_index_inplace`] are only reached by
+    ///    an allocation. A window over the wrong rounds crosses neither.
+    /// 2. End-of-file is **far enough from the index** that the two sides of a
+    ///    publish cannot share a gathered write. This is the condition that is
+    ///    easy to lose by retuning a constant: [`CHUNK`] used to be one element,
+    ///    which kept the whole file inside two pages, and two writes that merge
+    ///    into one are atomic — the inversion still happens and no prefix can
+    ///    observe it. Deleting a barrier and shrinking `CHUNK` back to 1 makes
+    ///    the sweeps pass again with condition 1 still satisfied, so nothing but
+    ///    this catches it.
+    fn assert_positioned(&self, data_blocks: usize, super_blocks: usize) {
         assert!(
             self.data_blocks >= data_blocks && self.super_blocks >= super_blocks,
             "{}: the recorded window allocated {} data block(s) and {} super block(s), \
@@ -180,6 +208,15 @@ impl Recording {
             self.label,
             self.data_blocks,
             self.super_blocks
+        );
+        let pages = std::fs::metadata(&self.real).unwrap().len() / GATHER_PAGE;
+        assert!(
+            pages >= MIN_PAGES,
+            "{}: the file spans {pages} gather pages of {GATHER_PAGE} bytes, under the \
+             {MIN_PAGES} this needs. Below that, a publish point near the front of the \
+             file and the block it names at end-of-file merge into one gathered write, \
+             which is atomic, and no replayed prefix can fall between them.",
+            self.label
         );
     }
 
@@ -202,11 +239,19 @@ impl Recording {
 
     /// Materialize every prefix in turn and hand each to `check`, then hold it to
     /// `expect`.
+    ///
+    /// `finished` is what the *last* prefix must satisfy — the state the workload
+    /// was supposed to reach. Without it every sweep here is satisfiable by doing
+    /// nothing: prefix 0 is the untouched starting file, every checker accepts it
+    /// (an append that has not happened and a commit that has not landed are both
+    /// legitimate crash states), and so a regression that silently stopped
+    /// publishing would leave all five sweeps reporting 100% clean.
     fn replay_every_prefix(
         &self,
         dir: &Path,
         expect: Expect,
         check: impl Fn(&Path) -> Verdict,
+        finished: impl Fn(&Path) -> Result<(), String>,
     ) -> Tally {
         let path = dir.join(std::format!("{}.replay.h5", self.label));
         let mut image = self.base.clone();
@@ -222,6 +267,28 @@ impl Recording {
                 Self::apply(&mut image, &self.ops[k - 1]);
             }
             std::fs::write(&path, &image).unwrap();
+            if k == self.ops.len() {
+                // Replaying the whole log must reproduce the file the session
+                // actually left. Anything reaching the disk outside
+                // `BufferedWrites` — a raw positioned write on the handle, a
+                // second thread — is invisible to the log, and every prefix
+                // above would then be a state that never existed.
+                assert_eq!(
+                    image,
+                    std::fs::read(&self.real).unwrap(),
+                    "{}: replaying every recorded operation does not reproduce the \
+                     file the session left, so the log is not everything that \
+                     reached the disk",
+                    self.label
+                );
+                if let Err(why) = finished(&path) {
+                    panic!(
+                        "{}: the completed workload did not reach the state this \
+                         sweep is judging interruptions of: {why}",
+                        self.label
+                    );
+                }
+            }
             let after = if k == 0 {
                 "the starting file".to_string()
             } else {
@@ -269,10 +336,13 @@ enum Expect {
     /// went from readable to not, which is a regression a caller experiences even
     /// though nothing is silently wrong.
     ///
-    /// It is what the ordering barriers buy. Removing either of the two in
-    /// [`crate::chunk_index_inplace`] breaks it immediately: the pointer to a
-    /// fresh index block is issued before the block, and the prefix between them
-    /// reads `UnexpectedEof`, naming an address past end-of-file.
+    /// It is what the ordering barriers buy, though not all of them through this
+    /// rule. Removing the barrier before a fresh *data* block breaks it directly:
+    /// the pointer is issued before the block, and the prefix between them reads
+    /// `UnexpectedEof`, naming an address past end-of-file. The *super* block's
+    /// barrier produces no unreadable prefix at all and is caught by the silent
+    /// rule instead, in
+    /// [`a_crashed_append_can_be_reopened_and_appended_to`].
     ///
     /// The rule holds for an object header whose chunk 0 fits inside one gather
     /// page. Above that, a value and the checksum covering it can land in
@@ -280,8 +350,13 @@ enum Expect {
     /// which predates the gathering and is not what these sweeps are about.
     EveryPrefixReads,
     /// Some prefixes may refuse to read; at least this fraction must not. For the
-    /// baseline sweeps, which are deliberately run in a mode that does *not*
-    /// provide the rule above.
+    /// baseline sweeps, run in a mode that deliberately does *not* provide the
+    /// rule above.
+    ///
+    /// The floor is loose on purpose and is not the interesting assertion — the
+    /// unbuffered sweep measures 88% clean against a 0.5 floor. What it bounds
+    /// that nothing else does is the baseline mode itself degenerating to
+    /// all-loud, which the gathered half cannot see.
     SomeMayRefuse { min_clean: f64 },
 }
 
@@ -336,6 +411,11 @@ impl Tally {
 // ---------------------------------------------------------------------------
 // The append workload
 // ---------------------------------------------------------------------------
+
+/// The page a locked session merges its writes within, and the least number of
+/// them a fixture must span. See [`Recording::assert_positioned`].
+const GATHER_PAGE: u64 = crate::file_space_info::DEFAULT_PAGE_SIZE;
+const MIN_PAGES: u64 = 8;
 
 /// Elements per chunk, and per recorded round: one whole chunk per append.
 ///
@@ -418,6 +498,9 @@ fn append(s: &mut WriteEngine, from: i32, count: i32) {
 /// a crash before that append published, which is the whole point of the
 /// barriers.
 fn appended_prefix_is_intact(path: &Path, lo: i32, hi: i32) -> Verdict {
+    if let Err(why) = recorded_eof_covers_the_file(path) {
+        return Verdict::Silent(why);
+    }
     let read = crate::reader::File::open(path).and_then(|f| f.dataset("d")?.read_i32());
     Verdict::of(read, |data| {
         let n = data.len() as i32;
@@ -436,33 +519,57 @@ fn appended_prefix_is_intact(path: &Path, lo: i32, hi: i32) -> Verdict {
     })
 }
 
-/// Stopping an in-place append at *any* write must leave a file that either
-/// refuses to open or reads as an intact prefix of the sequence.
+/// The superblock's recorded end-of-file must not name bytes the file does not
+/// have.
 ///
-/// This is the test the two barriers in [`crate::chunk_index_inplace`] were added
-/// for. Deleting either one makes it fail here rather than in a later session:
-/// the index block or data block pointer is published while the block itself is
-/// still only in the buffer, so the next read follows it past end-of-file.
-#[test]
-fn appending_survives_a_crash_at_every_write() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("append.h5");
-    warmed_base(&path, false);
+/// Reading one dataset cannot see this. The recorded end-of-file is the
+/// allocator's cursor, not something a read follows, so a superblock claiming
+/// more file than exists decodes perfectly and returns every correct value — and
+/// then the next session allocates from a cursor past the real end, placing a
+/// block in a hole.
+///
+/// It is the check the three barriers in the first half of
+/// [`apply_ea_append`](crate::chunk_index_inplace::apply_ea_append) exist for,
+/// and the reason they were invisible to the first version of this module: they
+/// separate content at end-of-file from the *superblock field that covers it*,
+/// which is at address 8-ish and therefore first in address order. Every one of
+/// them is caught here and nowhere else in the crate.
+fn recorded_eof_covers_the_file(path: &Path) -> Result<(), String> {
+    let bytes = std::fs::read(path).map_err(|e| std::format!("reading the file back: {e}"))?;
+    // A prefix whose superblock does not parse is a *loud* state, not this
+    // function's business; the read below will classify it.
+    let Ok(sb) = crate::superblock::Superblock::parse(&bytes, 0) else {
+        return Ok(());
+    };
+    if sb.eof_address > bytes.len() as u64 {
+        return Err(std::format!(
+            "the superblock records end-of-file at {} but the file is {} bytes: \
+             every byte between is one a later session would allocate from and \
+             never find",
+            sb.eof_address,
+            bytes.len()
+        ));
+    }
+    Ok(())
+}
 
-    let rec = Recording::of("append", &path, |p| {
-        let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
-        s.set_sync_policy(SyncPolicy::OnClose);
-        for r in 0..ROUNDS {
-            append(&mut s, WARMUP + r * ROUND, ROUND);
-        }
-        drop(s);
-    });
-
-    rec.assert_allocated(2, 1);
-    let hi = WARMUP + ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
-        appended_prefix_is_intact(p, WARMUP, hi)
-    });
+/// The completed workload must have reached the length it was aiming at.
+///
+/// This is what the last replayed prefix is held to. Every *other* prefix
+/// legitimately accepts a shorter dataset — that is what a crash mid-append
+/// leaves — so without this the whole sweep is satisfied by a session that
+/// appended nothing at all.
+fn appended_all_the_way(path: &Path, hi: i32) -> Result<(), String> {
+    let data = crate::reader::File::open(path)
+        .and_then(|f| f.dataset("d")?.read_i32())
+        .map_err(|e| std::format!("the finished file does not read: {e:?}"))?;
+    if data.len() as i32 != hi {
+        return Err(std::format!(
+            "it holds {} elements rather than the {hi} the workload appended",
+            data.len()
+        ));
+    }
+    Ok(())
 }
 
 /// The same sweep on a paged file, where the free-space managers are written and
@@ -485,11 +592,14 @@ fn appending_to_a_paged_file_survives_a_crash_at_every_write() {
         drop(s);
     });
 
-    rec.assert_allocated(2, 1);
+    rec.assert_positioned(2, 1);
     let hi = WARMUP + ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
-        appended_prefix_is_intact(p, WARMUP, hi)
-    });
+    rec.replay_every_prefix(
+        dir.path(),
+        Expect::EveryPrefixReads,
+        |p| appended_prefix_is_intact(p, WARMUP, hi),
+        |p| appended_all_the_way(p, hi),
+    );
 }
 
 /// A file left by a crash must not merely *read* — it must be usable. Every
@@ -510,10 +620,15 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
     warmed_base(&path, false);
 
     const RECOVER_ROUNDS: i32 = ROUNDS;
-    // Enough to cross a whole data block (`data_blk_min_elmts` is 16), so the
-    // recovery reaches the region the crashed session was allocating rather than
-    // filling in behind it.
-    const RECOVER_APPEND: i32 = 40;
+    // Chunks, not elements. The recovery has to reach past the region the
+    // crashed session was allocating rather than filling in behind it, and a
+    // data block is `data_blk_min_elmts` = 16 *chunks*, so this crosses two of
+    // them. Written as a count of `ROUND` because it was once a bare 40 back
+    // when a chunk was one element, and widening `CHUNK` silently turned it into
+    // two thirds of a single chunk — an append that advanced the dataset barely
+    // at all while its comment still claimed to cross a block.
+    const RECOVER_CHUNKS: i32 = 40;
+    const RECOVER_APPEND: i32 = RECOVER_CHUNKS * ROUND;
     let rec = Recording::of("recover", &path, |p| {
         let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
         s.set_sync_policy(SyncPolicy::OnClose);
@@ -523,9 +638,12 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
         drop(s);
     });
 
-    rec.assert_allocated(2, 1);
+    rec.assert_positioned(2, 1);
     let hi = WARMUP + RECOVER_ROUNDS * ROUND;
-    rec.replay_every_prefix(dir.path(), Expect::EveryPrefixReads, |p| {
+    rec.replay_every_prefix(
+        dir.path(),
+        Expect::EveryPrefixReads,
+        |p| {
         // Read it first: a file that will not open is loud, and there is nothing
         // to recover.
         match appended_prefix_is_intact(p, WARMUP, hi) {
@@ -578,7 +696,9 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
             }
         }
         appended_prefix_is_intact(p, before + RECOVER_APPEND, before + RECOVER_APPEND)
-    });
+        },
+        |p| appended_all_the_way(p, hi),
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -588,17 +708,22 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
 /// Churn rounds in one recorded commit session.
 const CHURN: i32 = 6;
 /// Elements `d` starts the commit workload with, and gains per round.
-const COMMIT_BASE: i32 = 64;
-const COMMIT_STEP: i32 = 16;
+///
+/// Sized so the file spans well over [`MIN_PAGES`] gather pages, for the reason
+/// [`Recording::assert_positioned`] gives: at the 64 and 16 this used to be, the
+/// whole file was under 4 KB, every write merged with every other, and the sweep
+/// could not observe an inversion it nonetheless produced.
+const COMMIT_BASE: i32 = 4096;
+const COMMIT_STEP: i32 = 1024;
 
 /// Elements of `added{r}`, and of the `doomed{r}` it replaces. Different lengths
 /// so a round that resurrected the wrong object reads as the wrong length rather
 /// than as plausible data.
 fn added_values(r: i32) -> Vec<i32> {
-    (0..48 + r).map(|i| i * 7 + r).collect()
+    (0..2048 + r).map(|i| i * 7 + r).collect()
 }
 fn doomed_values(r: i32) -> Vec<i32> {
-    (0..32 + r).map(|i| i * 3 + r).collect()
+    (0..1024 + r).map(|i| i * 3 + r).collect()
 }
 
 /// Build the file the commit workload churns: one growable dataset, and one
@@ -623,6 +748,21 @@ fn commit_base(path: &Path, paged: bool) {
     b.write(path).unwrap();
 }
 
+/// Read a dataset that may legitimately not be in the file, distinguishing "no
+/// such path" from "the path is there and will not decode".
+///
+/// The difference matters and is easy to lose: mapping every error to `None`
+/// turns a commit that published a link to a half-written object header — a
+/// genuinely torn commit — into "this round has not committed yet", which every
+/// rule below accepts.
+fn read_optional(f: &crate::reader::File, path: &str) -> Result<Option<Vec<i32>>, Error> {
+    match f.dataset(path) {
+        Ok(ds) => ds.read_i32().map(Some),
+        Err(Error::Format(FormatError::PathNotFound { .. })) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 /// `d`'s elements, then each round's `added{r}` and `doomed{r}` — `None` where
 /// the path is not in the file at all.
 type CommitState = (Vec<i32>, Vec<Option<Vec<i32>>>, Vec<Option<Vec<i32>>>);
@@ -640,19 +780,11 @@ fn commit_state_is_one_or_the_other(path: &Path) -> Verdict {
     let read = (|| -> Result<CommitState, Error> {
         let f = crate::reader::File::open(path)?;
         let d = f.dataset("d")?.read_i32()?;
-        // A path that is absent is a state, not a failure; a path that is present
-        // and unreadable is a failure, and stays an `Err`.
         let mut added = Vec::new();
         let mut doomed = Vec::new();
         for r in 0..CHURN {
-            added.push(match f.dataset(&std::format!("added{r}")) {
-                Ok(ds) => Some(ds.read_i32()?),
-                Err(_) => None,
-            });
-            doomed.push(match f.dataset(&std::format!("doomed{r}")) {
-                Ok(ds) => Some(ds.read_i32()?),
-                Err(_) => None,
-            });
+            added.push(read_optional(&f, &std::format!("added{r}"))?);
+            doomed.push(read_optional(&f, &std::format!("doomed{r}"))?);
         }
         Ok((d, added, doomed))
     })();
@@ -723,6 +855,34 @@ fn commit_state_is_one_or_the_other(path: &Path) -> Verdict {
     })
 }
 
+/// Every round of the commit workload must actually have committed, or the sweep
+/// above is judging interruptions of a session that did nothing. `d` must also
+/// have grown by every round's append.
+fn every_round_committed(path: &Path) -> Result<(), String> {
+    let f = crate::reader::File::open(path)
+        .map_err(|e| std::format!("the finished file does not open: {e:?}"))?;
+    let d = f
+        .dataset("d")
+        .and_then(|d| d.read_i32())
+        .map_err(|e| std::format!("the finished `d` does not read: {e:?}"))?;
+    let want = COMMIT_BASE + CHURN * COMMIT_STEP;
+    if d.len() as i32 != want {
+        return Err(std::format!(
+            "`d` holds {} elements rather than {want}",
+            d.len()
+        ));
+    }
+    for r in 0..CHURN {
+        if f.dataset(&std::format!("added{r}")).is_err() {
+            return Err(std::format!("`added{r}` was never created"));
+        }
+        if f.dataset(&std::format!("doomed{r}")).is_ok() {
+            return Err(std::format!("`doomed{r}` was never deleted"));
+        }
+    }
+    Ok(())
+}
+
 /// One recorded churn round: grow a dataset in place, create another, delete a
 /// third, and commit. The three edits take different routes to the disk — the
 /// append patches the header in place, the create and the delete both go through
@@ -786,10 +946,12 @@ fn committing_survives_a_crash_at_every_write() {
                 drop(s);
             });
 
+            rec.assert_positioned(1, 0);
             rec.replay_every_prefix(
                 dir.path(),
                 Expect::EveryPrefixReads,
                 commit_state_is_one_or_the_other,
+                every_round_committed,
             );
         }
     }
@@ -811,8 +973,9 @@ fn committing_survives_a_crash_at_every_write() {
 /// size is issue #307).
 ///
 /// So the same workload, swept the same way, leaves *fewer* unreadable states
-/// when gathered. Both are run here in one process against one warmed base file,
-/// so the comparison is between the two modes and not between two machines.
+/// when gathered. Both are run here in one process, from base files built by the
+/// same function with the same arguments, so the comparison is between the two
+/// modes and not between two machines.
 #[test]
 fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
     use crate::image::WriteBuffering;
@@ -835,9 +998,13 @@ fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
             }
             drop(s);
         });
-        rec.replay_every_prefix(dir.path(), expect, |p| {
-            appended_prefix_is_intact(p, WARMUP, hi)
-        })
+        rec.assert_positioned(1, 0);
+        rec.replay_every_prefix(
+            dir.path(),
+            expect,
+            |p| appended_prefix_is_intact(p, WARMUP, hi),
+            |p| appended_all_the_way(p, hi),
+        )
     };
 
     // `None` keeps the session default, which is the gathering a locked
@@ -851,31 +1018,32 @@ fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
         Expect::SomeMayRefuse { min_clean: 0.5 },
     );
 
-    // Neither mode may corrupt silently — `assert_sound` has already said so for
-    // both, and that is the guarantee. This is the softer, measured claim on top
-    // of it.
+    // `gathered.loud.len() < straight.loud.len()` would read as the headline
+    // claim and assert almost nothing: `Expect::EveryPrefixReads` has already
+    // required the left side to be empty, so it degenerates to "the right side is
+    // not zero". What is worth pinning is the *right* side — that straight-
+    // through writing really does leave unreadable states here, and why.
+    //
+    // Every one of them is a torn publish point: a value written without the
+    // checksum covering it, which gathering merges into one write whenever the
+    // two share a page. Requiring *all* of them to be torn rather than merely one
+    // is what makes this a description of the mechanism rather than a floor.
     assert!(
-        gathered.loud.len() < straight.loud.len(),
-        "gathering was supposed to leave fewer unreadable crash states, but left \
-         {} of {} against {} of {}. The gathered ones:\n  {}",
-        gathered.loud.len(),
-        gathered.total,
-        straight.loud.len(),
-        straight.total,
-        gathered.loud.join("\n  ")
+        gathered.loud.is_empty(),
+        "the gathered sweep should have left no unreadable state"
     );
-    // And the reason it is fewer: the states straight-through writing leaves are
-    // torn publish points, a value written without the checksum that covers it.
     let torn = straight
         .loud
         .iter()
         .filter(|why| why.contains("ChecksumMismatch"))
         .count();
     assert!(
-        torn > 0,
-        "expected the unbuffered sweep to tear a checksum away from the value it \
-         covers, but none of its {} unreadable states says so:\n  {}",
+        torn == straight.loud.len() && torn > 0,
+        "straight-through writing should leave unreadable crash states, all of them \
+         a checksum torn from the value it covers; got {torn} torn of {} unreadable \
+         in {} prefixes:\n  {}",
         straight.loud.len(),
+        straight.total,
         straight.loud.join("\n  ")
     );
 }

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -1,0 +1,705 @@
+//! Replay every prefix of what reached the disk, and read what it left.
+//!
+//! # The defect class this exists for
+//!
+//! Since the write gathering of issue #288, the writes an operation makes
+//! between two ordering barriers are issued in **address order** rather than in
+//! the order the engine made them. In this format that is systematically the
+//! wrong way round: every publish point sits at a *lower* address than the
+//! content it names — the superblock at address 0, an object header's dataspace
+//! dimension and Extensible-Array element count near the front of the file, the
+//! chunk bytes and index blocks they name at end-of-file. So an
+//! append-then-publish pair with no barrier between them now publishes *first*.
+//!
+//! The resulting failure is the bad kind. A pointer that survives while the
+//! block it names does not is a checksummed, valid-looking address into bytes
+//! past end-of-file, and the *next* append believes the block exists and writes
+//! into nothing.
+//!
+//! What holds this together is [`FileImage::ordering_barrier`], and a missing one
+//! is invisible to every ordinary test: the operation completes, the file is
+//! correct, and only a machine that stops at the wrong instant can tell. This
+//! module is what stops the machine at every instant.
+//!
+//! # How it works
+//!
+//! [`disk_log`] records each write and each `set_len` that a session actually
+//! issued. A [`Recording`] pairs that log with the file's bytes as they were
+//! before the session opened, which makes every prefix of the log a file that
+//! could really have existed: the operations are positioned, so applying the
+//! first *k* of them to the starting bytes is exactly the disk state after *k*
+//! of them completed.
+//!
+//! Each prefix is then read back and classified:
+//!
+//! - **clean** — it reads, and returns a state a crash at that point may leave.
+//! - **loud** — it refuses to read. This is the *benign* outcome: the caller is
+//!   told, rather than handed something wrong.
+//! - **silent** — it reads without complaint and returns something else. This is
+//!   the outcome the barriers exist to prevent, and any occurrence fails.
+//!
+//! # This one can fail
+//!
+//! A crash harness that cannot fail is decoration. Two things keep this one
+//! honest. Deleting either ordering barrier in
+//! [`crate::chunk_index_inplace`] makes
+//! [`appending_survives_a_crash_at_every_write`] report the unreachable block
+//! those barriers exist to prevent. And the driver asserts a floor on how many
+//! prefixes came back **clean**, because a checker that called everything loud,
+//! or a workload that stopped doing any work, would otherwise report no silent
+//! corruption and pass.
+
+use std::path::Path;
+
+use crate::edit::{AppendBuilder, AppendTarget, MemoryStrategy, SyncPolicy, WriteEngine};
+use crate::error::Error;
+use crate::file_lock::FileLocking;
+use crate::file_space_info::FileSpaceStrategy;
+use crate::image::disk_log::{self, DiskOp};
+use crate::source::MetadataCacheConfig;
+use crate::type_builders::DatasetBuilder;
+use crate::writer::FileBuilder;
+
+/// What reading one replayed prefix made of it.
+#[derive(Debug)]
+enum Verdict {
+    /// Read back, and the state is one a crash at this point may leave.
+    Clean,
+    /// Refused to read. The benign failure: the caller is told.
+    Loud(String),
+    /// Read back without complaint, and returned something else.
+    Silent(String),
+}
+
+impl Verdict {
+    /// Classify a read. An `Error` is [`Loud`](Verdict::Loud) whatever it says —
+    /// the file declined to hand over data, which is the outcome that cannot
+    /// mislead. Only a *successful* read is judged on its contents.
+    fn of<T>(read: Result<T, Error>, judge: impl FnOnce(T) -> Result<(), String>) -> Verdict {
+        match read {
+            Err(e) => Verdict::Loud(std::format!("{e:?}")),
+            Ok(v) => match judge(v) {
+                Ok(()) => Verdict::Clean,
+                Err(why) => Verdict::Silent(why),
+            },
+        }
+    }
+}
+
+/// A session's disk operations, and the file they started from.
+struct Recording {
+    label: String,
+    /// The file's bytes before the recorded session opened it. Read before the
+    /// session exists rather than alongside it, so no platform's file locking
+    /// has an opinion about it.
+    base: Vec<u8>,
+    ops: Vec<DiskOp>,
+}
+
+impl Recording {
+    /// Record everything `work` puts on the disk. `work` is handed `path`, and
+    /// must open and close its own session inside the call: a session's teardown
+    /// writes are part of what a crash can interrupt, so they belong in the log.
+    fn of(label: &str, path: &Path, work: impl FnOnce(&Path)) -> Self {
+        let base = std::fs::read(path).expect("the starting file");
+        disk_log::start();
+        work(path);
+        let ops = disk_log::take();
+        assert!(
+            !ops.is_empty(),
+            "{label}: recorded nothing, so there is no crash point to replay"
+        );
+        Self {
+            label: label.to_string(),
+            base,
+            ops,
+        }
+    }
+
+    /// Apply one operation to an in-memory image of the file, exactly as the
+    /// filesystem would: a positioned write past end-of-file extends it, leaving
+    /// the gap reading as zeros, and `set_len` both truncates and extends.
+    fn apply(image: &mut Vec<u8>, op: &DiskOp) {
+        match op {
+            DiskOp::Write { offset, bytes } => {
+                let start = *offset as usize;
+                let end = start + bytes.len();
+                if image.len() < end {
+                    image.resize(end, 0);
+                }
+                image[start..end].copy_from_slice(bytes);
+            }
+            DiskOp::SetLen(len) => image.resize(*len as usize, 0),
+        }
+    }
+
+    /// Materialize every prefix in turn and hand each to `check`.
+    ///
+    /// `min_clean` is the floor this run must meet, as a fraction of the prefixes
+    /// replayed. It is what makes a vacuous pass fail: a workload that stopped
+    /// doing work, or a checker that called every state loud, would report no
+    /// silent corruption and otherwise sail through.
+    fn replay_every_prefix(
+        &self,
+        dir: &Path,
+        min_clean: f64,
+        check: impl Fn(&Path) -> Verdict,
+    ) -> Tally {
+        let path = dir.join(std::format!("{}.replay.h5", self.label));
+        let mut image = self.base.clone();
+        let mut tally = Tally {
+            total: self.ops.len() + 1,
+            clean: 0,
+            loud: Vec::new(),
+            silent: Vec::new(),
+        };
+
+        for k in 0..=self.ops.len() {
+            if k > 0 {
+                Self::apply(&mut image, &self.ops[k - 1]);
+            }
+            std::fs::write(&path, &image).unwrap();
+            let after = if k == 0 {
+                "the starting file".to_string()
+            } else {
+                self.ops[k - 1].describe()
+            };
+            match check(&path) {
+                Verdict::Clean => tally.clean += 1,
+                Verdict::Loud(why) => tally
+                    .loud
+                    .push(std::format!("after op {k} ({after}): {why}")),
+                Verdict::Silent(why) => tally
+                    .silent
+                    .push(std::format!("after op {k} ({after}): {why}")),
+            }
+        }
+        std::fs::remove_file(&path).ok();
+        // How wide the sweep actually was, for whoever is changing it. The
+        // assertions below are rules rather than counts — an exact figure here is
+        // a property of one platform's allocator and page size — so the numbers
+        // are printed on request instead of pinned.
+        if std::env::var_os("CRASH_REPLAY_STATS").is_some() {
+            std::eprintln!(
+                "{}: {} prefixes, {} clean, {} loud, {} silent",
+                self.label,
+                tally.total,
+                tally.clean,
+                tally.loud.len(),
+                tally.silent.len()
+            );
+        }
+        tally.assert_sound(&self.label, min_clean);
+        tally
+    }
+}
+
+/// What one sweep found, kept so a caller can compare two of them.
+struct Tally {
+    total: usize,
+    clean: usize,
+    /// Why each prefix refused to read. The benign outcome, but the reasons are
+    /// what say *which* benign outcome, and they are the first thing to read when
+    /// the floor below fails.
+    loud: Vec<String>,
+    silent: Vec<String>,
+}
+
+impl Tally {
+    /// Fail on any silent corruption, and on a run too quiet to have proved
+    /// anything.
+    fn assert_sound(&self, label: &str, min_clean: f64) {
+        assert!(
+            self.silent.is_empty(),
+            "{label}: {} of {} replayed prefixes read cleanly and returned the wrong data:\n  {}",
+            self.silent.len(),
+            self.total,
+            self.silent.join("\n  ")
+        );
+        // Without this a checker that called every state loud, or a workload that
+        // quietly stopped doing work, would report no silent corruption and pass.
+        assert!(
+            self.clean as f64 >= min_clean * self.total as f64,
+            "{label}: only {} of {} prefixes read cleanly, below the {min_clean} floor, \
+             so this run proved nothing. The {} that refused:\n  {}",
+            self.clean,
+            self.total,
+            self.loud.len(),
+            self.loud.join("\n  ")
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The append workload
+// ---------------------------------------------------------------------------
+
+/// Elements the base file already holds when recording starts.
+const WARMUP: i32 = 270;
+/// Elements each recorded round appends.
+const ROUND: i32 = 4;
+/// Recorded rounds.
+const ROUNDS: i32 = 70;
+/// Chunk length, small enough that the warm-up crosses an Extensible-Array data
+/// block *and* the super-block level above it rather than staying in the index
+/// block's inline elements.
+const CHUNK: u64 = 4;
+
+/// Build a chunked, unlimited `i32` dataset holding `0..n`, and append to it
+/// until it holds `WARMUP`. The appends are what matter: a file *written* with
+/// 270 elements has one index shape, and a file *appended* to 270 has the shape
+/// this harness is about, with the blocks allocated in the order an append
+/// allocates them.
+fn warmed_base(path: &Path, paged: bool) {
+    let mut b = FileBuilder::new();
+    if paged {
+        b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1)
+            .with_file_space_page_size(4096);
+    }
+    b.create_dataset("d")
+        .with_i32_data(&[0i32])
+        .with_shape(&[1])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[CHUNK]);
+    b.write(path).unwrap();
+
+    let mut s = WriteEngine::open_with_locking(path, FileLocking::Enabled).unwrap();
+    s.set_sync_policy(SyncPolicy::OnClose);
+    let mut n = 1i32;
+    while n < WARMUP {
+        let take = ROUND.min(WARMUP - n);
+        append(&mut s, n, take);
+        n += take;
+    }
+    drop(s);
+}
+
+/// Append `count` elements continuing the sequence at `from`.
+fn append(s: &mut WriteEngine, from: i32, count: i32) {
+    let mut b = AppendBuilder::new();
+    b.append_i32(&(from..from + count).collect::<Vec<_>>());
+    s.append_inplace_gathered(AppendTarget::Path("d"), &b, 4)
+        .unwrap();
+}
+
+/// Read `d` and require that whatever length the file claims, every element up to
+/// it is the one that belongs there, and that the length is between the one the
+/// recording started at and the one it ended at.
+///
+/// Element *i* holds the value *i*, so a stale byte, a hole read as a fill value,
+/// or a block resurrected from a previous shape all show up as a wrong value
+/// rather than having to be looked for. A file that simply has fewer elements is
+/// a crash before that append published, which is the whole point of the
+/// barriers.
+fn appended_prefix_is_intact(path: &Path, lo: i32, hi: i32) -> Verdict {
+    let read = crate::reader::File::open(path).and_then(|f| f.dataset("d")?.read_i32());
+    Verdict::of(read, |data| {
+        let n = data.len() as i32;
+        if !(lo..=hi).contains(&n) {
+            return Err(std::format!(
+                "length {n} is outside the {lo}..={hi} this crash point can produce"
+            ));
+        }
+        if let Some(i) = (0..data.len()).find(|&i| data[i] != i as i32) {
+            return Err(std::format!(
+                "element {i} is {} rather than {i} (length {n})",
+                data[i]
+            ));
+        }
+        Ok(())
+    })
+}
+
+/// Stopping an in-place append at *any* write must leave a file that either
+/// refuses to open or reads as an intact prefix of the sequence.
+///
+/// This is the test the two barriers in [`crate::chunk_index_inplace`] were added
+/// for. Deleting either one makes it fail here rather than in a later session:
+/// the index block or data block pointer is published while the block itself is
+/// still only in the buffer, so the next read follows it past end-of-file.
+#[test]
+fn appending_survives_a_crash_at_every_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("append.h5");
+    warmed_base(&path, false);
+
+    let rec = Recording::of("append", &path, |p| {
+        let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
+        s.set_sync_policy(SyncPolicy::OnClose);
+        for r in 0..ROUNDS {
+            append(&mut s, WARMUP + r * ROUND, ROUND);
+        }
+        drop(s);
+    });
+
+    let hi = WARMUP + ROUNDS * ROUND;
+    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+        appended_prefix_is_intact(p, WARMUP, hi)
+    });
+}
+
+/// The same sweep on a paged file, where the free-space managers are written and
+/// re-homed at close and the allocator rounds to a page. That teardown is a
+/// second set of low-address publish points, at the end of a session rather than
+/// of an operation.
+#[test]
+fn appending_to_a_paged_file_survives_a_crash_at_every_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("append_paged.h5");
+    warmed_base(&path, true);
+
+    let rec = Recording::of("append-paged", &path, |p| {
+        let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
+        s.set_sync_policy(SyncPolicy::OnClose);
+        for r in 0..ROUNDS {
+            append(&mut s, WARMUP + r * ROUND, ROUND);
+        }
+        s.finalize_persist().unwrap();
+        drop(s);
+    });
+
+    let hi = WARMUP + ROUNDS * ROUND;
+    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+        appended_prefix_is_intact(p, WARMUP, hi)
+    });
+}
+
+/// A file left by a crash must not merely *read* — it must be usable. Every
+/// prefix that reads cleanly is reopened, appended to, and read again, which is
+/// what catches a state that decodes but whose index no longer describes where
+/// the next element goes.
+///
+/// Fewer rounds than the sweeps above: each prefix costs a session here rather
+/// than a read.
+#[test]
+fn a_crashed_append_can_be_reopened_and_appended_to() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("recover.h5");
+    warmed_base(&path, false);
+
+    const RECOVER_ROUNDS: i32 = 8;
+    let rec = Recording::of("recover", &path, |p| {
+        let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
+        s.set_sync_policy(SyncPolicy::OnClose);
+        for r in 0..RECOVER_ROUNDS {
+            append(&mut s, WARMUP + r * ROUND, ROUND);
+        }
+        drop(s);
+    });
+
+    let hi = WARMUP + RECOVER_ROUNDS * ROUND;
+    rec.replay_every_prefix(dir.path(), 0.5, |p| {
+        // Read it first: a file that will not open is loud, and there is nothing
+        // to recover.
+        match appended_prefix_is_intact(p, WARMUP, hi) {
+            Verdict::Clean => {}
+            other => return other,
+        }
+        let before = crate::reader::File::open(p)
+            .and_then(|f| f.dataset("d")?.read_i32())
+            .expect("just read it")
+            .len() as i32;
+        let reopened = (|| -> Result<(), Error> {
+            let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled)?;
+            s.set_sync_policy(SyncPolicy::OnClose);
+            let mut b = AppendBuilder::new();
+            b.append_i32(&(before..before + ROUND).collect::<Vec<_>>());
+            s.append_inplace_gathered(AppendTarget::Path("d"), &b, 4)?;
+            drop(s);
+            Ok(())
+        })();
+        if let Err(e) = reopened {
+            return Verdict::Loud(std::format!("reopen and append: {e:?}"));
+        }
+        appended_prefix_is_intact(p, before + ROUND, before + ROUND)
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The commit workload
+// ---------------------------------------------------------------------------
+
+/// Churn rounds in one recorded commit session.
+const CHURN: i32 = 6;
+/// Elements `d` starts the commit workload with, and gains per round.
+const COMMIT_BASE: i32 = 64;
+const COMMIT_STEP: i32 = 16;
+
+/// Elements of `added{r}`, and of the `doomed{r}` it replaces. Different lengths
+/// so a round that resurrected the wrong object reads as the wrong length rather
+/// than as plausible data.
+fn added_values(r: i32) -> Vec<i32> {
+    (0..48 + r).map(|i| i * 7 + r).collect()
+}
+fn doomed_values(r: i32) -> Vec<i32> {
+    (0..32 + r).map(|i| i * 3 + r).collect()
+}
+
+/// Build the file the commit workload churns: one growable dataset, and one
+/// `doomed{r}` per round for the delete half to consume.
+fn commit_base(path: &Path, paged: bool) {
+    let mut b = FileBuilder::new();
+    if paged {
+        b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1)
+            .with_file_space_page_size(4096);
+    }
+    b.create_dataset("d")
+        .with_i32_data(&(0..COMMIT_BASE).collect::<Vec<i32>>())
+        .with_shape(&[COMMIT_BASE as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[COMMIT_STEP as u64]);
+    for r in 0..CHURN {
+        let v = doomed_values(r);
+        b.create_dataset(&std::format!("doomed{r}"))
+            .with_i32_data(&v)
+            .with_shape(&[v.len() as u64]);
+    }
+    b.write(path).unwrap();
+}
+
+/// `d`'s elements, then each round's `added{r}` and `doomed{r}` — `None` where
+/// the path is not in the file at all.
+type CommitState = (Vec<i32>, Vec<Option<Vec<i32>>>, Vec<Option<Vec<i32>>>);
+
+/// A commit publishes at its superblock write, so every object must read as
+/// either its pre-commit or its post-commit state — never a mixture, and never
+/// something that is neither.
+///
+/// Each round creates one object and deletes another, so a later round reuses
+/// space an earlier one freed (issue #261). That is what makes "reads as
+/// something that is neither" reachable rather than theoretical: a header
+/// published over a region a previous commit released is a *readable* file whose
+/// dataset returns the deleted object's bytes.
+fn commit_state_is_one_or_the_other(path: &Path) -> Verdict {
+    let read = (|| -> Result<CommitState, Error> {
+        let f = crate::reader::File::open(path)?;
+        let d = f.dataset("d")?.read_i32()?;
+        // A path that is absent is a state, not a failure; a path that is present
+        // and unreadable is a failure, and stays an `Err`.
+        let mut added = Vec::new();
+        let mut doomed = Vec::new();
+        for r in 0..CHURN {
+            added.push(match f.dataset(&std::format!("added{r}")) {
+                Ok(ds) => Some(ds.read_i32()?),
+                Err(_) => None,
+            });
+            doomed.push(match f.dataset(&std::format!("doomed{r}")) {
+                Ok(ds) => Some(ds.read_i32()?),
+                Err(_) => None,
+            });
+        }
+        Ok((d, added, doomed))
+    })();
+
+    Verdict::of(read, |(d, added, doomed)| {
+        // `d` is judged on its own. An in-place append publishes at its own
+        // phase 4, before the staged commit in the same round runs, so its length
+        // says nothing about whether that commit landed — the two are separate
+        // publish points and this must not conflate them.
+        let n = d.len() as i32;
+        if !(COMMIT_BASE..=COMMIT_BASE + CHURN * COMMIT_STEP).contains(&n) {
+            return Err(std::format!(
+                "`d` has {n} elements, outside the {COMMIT_BASE}..={} this session can produce",
+                COMMIT_BASE + CHURN * COMMIT_STEP
+            ));
+        }
+        if let Some(i) = (0..d.len()).find(|&i| d[i] != i as i32) {
+            return Err(std::format!("`d`[{i}] is {} rather than {i}", d[i]));
+        }
+
+        for r in 0..CHURN {
+            if let Some(a) = &added[r as usize] {
+                if *a != added_values(r) {
+                    return Err(std::format!(
+                        "`added{r}` is present with the wrong bytes (len {}, wanted {})",
+                        a.len(),
+                        added_values(r).len()
+                    ));
+                }
+            }
+            if let Some(x) = &doomed[r as usize] {
+                if *x != doomed_values(r) {
+                    return Err(std::format!(
+                        "`doomed{r}` is still present but its bytes have changed"
+                    ));
+                }
+            }
+            // The create and the delete are staged together and published by one
+            // superblock write, so they land together or not at all. This is the
+            // commit's atomicity, and the one thing a torn commit cannot satisfy.
+            if added[r as usize].is_some() != doomed[r as usize].is_none() {
+                return Err(std::format!(
+                    "round {r} is half-committed: added{r} {}, doomed{r} {}",
+                    if added[r as usize].is_some() {
+                        "present"
+                    } else {
+                        "absent"
+                    },
+                    if doomed[r as usize].is_some() {
+                        "present"
+                    } else {
+                        "absent"
+                    }
+                ));
+            }
+        }
+        // Rounds commit in order, so the committed ones are a prefix. A later
+        // round present while an earlier one is missing means a commit was
+        // published over a state it did not build on.
+        let committed: Vec<bool> = (0..CHURN).map(|r| added[r as usize].is_some()).collect();
+        if let Some(r) = (1..CHURN as usize).find(|&r| committed[r] && !committed[r - 1]) {
+            return Err(std::format!(
+                "round {r} committed but round {} did not, though {r} came second",
+                r - 1
+            ));
+        }
+        Ok(())
+    })
+}
+
+/// One recorded churn round: grow a dataset in place, create another, delete a
+/// third, and commit. The three edits take different routes to the disk — the
+/// append patches the header in place, the create and the delete both go through
+/// the staged commit — so one recording covers all of them.
+fn churn(s: &mut WriteEngine, r: i32) {
+    let from = COMMIT_BASE + r * COMMIT_STEP;
+    let mut b = AppendBuilder::new();
+    b.append_i32(&(from..from + COMMIT_STEP).collect::<Vec<_>>());
+    s.append_inplace_gathered(AppendTarget::Path("d"), &b, 4)
+        .unwrap();
+
+    let v = added_values(r);
+    let mut db = DatasetBuilder::new(&std::format!("added{r}"));
+    db.with_i32_data(&v).with_shape(&[v.len() as u64]);
+    s.stage_created_dataset(&std::format!("/added{r}"), db)
+        .unwrap();
+    s.delete(&std::format!("doomed{r}")).unwrap();
+    s.commit().unwrap();
+
+    // The workload has to have done all three, or the sweep is judging a session
+    // that quietly did nothing.
+    assert!(!s.has_staged_edits(), "the commit left edits staged");
+}
+
+/// The staged-commit path, swept over both backings and both file-space
+/// strategies. A commit's publish point is the superblock at address zero, which
+/// is the lowest address in the file and therefore the first thing gathering
+/// wants to issue.
+#[test]
+fn committing_survives_a_crash_at_every_write() {
+    for paged in [false, true] {
+        for bounded in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("commit.h5");
+            commit_base(&path, paged);
+            let label = std::format!(
+                "commit-{}-{}",
+                if paged { "paged" } else { "plain" },
+                if bounded { "bounded" } else { "mirrored" }
+            );
+
+            let rec = Recording::of(&label, &path, |p| {
+                let mut s = if bounded {
+                    WriteEngine::open_rw_with_strategy(
+                        p,
+                        MetadataCacheConfig::new(64 * 1024),
+                        FileLocking::Enabled,
+                        MemoryStrategy::Bounded,
+                    )
+                    .unwrap()
+                } else {
+                    WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap()
+                };
+                s.set_sync_policy(SyncPolicy::OnClose);
+                for r in 0..CHURN {
+                    churn(&mut s, r);
+                }
+                if paged {
+                    s.finalize_persist().unwrap();
+                }
+                drop(s);
+            });
+
+            rec.replay_every_prefix(dir.path(), 0.5, commit_state_is_one_or_the_other);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gathering against not gathering
+// ---------------------------------------------------------------------------
+
+/// Gathering makes each individual write *larger*, which sounds like it should
+/// widen the window a crash can land in. It does the opposite, and this measures
+/// by how much.
+///
+/// The reason is that the format's publish points are frequently a pair of
+/// writes — a value, and the checksum covering it — and a pair is atomic only
+/// when both land together. Straight-through writing never joins them.
+/// Gathering joins them whenever they share a page, which is every object header
+/// this crate's own writer produces below about 3.9 KB (the residue above that
+/// size is issue #307).
+///
+/// So the same workload, swept the same way, leaves *fewer* unreadable states
+/// when gathered. Both are run here in one process against one warmed base file,
+/// so the comparison is between the two modes and not between two machines.
+#[test]
+fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
+    use crate::image::WriteBuffering;
+
+    const ROUNDS_EACH: i32 = 20;
+    let hi = WARMUP + ROUNDS_EACH * ROUND;
+
+    let sweep = |label: &str, mode: Option<WriteBuffering>| -> Tally {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("compare.h5");
+        warmed_base(&path, false);
+        let rec = Recording::of(label, &path, |p| {
+            let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
+            s.set_sync_policy(SyncPolicy::OnClose);
+            if let Some(mode) = mode {
+                s.set_write_buffering(mode).unwrap();
+            }
+            for r in 0..ROUNDS_EACH {
+                append(&mut s, WARMUP + r * ROUND, ROUND);
+            }
+            drop(s);
+        });
+        rec.replay_every_prefix(dir.path(), 0.5, |p| {
+            appended_prefix_is_intact(p, WARMUP, hi)
+        })
+    };
+
+    // `None` keeps the session default, which is the gathering a locked
+    // read-write session takes.
+    let gathered = sweep("compare-gathered", None);
+    let straight = sweep("compare-unbuffered", Some(WriteBuffering::Unbuffered));
+
+    // Neither mode may corrupt silently — `assert_sound` has already said so for
+    // both, and that is the guarantee. This is the softer, measured claim on top
+    // of it.
+    assert!(
+        gathered.loud.len() < straight.loud.len(),
+        "gathering was supposed to leave fewer unreadable crash states, but left \
+         {} of {} against {} of {}. The gathered ones:\n  {}",
+        gathered.loud.len(),
+        gathered.total,
+        straight.loud.len(),
+        straight.total,
+        gathered.loud.join("\n  ")
+    );
+    // And the reason it is fewer: the states straight-through writing leaves are
+    // torn publish points, a value written without the checksum that covers it.
+    let torn = straight
+        .loud
+        .iter()
+        .filter(|why| why.contains("ChecksumMismatch"))
+        .count();
+    assert!(
+        torn > 0,
+        "expected the unbuffered sweep to tear a checksum away from the value it \
+         covers, but none of its {} unreadable states says so:\n  {}",
+        straight.loud.len(),
+        straight.loud.join("\n  ")
+    );
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -2299,6 +2299,18 @@ impl WriteEngine {
         self.sync_policy
     }
 
+    /// Override how long this session's writes may sit in memory.
+    ///
+    /// The image is private to this module, and the only caller outside it is
+    /// [`crate::crash_replay`], which sweeps the *same* workload under gathering
+    /// and without it. That comparison is the answer to the obvious worry about
+    /// making writes larger, so it is worth an accessor; nothing outside a test
+    /// build has one.
+    #[cfg(test)]
+    pub(crate) fn set_write_buffering(&mut self, mode: WriteBuffering) -> Result<(), Error> {
+        self.image.set_write_buffering(mode)
+    }
+
     /// The durability barrier a write path calls for, data and metadata both —
     /// issued unless this session's [`SyncPolicy`] leaves the `fsync` cadence to
     /// the application.

--- a/src/image.rs
+++ b/src/image.rs
@@ -124,6 +124,72 @@ impl WriteBuffering {
     }
 }
 
+/// A recording of everything that reached the operating system, so a test can
+/// replay a prefix of it and see what a crash at that instant would have left.
+///
+/// The log is per thread and off by default, which is what lets it live under
+/// every write in the crate: an inactive thread pays one thread-local read per
+/// issued write, and the lib tests that are not recording are unaffected by the
+/// ones that are, however the harness schedules them.
+///
+/// It records only operations that *succeeded*. A write that returned an error
+/// may have put any prefix of its bytes on the disk, and this cannot know which,
+/// so a failed write is not a point this can replay. That is the boundary
+/// between this and a fault injector: this models the machine stopping between
+/// two completed operations, which is the case the crate's ordering barriers are
+/// written against.
+#[cfg(test)]
+pub(crate) mod disk_log {
+    use std::cell::RefCell;
+
+    /// One completed operation against the file, in the order it was issued.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub(crate) enum DiskOp {
+        /// `bytes` landed at `offset`. Positioned, so replaying it is exact
+        /// wherever the file's length happens to be.
+        Write { offset: u64, bytes: Vec<u8> },
+        /// The file was resized to this length, discarding anything past it.
+        SetLen(u64),
+    }
+
+    impl DiskOp {
+        /// A short label for a failure message: what it touched, not its bytes.
+        pub(crate) fn describe(&self) -> String {
+            match self {
+                DiskOp::Write { offset, bytes } => {
+                    std::format!("write {offset}..{}", offset + bytes.len() as u64)
+                }
+                DiskOp::SetLen(len) => std::format!("set_len {len}"),
+            }
+        }
+    }
+
+    thread_local! {
+        /// `None` when this thread is not recording, which is every thread that
+        /// has not asked to be.
+        static LOG: RefCell<Option<Vec<DiskOp>>> = const { RefCell::new(None) };
+    }
+
+    /// Begin recording on this thread, discarding any previous log.
+    pub(crate) fn start() {
+        LOG.with(|l| *l.borrow_mut() = Some(Vec::new()));
+    }
+
+    /// Stop recording and return what was recorded.
+    pub(crate) fn take() -> Vec<DiskOp> {
+        LOG.with(|l| l.borrow_mut().take()).unwrap_or_default()
+    }
+
+    /// Note one completed operation, if this thread is recording.
+    pub(crate) fn record(op: DiskOp) {
+        LOG.with(|l| {
+            if let Some(log) = l.borrow_mut().as_mut() {
+                log.push(op);
+            }
+        });
+    }
+}
+
 /// The file bytes a mutating session works on.
 ///
 /// Implementors keep the image and the file on disk consistent, and are free to
@@ -682,6 +748,11 @@ impl BufferedWrites {
         self.handle.write_all(bytes).map_err(Error::Io)?;
         #[cfg(test)]
         self.issued_order.push((offset, bytes.len() as u64));
+        #[cfg(test)]
+        disk_log::record(disk_log::DiskOp::Write {
+            offset,
+            bytes: bytes.to_vec(),
+        });
         self.on_disk_len = self.on_disk_len.max(offset + bytes.len() as u64);
         Ok(())
     }
@@ -704,6 +775,8 @@ impl BufferedWrites {
         // is an error path in both orders; this one is the half that cannot lose
         // a write.
         self.handle.set_len(len).map_err(Error::Io)?;
+        #[cfg(test)]
+        disk_log::record(disk_log::DiskOp::SetLen(len));
         self.discard_from(len);
         self.on_disk_len = len;
         self.flush()?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -143,7 +143,6 @@ pub(crate) mod disk_log {
     use std::cell::RefCell;
 
     /// One completed operation against the file, in the order it was issued.
-    #[derive(Clone, Debug, PartialEq, Eq)]
     pub(crate) enum DiskOp {
         /// `bytes` landed at `offset`. Positioned, so replaying it is exact
         /// wherever the file's length happens to be.
@@ -180,11 +179,29 @@ pub(crate) mod disk_log {
         LOG.with(|l| l.borrow_mut().take()).unwrap_or_default()
     }
 
-    /// Note one completed operation, if this thread is recording.
-    pub(crate) fn record(op: DiskOp) {
+    /// Note one completed write, if this thread is recording.
+    ///
+    /// Takes the bytes by reference and copies them *inside* the recording
+    /// check, which is the difference between the claim above and a lie: built
+    /// as a `DiskOp` at the call site, every write in the whole `cfg(test)`
+    /// build would pay a heap allocation and a copy to hand it to a thread that
+    /// is not recording and will drop it.
+    pub(crate) fn record_write(offset: u64, bytes: &[u8]) {
         LOG.with(|l| {
             if let Some(log) = l.borrow_mut().as_mut() {
-                log.push(op);
+                log.push(DiskOp::Write {
+                    offset,
+                    bytes: bytes.to_vec(),
+                });
+            }
+        });
+    }
+
+    /// Note one completed resize, if this thread is recording.
+    pub(crate) fn record_set_len(len: u64) {
+        LOG.with(|l| {
+            if let Some(log) = l.borrow_mut().as_mut() {
+                log.push(DiskOp::SetLen(len));
             }
         });
     }
@@ -749,10 +766,7 @@ impl BufferedWrites {
         #[cfg(test)]
         self.issued_order.push((offset, bytes.len() as u64));
         #[cfg(test)]
-        disk_log::record(disk_log::DiskOp::Write {
-            offset,
-            bytes: bytes.to_vec(),
-        });
+        disk_log::record_write(offset, bytes);
         self.on_disk_len = self.on_disk_len.max(offset + bytes.len() as u64);
         Ok(())
     }
@@ -776,7 +790,7 @@ impl BufferedWrites {
         // a write.
         self.handle.set_len(len).map_err(Error::Io)?;
         #[cfg(test)]
-        disk_log::record(disk_log::DiskOp::SetLen(len));
+        disk_log::record_set_len(len);
         self.discard_from(len);
         self.on_disk_len = len;
         self.flush()?;
@@ -2118,8 +2132,9 @@ mod tests {
             self.0
         }
 
+        /// A value in `0..n`. Every caller passes a positive `n`.
         fn upto(&mut self, n: u64) -> u64 {
-            if n == 0 { 0 } else { self.next() % n }
+            self.next() % n
         }
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -2102,4 +2102,196 @@ mod tests {
         only.read_at(0, &mut buf).unwrap();
         assert_eq!(&buf, b"aZcdefgh");
     }
+
+    // -----------------------------------------------------------------------
+    // Differential tests against a byte model
+    // -----------------------------------------------------------------------
+
+    /// A deterministic xorshift, so a failure is reproducible from its seed.
+    struct Xorshift(u64);
+
+    impl Xorshift {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0
+        }
+
+        fn upto(&mut self, n: u64) -> u64 {
+            if n == 0 { 0 } else { self.next() % n }
+        }
+    }
+
+    /// The gathering configurations the sweep below runs under.
+    ///
+    /// The narrow ones are the point. `max_bytes` of 96 against writes of up to
+    /// 80 bytes means a single write frequently exceeds the budget on its own,
+    /// which is the bypass in [`BufferedWrites::write_at`] that flushes and
+    /// issues rather than absorbing; a configuration generous enough never to
+    /// reach it leaves that path untested. The 1-byte page is the degenerate end,
+    /// where two writes merge only by touching.
+    const MIXES: [WriteBuffering; 5] = [
+        WriteBuffering::Unbuffered,
+        WriteBuffering::Operation {
+            page_size: 1,
+            max_bytes: 4096,
+        },
+        WriteBuffering::Operation {
+            page_size: 16,
+            max_bytes: 96,
+        },
+        WriteBuffering::Operation {
+            page_size: 64,
+            max_bytes: 4096,
+        },
+        WriteBuffering::Operation {
+            page_size: 4096,
+            max_bytes: 1 << 20,
+        },
+    ];
+
+    /// Random sequences of every primitive, against a `Vec<u8>` that models what
+    /// the file should hold, on both backings and under every gathering
+    /// configuration.
+    ///
+    /// Two claims, checked after *every* operation rather than at the end, so a
+    /// failure names the operation that caused it rather than the one that
+    /// happened to notice:
+    ///
+    /// - reads through the image equal the model, which for the handle backing
+    ///   means the overlay reassembles pending runs, clean bytes and the gaps
+    ///   between them correctly;
+    /// - at every ordering barrier the *file* equals the model too. The
+    ///   gathering may delay a write, but never lose or reorder one across the
+    ///   point that exists to bound it.
+    ///
+    /// Sequences rather than cases, because what this shape catches is about
+    /// *history*: a run left touching its neighbour, a merge that copies the old
+    /// bytes over the new, a trailing-run scan off by one at a page boundary.
+    /// None of those is reachable by a single write.
+    ///
+    /// The in-loop barrier is [`FileImage::ordering_barrier`] and not
+    /// `sync_data`, which would prove exactly the same thing about the model and
+    /// cost twenty times the wall clock: measured here at **12.4s against 0.6s**,
+    /// the difference being 2,400 `fsync`s that flush what the barrier had
+    /// already flushed. One `sync_data` per configuration covers the flush-then-
+    /// fsync ordering, and `assert_in_sync` closes each one.
+    #[test]
+    fn a_random_operation_sequence_matches_a_byte_model() {
+        let dir = tempfile::tempdir().unwrap();
+        for backing in BACKINGS {
+            for (mi, mode) in MIXES.into_iter().enumerate() {
+                for seed in 0..8u64 {
+                    let initial: Vec<u8> = (0..300u32).map(|i| (i % 251) as u8).collect();
+                    let sub = dir.path().join(std::format!("m{mi}s{seed}"));
+                    std::fs::create_dir_all(&sub).unwrap();
+                    let (path, mut img) = gathering(&sub, &initial, backing, mode);
+                    let mut model = initial.clone();
+                    let mut rng = Xorshift(0x9E37_79B9_7F4A_7C15 ^ (seed << 32) ^ (mi as u64));
+                    let at =
+                        |step: u32| std::format!("{backing:?} mode {mi} seed {seed} step {step}");
+                    // One step per configuration takes the durable barrier
+                    // instead of the ordering one.
+                    let fsync_at = rng.upto(300) as u32;
+
+                    for step in 0..300u32 {
+                        match rng.upto(10) {
+                            0..=3 if !model.is_empty() => {
+                                let len = 1 + rng.upto(48).min(model.len() as u64 - 1);
+                                let offset = rng.upto(model.len() as u64 - len + 1);
+                                let bytes = vec![(rng.next() & 0xff) as u8; len as usize];
+                                img.write_at(offset, &bytes).unwrap();
+                                model[offset as usize..(offset + len) as usize]
+                                    .copy_from_slice(&bytes);
+                            }
+                            4..=6 => {
+                                let bytes =
+                                    vec![(rng.next() & 0xff) as u8; 1 + rng.upto(80) as usize];
+                                let placed = img.append(&bytes).unwrap();
+                                assert_eq!(placed, model.len() as u64, "{}: append", at(step));
+                                model.extend_from_slice(&bytes);
+                            }
+                            7 => {
+                                let keep = rng.upto(model.len() as u64 + 1);
+                                img.truncate(keep).unwrap();
+                                model.truncate(keep as usize);
+                            }
+                            _ => {
+                                if step == fsync_at {
+                                    img.sync_data().unwrap();
+                                } else {
+                                    img.ordering_barrier().unwrap();
+                                }
+                                assert_eq!(
+                                    std::fs::read(&path).unwrap(),
+                                    model,
+                                    "{}: a barrier left the file disagreeing with the model",
+                                    at(step)
+                                );
+                            }
+                        }
+                        assert_eq!(img.len(), model.len() as u64, "{}: length", at(step));
+                        assert_eq!(bytes(img.as_ref()), model, "{}: reads", at(step));
+                        if let Some(slice) = img.as_slice() {
+                            assert_eq!(slice, &model[..], "{}: slice", at(step));
+                        }
+                    }
+
+                    img.sync_all().unwrap();
+                    assert_in_sync(&path, img.as_ref(), backing);
+                }
+            }
+        }
+    }
+
+    /// Every window of a buffer holding several pending runs reads back as the
+    /// model says, including the ones that make the overlay's bookkeeping
+    /// awkward: a window entirely inside one run, one spanning a gap, one
+    /// covering two runs that meet on the same byte, a single byte, an empty
+    /// window, and one reaching past the file's real end into bytes that exist
+    /// only as a pending append.
+    ///
+    /// Exhaustive rather than sampled. There are only a few thousand windows, and
+    /// choosing a handful by hand is how an off-by-one at exactly one boundary
+    /// survives.
+    #[test]
+    fn every_window_over_a_buffered_image_matches_the_model() {
+        let dir = tempfile::tempdir().unwrap();
+        for backing in BACKINGS {
+            let initial: Vec<u8> = (0..200u32).map(|i| (i % 251) as u8).collect();
+            let (_, mut img) = gathering(dir.path(), &initial, backing, GATHERED);
+            let mut model = initial.clone();
+
+            // Runs chosen for their relationships rather than their contents: two
+            // that meet exactly at byte 40, one alone in the middle of a page, a
+            // single byte, and one that exists only as a pending append past the
+            // file's real end.
+            let put = |img: &mut Box<dyn FileImage>, model: &mut Vec<u8>, at: u64, b: &[u8]| {
+                img.write_at(at, b).unwrap();
+                model[at as usize..at as usize + b.len()].copy_from_slice(b);
+            };
+            put(&mut img, &mut model, 30, &[0xA1; 10]);
+            put(&mut img, &mut model, 40, &[0xA2; 10]);
+            put(&mut img, &mut model, 90, &[0xB0; 1]);
+            put(&mut img, &mut model, 130, &[0xC0; 20]);
+            let tail = [0xD0u8; 30];
+            img.append(&tail).unwrap();
+            model.extend_from_slice(&tail);
+
+            let len = model.len() as u64;
+            assert_eq!(img.len(), len);
+            for start in 0..=len {
+                for end in start..=len {
+                    let mut buf = vec![0u8; (end - start) as usize];
+                    img.read_at(start, &mut buf).unwrap();
+                    assert_eq!(
+                        buf,
+                        &model[start as usize..end as usize],
+                        "{backing:?}: window {start}..{end}"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,8 @@ pub(crate) mod nosync;
 pub(crate) mod appender;
 #[cfg(feature = "std")]
 pub(crate) mod chunk_index_inplace;
+#[cfg(all(test, feature = "std"))]
+mod crash_replay;
 #[cfg(feature = "std")]
 pub(crate) mod edit;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Closes #309.

Records every write and every `set_len` that reaches the operating system, replays each **prefix** of that log onto the file's starting bytes, and reads the result back — classifying it **clean**, **loud** (refused to read) or **silent** (read fine, wrong data or unusable file). Four sweeps: in-place append on a paged file, recovery, the staged commit across both backings and both space strategies, and gathered against unbuffered. Plus the two `BufferedWrites` model tests the issue asked for.

All test-only (`cfg(test)`), no API, feature or behavior change, so no changelog entry.

## It covers a barrier nothing in the crate did

`apply_ea_append` has five ordering barriers. Deleting three of them left all 893 library tests green, including the one separating the appended chunk bytes from the superblock's end-of-file field — content at end-of-file, then a patch to address 0, which is exactly the shape #309 was filed about, inside the function whose own doc calls it "the crash-safety heart of the engine."

A read cannot see it. The recorded end-of-file is the allocator's cursor, not something a read follows, so the file decodes perfectly and returns every correct value; the next session then allocates from a cursor past the real end. `recorded_eof_covers_the_file` checks it, and three sweeps now fail when that barrier goes.

Measured coverage, by deleting each barrier in turn and running the library:

| barrier | caught |
| --- | --- |
| before a fresh data-block pointer | yes (also by the pre-existing structural test) |
| before a fresh super-block pointer | yes, only by the recovery sweep |
| phase 1, chunk bytes → superblock end-of-file | **new in this PR** |
| phase 1, end-of-file → index writes | no |
| phase 2 → 3 | no |
| phase 3, header count → dimension | yes |

The two uncovered ones are explained rather than left blank. Deleting the first changes **nothing that reaches the disk** — the recorded write order is byte-identical, because the order it enforces is what address-sorting already produces. The second reorders two metadata writes, but the state between them is a published element count with a stale block, indistinguishable from a normal in-progress append to a reader bounded by the dataspace dimension. Both stay load-bearing for what this does not model: `fsync` durability under `SyncPolicy::Always`, and SWMR visibility, which is defined on the header counts rather than the dimension. Everything outside this engine — dense attribute heaps, Fixed-Array and v2 B-tree indexes, filtered and variable-length writes, group link tables — is still uncovered, and that is the remaining half of #309.

## The first draft was decoration, and that shaped the design

It swept five hundred prefixes, called every one clean, and did so with **both** barriers it was written for deleted. Three causes, each now a demand the code makes rather than a value that happens to be right:

- **The window was in the wrong place.** Extensible-Array blocks are allocated by chunk count — a data block roughly every sixteen, a super block at 244 and then not until 500 — so the obvious 270-round window crosses no super-block allocation. `alloc_probe` counts what a recorded window really allocated.
- **The file was too small.** At one element per chunk the index block and end-of-file land in one gathered write, and one write is atomic: the inversion still happens and no prefix can observe it. `assert_positioned` requires the file to span several gather pages — and immediately caught the commit sweep sitting under a single page.
- **The rule was too weak.** A prefix that refused to read was counted benign. An in-place append leaves the previous value readable throughout, so readable-to-unreadable is the defect.

Two more guards of the same kind: replaying the whole log must reproduce the file the session actually left (so a write escaping the recorder cannot pass unnoticed), and the last prefix must meet the workload's finished state (so a session that quietly stopped working cannot).

## Measured, not asserted

Gathering makes each write larger, which sounds like it should widen the crash window. Same workload, one process: gathered leaves **0 of 109** prefixes unreadable, straight-through leaves **20 of 168**, and every one of those twenty is a checksum torn from the value it covers. #309 recorded that from a review transcript; it is now a test.

## Review

Two agents reviewed this in isolated worktrees, and both found real problems. Applied from them: the uncovered barrier above; a headline assertion that was vacuous by construction (the left side had already been asserted empty); a commit checker that read any error as "the object is absent", accepting a link published to a half-written header; a `RECOVER_APPEND` left in elements when chunks widened to 64, silently shrinking the recovery append to two thirds of a chunk; a recorder copying every written buffer in every test whether recording or not, contradicting its own doc; and one sweep deleted after the reviewer proved it a strict subset of another.

Worth stating plainly: both allocation barriers were **already** caught by the structural test that shipped with #306. This harness is confirmatory there. Its new coverage is the phase-1 barrier.

## Verification

`cargo nextest run --all-features` (2,210 passed) and `cargo test --all-features --doc` (45 passed); clippy clean at `--all-features`, release build clean, allocation baseline unmoved. The harness runs in about 2s.
