### PR TITLE
Publish a checksummed structure as one write (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - A read-write session issues far fewer writes for the same file: one per dirty page, gathered across the many small writes a commit or in-place append makes. A session of 32 chunk appends issued 160 writes where it once made 448, with no change to the bytes on disk or to what a failed write leaves behind, and the SWMR writer gathers nothing ([#288](https://github.com/stephenberry/hdf5-pure/issues/288)).
 - The typed whole-dataset readers (`Dataset::read_f64` and its eight siblings) decode a row window at a time instead of the whole dataset at once, so peak memory is the values they return plus about a mebibyte rather than twice the dataset: an 8 MiB `f64` dataset peaked at 16.8 MB and now peaks at 10.1 MB ([#289](https://github.com/stephenberry/hdf5-pure/issues/289)).
+- An in-place append that is not write-gathered — an unbuffered session and every SWMR append — costs 8 writes where it cost 12, since each checksummed structure is now published in a single write ([#307](https://github.com/stephenberry/hdf5-pure/issues/307)).
 - A row window takes only its own chunks out of the cached chunk index rather than the whole index, so reading a dataset window by window costs a constant per chunk instead of one allocation per chunk of the dataset per window ([#289](https://github.com/stephenberry/hdf5-pure/issues/289)).
 
 ### Fixed
 
+- Appending in place to a dataset whose Extensible Array header names an element wider than the fields it holds is refused rather than panicking. Only a corrupt or crafted file reaches it; the whole-file read path already refused the same header ([#307](https://github.com/stephenberry/hdf5-pure/issues/307)).
+- An interrupted in-place append no longer leaves a dataset unreadable. A value and the checksum covering it are published in one write, where they were two that only became atomic when they shared a file-space page — so a dataset whose object header exceeded one page, such as a compound type with many members or a few string attributes, tore on every append ([#307](https://github.com/stephenberry/hdf5-pure/issues/307)).
 - A paged file (`FileSpaceStrategy::Page`) stops growing under delete-and-recreate churn: the free-space managers a commit rewrites are placed in free space rather than in a fresh page whose remainder nothing recorded, which cost a page per commit. A wholly free page can also be reopened for the other page type, so space a delete released is no longer stranded for the kind of data that released it ([#286](https://github.com/stephenberry/hdf5-pure/issues/286)).
 
 ## [0.39.0] - 2026-08-17

--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -189,30 +189,6 @@ pub(crate) trait Store: Source {
     /// reader observes (issue #288).
     fn sync(&mut self) -> Result<(), Error>;
 
-    /// Write an offset-sized address at `offset`.
-    fn write_addr_at(&mut self, offset: u64, addr: u64) -> Result<(), Error> {
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "the 4-byte arm is taken only when this file's offset_size is 4 bytes"
-        )]
-        match self.offset_size() {
-            4 => self.write_at(offset, &(addr as u32).to_le_bytes()),
-            _ => self.write_at(offset, &addr.to_le_bytes()),
-        }
-    }
-
-    /// Write a length-sized value at `offset`.
-    fn write_length_at(&mut self, offset: u64, val: u64) -> Result<(), Error> {
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "the 4-byte arm is taken only when this file's length_size is 4 bytes"
-        )]
-        match self.length_size() {
-            4 => self.write_at(offset, &(val as u32).to_le_bytes()),
-            _ => self.write_at(offset, &val.to_le_bytes()),
-        }
-    }
-
     /// Read an offset-sized address at `offset`.
     fn read_addr_at(&self, offset: u64) -> Result<u64, Error> {
         let mut buf = [0u8; 8];
@@ -221,14 +197,64 @@ pub(crate) trait Store: Source {
         Ok(u64::from_le_bytes(buf))
     }
 
-    /// Recompute the Jenkins checksum over `[start, cks_off)` and store it at
-    /// `cks_off`.
-    fn rechecksum_range(&mut self, start: u64, cks_off: u64) -> Result<(), Error> {
-        let bytes = self.read_exact_at(start, (cks_off - start).to_usize()?)?;
-        let cks = jenkins_lookup3(&bytes);
-        self.write_at(cks_off, &cks.to_le_bytes())
+    /// Change a checksummed structure and publish it as **one** write.
+    ///
+    /// Reads `[start, cks_off + 4)`, places `value` at `at` inside the body
+    /// before `cks_off`, recomputes the Jenkins checksum over it, and writes back
+    /// everything from `at` through the checksum field.
+    ///
+    /// The single write is the point, not an optimization. A value written
+    /// separately from the checksum covering it is atomic only where the
+    /// gatherer joins the two, which it does only when both land in the same
+    /// page; a structure wider than one page publishes the new value under the
+    /// *old* checksum, and a failure between the two writes leaves it unreadable
+    /// (issue #307). Every other publish point in this crate — the superblock
+    /// repoint above all — is already a single write, and this is what brings
+    /// these into line rather than a new mechanism.
+    ///
+    /// One write is not crash-atomicity: a `pwrite` wide enough may still tear at
+    /// a device boundary. It is the same window the superblock publish has always
+    /// had, which is this crate's bar.
+    ///
+    /// The write starts at `at` rather than at `start`, so patching an element
+    /// near the end of a large block does not rewrite the block. The *read* still
+    /// covers the whole body, because the checksum does. Measured over six
+    /// appends at the same number of writes: 3,066 bytes against 5,952 unpaged
+    /// and 31,266 against 34,158 on a paged file with a 4 KiB header — the index
+    /// block, not the object header, is where most of that sits.
+    /// `crash_replay::a_publish_writes_from_the_byte_it_changed` is what holds
+    /// it, since the write count is the same either way.
+    fn publish_checksummed(
+        &mut self,
+        start: u64,
+        cks_off: u64,
+        at: u64,
+        value: &[u8],
+    ) -> Result<(), Error> {
+        let span = (cks_off + 4 - start).to_usize()?;
+        // A range outside the structure is refused rather than asserted: every
+        // offset here is derived from geometry parsed out of the file, so a
+        // malformed one is untrusted input, not a broken invariant. Checked
+        // before the read, so a refusal costs nothing.
+        let from = at
+            .checked_sub(start)
+            .and_then(|d| d.to_usize().ok())
+            .filter(|&f| f.checked_add(value.len()).is_some_and(|e| e <= span - 4))
+            .ok_or(Error::AppendUnsupported(
+                "a checksummed structure was patched outside itself",
+            ))?;
+        let mut bytes = self.read_exact_at(start, span)?;
+        bytes[from..from + value.len()].copy_from_slice(value);
+        let (body, cks_field) = bytes.split_at_mut(span - 4);
+        cks_field.copy_from_slice(&jenkins_lookup3(body).to_le_bytes());
+        self.write_at(at, &bytes[from..])
     }
 }
+
+/// Widest Extensible-Array element this engine can be asked to place: an
+/// 8-byte address, a stored size no wider than the `u64` that fills it, and a
+/// 4-byte filter mask. `locate` refuses any file naming more.
+const MAX_EA_ELEM: usize = 8 + 8 + 4;
 
 /// Absolute file offsets of the object-header messages a caller may need to
 /// parse after locating a dataset.
@@ -433,10 +459,13 @@ impl Located {
             ));
         }
         // A filtered element is `address + compressed_size + filter_mask`, so its
-        // stored width must leave room for at least a one-byte size field. Reject
-        // a corrupt header whose element_size is too small before the width
-        // arithmetic (`ea_elem_size - offset_size - 4`) would underflow.
-        if ea_header.client_id == 1 && (ea_header.element_size as usize) < os as usize + 5 {
+        // stored width must leave room for a size field of one to eight bytes.
+        // Reject a corrupt header outside that range before the width arithmetic
+        // (`ea_elem_size - offset_size - 4`) underflows below it, or names above
+        // it a size field wider than the `u64` that fills it. The whole-file read
+        // path refuses both ends in `read_variable_length`.
+        let elem_w = ea_header.element_size as usize;
+        if ea_header.client_id == 1 && !(os as usize + 5..=os as usize + 12).contains(&elem_w) {
             return Err(unsupported(
                 "malformed filtered extensible-array element width",
             ));
@@ -482,31 +511,6 @@ impl Located {
                 fill: fill_msg.map(|m| (m.msg_type, m.data_off, m.size)),
             },
         })
-    }
-
-    /// Write element record `rec` at byte offset `off` (a slot known to exist).
-    /// For an unfiltered array only the address is written; for a filtered array
-    /// the full `address + compressed_size + filter_mask` record is written,
-    /// refusing a stored size that does not fit the array's fixed element width.
-    fn write_element_at<F: Store>(
-        &self,
-        file: &mut F,
-        off: u64,
-        rec: ElemRecord,
-    ) -> Result<(), Error> {
-        if self.client_id == 0 {
-            return file.write_addr_at(off, rec.addr);
-        }
-        let os = file.offset_size() as usize;
-        let csz = self.ea_elem_size - os - 4;
-        if csz < 8 && rec.stored_size >= (1u64 << (8 * csz)) {
-            return Err(Error::AppendUnsupported(
-                "recompressed chunk size exceeds the dataset's extensible-array element width",
-            ));
-        }
-        file.write_addr_at(off, rec.addr)?;
-        file.write_at(off + os as u64, &rec.stored_size.to_le_bytes()[..csz])?;
-        file.write_at(off + (os + csz) as u64, &rec.filter_mask.to_le_bytes())
     }
 
     /// Read the element record stored at byte offset `off`.
@@ -663,9 +667,9 @@ impl Located {
         if e < idx {
             let ib_prefix = (4 + 1 + 1 + os) as u64;
             let slot_off = self.index_block_addr + ib_prefix + e * elem_size;
-            self.write_element_at(file, slot_off, rec)?;
-            self.rechecksum_index_block(file)?;
-            return Ok(());
+            let mut buf = [0u8; MAX_EA_ELEM];
+            let n = self.element_bytes(&mut buf, os, rec)?;
+            return self.publish_index_block(file, slot_off, &buf[..n]);
         }
 
         let region = locate_data_block(&self.geom, idx, e);
@@ -710,16 +714,19 @@ impl Located {
             // its parent pointer is not, so they need a barrier between them or
             // an address-ordered flush names a block that is not there yet.
             file.sync()?;
-            file.write_addr_at(dblk_ptr_off, new_addr)?;
             match region.parent {
-                Parent::IndexDirect { .. } => self.rechecksum_index_block(file)?,
-                Parent::Super { .. } => self.rechecksum_super_block(
+                Parent::IndexDirect { .. } => {
+                    self.publish_index_block(file, dblk_ptr_off, &new_addr.to_le_bytes()[..os])?;
+                }
+                Parent::Super { .. } => self.publish_super_block(
                     file,
                     sblk_addr.unwrap(),
                     ndblks,
                     dblk_nelmts,
                     self.page_nelmts,
                     blk_off,
+                    dblk_ptr_off,
+                    &new_addr.to_le_bytes()[..os],
                 )?,
             }
             new_addr
@@ -730,9 +737,10 @@ impl Located {
         if !is_paged {
             let db_prefix = (4 + 1 + 1 + os + blk_off) as u64;
             let elem_off = dblk_addr + db_prefix + slot * elem_size;
-            self.write_element_at(file, elem_off, rec)?;
+            let mut buf = [0u8; MAX_EA_ELEM];
+            let n = self.element_bytes(&mut buf, os, rec)?;
             let cks_off = dblk_addr + db_prefix + dblk_nelmts * elem_size;
-            file.rechecksum_range(dblk_addr, cks_off)?;
+            file.publish_checksummed(dblk_addr, cks_off, elem_off, &buf[..n])?;
         } else {
             let page_nelmts = self.page_nelmts;
             let header_size = (4 + 1 + 1 + os + blk_off + 4) as u64;
@@ -740,23 +748,27 @@ impl Located {
             let slot_in_page = slot % page_nelmts;
             let page_bytes = page_nelmts * elem_size + 4;
             let page_off = dblk_addr + header_size + page * page_bytes;
-            self.write_element_at(file, page_off + slot_in_page * elem_size, rec)?;
+            let elem_off = page_off + slot_in_page * elem_size;
+            let mut buf = [0u8; MAX_EA_ELEM];
+            let n = self.element_bytes(&mut buf, os, rec)?;
             let page_cks_off = page_off + page_nelmts * elem_size;
-            file.rechecksum_range(page_off, page_cks_off)?;
+            file.publish_checksummed(page_off, page_cks_off, elem_off, &buf[..n])?;
 
             if slot_in_page == 0 {
                 let sblk_addr = sblk_addr.unwrap();
                 let npages = dblk_nelmts / self.page_nelmts;
                 if let Parent::Super { dblk_local, .. } = region.parent {
                     let global_page = dblk_local as u64 * npages + page;
-                    self.set_sb_page_bit(file, sblk_addr, blk_off, global_page)?;
-                    self.rechecksum_super_block(
+                    let (byte, set) = sb_page_bit(file, sblk_addr, blk_off, global_page)?;
+                    self.publish_super_block(
                         file,
                         sblk_addr,
                         ndblks,
                         dblk_nelmts,
                         self.page_nelmts,
                         blk_off,
+                        byte,
+                        &[set],
                     )?;
                 }
             }
@@ -820,8 +832,7 @@ impl Located {
             + ib_prefix
             + self.idx_blk_elmts * self.ea_elem_size as u64
             + ((ndblk_addrs + sblk_j) * os) as u64;
-        file.write_addr_at(slot_off, new_addr)?;
-        self.rechecksum_index_block(file)?;
+        self.publish_index_block(file, slot_off, &new_addr.to_le_bytes()[..os])?;
         Ok(new_addr)
     }
 
@@ -881,26 +892,56 @@ impl Located {
         file.append_raw(&buf)
     }
 
-    /// Set page `global_page`'s bit in a super block's page-init bitmap
-    /// (MSB-first).
-    fn set_sb_page_bit<F: Store>(
-        &self,
-        file: &mut F,
-        sblk_addr: u64,
-        blk_off: usize,
-        global_page: u64,
-    ) -> Result<(), Error> {
-        let os = file.offset_size() as usize;
-        let bitmap_start = sblk_addr + (4 + 1 + 1 + os + blk_off) as u64;
-        let byte = bitmap_start + global_page / 8;
-        let mask = 0x80u8 >> (global_page % 8);
-        let mut v = [0u8; 1];
-        file.read_at(byte, &mut v)?;
-        file.write_at(byte, &[v[0] | mask])
+    /// Width of a filtered element's stored-size field, checked against the record
+    /// about to go in it. Zero for an unfiltered array, whose element is a bare
+    /// address.
+    fn element_size_width(&self, os: usize, rec: ElemRecord) -> Result<usize, Error> {
+        if self.client_id == 0 {
+            return Ok(0);
+        }
+        // `element_size` is one byte out of the array header, so a file can name
+        // a width the three fields do not fit in. `locate` is where that byte is
+        // refused; by here it is in `os + 5 ..= os + 12`.
+        debug_assert!(
+            (os + 5..=os + 12).contains(&self.ea_elem_size),
+            "locate admitted an element width of {} for a {os}-byte address",
+            self.ea_elem_size
+        );
+        let csz = self.ea_elem_size - os - 4;
+        if csz < 8 && rec.stored_size >= (1u64 << (8 * csz)) {
+            return Err(Error::AppendUnsupported(
+                "recompressed chunk size exceeds the dataset's extensible-array element width",
+            ));
+        }
+        Ok(csz)
     }
 
-    /// Recompute the index block checksum from the located dataset metadata.
-    fn rechecksum_index_block<F: Store>(&self, file: &mut F) -> Result<(), Error> {
+    /// Lay one Extensible-Array element into `buf`, returning the bytes used.
+    /// Its fields are contiguous, so this is one span rather than the three
+    /// writes it replaced.
+    fn element_bytes(
+        &self,
+        buf: &mut [u8; MAX_EA_ELEM],
+        os: usize,
+        rec: ElemRecord,
+    ) -> Result<usize, Error> {
+        buf[..os].copy_from_slice(&rec.addr.to_le_bytes()[..os]);
+        if self.client_id == 0 {
+            return Ok(os);
+        }
+        let csz = self.element_size_width(os, rec)?;
+        buf[os..os + csz].copy_from_slice(&rec.stored_size.to_le_bytes()[..csz]);
+        buf[os + csz..os + csz + 4].copy_from_slice(&rec.filter_mask.to_le_bytes());
+        Ok(os + csz + 4)
+    }
+
+    /// Change the index block and republish it, checksum included, as one write.
+    fn publish_index_block<F: Store>(
+        &self,
+        file: &mut F,
+        at: u64,
+        value: &[u8],
+    ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
         let ib_prefix = (4 + 1 + 1 + os) as u64;
         let ndblk_addrs = self.geom.direct_dblk_nelmts.len();
@@ -909,10 +950,11 @@ impl Located {
             + ib_prefix
             + self.idx_blk_elmts * self.ea_elem_size as u64
             + ((ndblk_addrs + nsblk_addrs) * os) as u64;
-        file.rechecksum_range(self.index_block_addr, cks_off)
+        file.publish_checksummed(self.index_block_addr, cks_off, at, value)
     }
 
-    fn rechecksum_super_block<F: Store>(
+    /// Change a super block and republish it, checksum included, as one write.
+    fn publish_super_block<F: Store>(
         &self,
         file: &mut F,
         sblk_addr: u64,
@@ -920,12 +962,14 @@ impl Located {
         dblk_nelmts: u64,
         page_nelmts: u64,
         blk_off: usize,
+        at: u64,
+        value: &[u8],
     ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
         let prefix = (4 + 1 + 1 + os + blk_off) as u64;
         let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)? as u64;
         let cks_off = sblk_addr + prefix + bitmap + ndblks * os as u64;
-        file.rechecksum_range(sblk_addr, cks_off)
+        file.publish_checksummed(sblk_addr, cks_off, at, value)
     }
 
     /// Patch the six EA header statistics and recompute the header checksum.
@@ -970,11 +1014,10 @@ impl Located {
             stat_block[at..at + ls].copy_from_slice(&value.to_le_bytes()[..ls]);
             at += ls;
         }
-        file.write_at(ea_addr + 12, &stat_block[..at])?;
         let aehd_size =
             ExtensibleArrayHeader::serialized_size(file.offset_size(), file.length_size()) as u64;
         let cks_off = ea_addr + aehd_size - 4;
-        file.rechecksum_range(ea_addr, cks_off)
+        file.publish_checksummed(ea_addr, cks_off, ea_addr + 12, &stat_block[..at])
     }
 
     /// Publish `new_dim` as the dataspace axis-0 dimension (the commit point) and
@@ -984,8 +1027,13 @@ impl Located {
         file: &mut F,
         new_dim: u64,
     ) -> Result<(), Error> {
-        file.write_length_at(self.dim0_off, new_dim)?;
-        file.rechecksum_range(self.ohdr_chunk_start, self.ohdr_chunk_msg_end)
+        let ls = file.length_size() as usize;
+        file.publish_checksummed(
+            self.ohdr_chunk_start,
+            self.ohdr_chunk_msg_end,
+            self.dim0_off,
+            &new_dim.to_le_bytes()[..ls],
+        )
     }
 }
 
@@ -1203,6 +1251,26 @@ pub(crate) fn apply_ea_append<F: Store>(
     loc.current_dim = plan.new_dim;
     loc.num_chunks = plan.new_num_chunks;
     Ok(())
+}
+
+/// The byte of a super block's page-init bitmap that holds page `global_page`'s
+/// bit (MSB-first), and that byte with the bit set.
+///
+/// A read-modify-write, so it reads the byte and hands the *result* back for the
+/// publish to place: one field of one byte is not a value the caller can name on
+/// its own.
+fn sb_page_bit<F: Store>(
+    file: &F,
+    sblk_addr: u64,
+    blk_off: usize,
+    global_page: u64,
+) -> Result<(u64, u8), Error> {
+    let os = file.offset_size() as usize;
+    let bitmap_start = sblk_addr + (4 + 1 + 1 + os + blk_off) as u64;
+    let byte = bitmap_start + global_page / 8;
+    let mut v = [0u8; 1];
+    file.read_at(byte, &mut v)?;
+    Ok((byte, v[0] | (0x80u8 >> (global_page % 8))))
 }
 
 /// Byte size of a super block's page-init bitmap (0 when its data blocks are not
@@ -1829,5 +1897,51 @@ mod tests {
         let got = file.dataset("d").unwrap().read_i32().unwrap();
         let expected: Vec<i32> = (0..n + 7 + 13).collect();
         assert_eq!(got, expected);
+    }
+
+    /// A filtered element's stored-size field is at most the eight bytes of the
+    /// `u64` that fills it, and a file naming a wider one is refused at `locate`
+    /// rather than panicking when the element is laid out.
+    ///
+    /// The refusal is two-sided for a reason: the low side alone was what this
+    /// guard checked, and the high side reached
+    /// `rec.stored_size.to_le_bytes()[..csz]` with `csz` up to 243. Reproduced
+    /// through the safe public API before the upper bound landed — an
+    /// `element_size` of 30 on an 8-byte-address file panicked with "range end
+    /// index 18 out of range for slice of length 8".
+    #[test]
+    fn an_element_width_wider_than_a_u64_is_refused_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wide_elem.h5");
+        let mut b = crate::writer::FileBuilder::new();
+        b.create_dataset("d")
+            .with_i32_data(&(0..4096).collect::<Vec<_>>())
+            .with_shape(&[4096])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[4])
+            .with_deflate(1);
+        b.write(&path).unwrap();
+
+        // Widen the array header's element_size (byte 6 of `EAHD`) past the three
+        // fields it names. A filtered element is address + stored size + filter
+        // mask, so on an 8-byte-address file the format's own ceiling is 20.
+        let mut bytes = std::fs::read(&path).unwrap();
+        let at = bytes
+            .windows(4)
+            .position(|w| w == b"EAHD")
+            .expect("a filtered unlimited dataset is indexed by an extensible array");
+        assert_eq!(bytes[at + 6], 14, "the writer's own element width moved");
+        bytes[at + 6] = 30;
+        std::fs::write(&path, &bytes).unwrap();
+
+        let f = crate::reader::File::open_rw(&path).unwrap();
+        let err = f
+            .dataset("d")
+            .and_then(|mut d| d.append(&[1i32, 2, 3, 4]))
+            .expect_err("an element width wider than a u64 must be refused");
+        assert!(
+            std::format!("{err:?}").contains("element width"),
+            "the refusal should name the element width, but said {err:?}"
+        );
     }
 }

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -48,7 +48,7 @@
 //!    merged into a single write, which is atomic — see [`CHUNK`] and the same
 //!    method's second condition.
 //! 3. A prefix that refused to read was counted as benign — see
-//!    [`Expect::EveryPrefixReads`].
+//!    [`Tally::assert_sound`].
 //!
 //! Each of those is now something a future change trips over rather than
 //! silently loses. [`Recording::replay_every_prefix`] adds two more of the same
@@ -70,6 +70,13 @@
 //! | `apply_ea_append` phase 1, end-of-file → index writes | **no** |
 //! | `apply_ea_append` phase 2 → 3 | **no** |
 //! | `apply_ea_append` phase 3, header count → dimension | yes |
+//!
+//! A barrier is not the only way this class of defect arrives. A *publish* is
+//! the other: a value written apart from the checksum covering it is two writes
+//! with a crash point between them, no matter how the barriers fall. That was
+//! issue #307, and it is why the sweeps here are run at more than one header
+//! width — see [`warmed_base_padded`] and
+//! [`a_publish_costs_the_same_whether_or_not_it_spans_a_page`].
 //!
 //! The two uncovered ones are not gaps in the sweep, and it is worth knowing why
 //! before adding a workload to chase them. Deleting the first changes **nothing
@@ -107,9 +114,8 @@ enum Verdict {
     /// Read back, and the state is one a crash at this point may leave.
     Clean,
     /// Refused to read. Benign in general — the caller is told rather than
-    /// misled — but see [`Expect::EveryPrefixReads`]: the operations swept here
-    /// promise that the previous value stays readable, so for most of them this
-    /// is a failure too.
+    /// misled — but see [`Tally::assert_sound`]: the operations swept here
+    /// promise that the previous value stays readable, so this is a failure too.
     Loud(String),
     /// Read back without complaint, and returned something else.
     Silent(String),
@@ -220,6 +226,36 @@ impl Recording {
         );
     }
 
+    /// Demand that a *publish* write in this recording crosses a gather-page
+    /// boundary — that the structure being published really is wider than the
+    /// page whose merging hid issue #307.
+    ///
+    /// A publish is a patch near the front of the file, so this looks for a write
+    /// that begins inside the first gather page and reaches past it. Any write is
+    /// not enough: an append at end-of-file crosses page boundaries all day and
+    /// says nothing about the header's width.
+    ///
+    /// Without this, a padded fixture is one object-header layout change away
+    /// from sitting wholly inside a page, where every publish is atomic for free
+    /// and the sweep passes while proving nothing. The padding was measured, and
+    /// a measured constant is exactly the kind that drifts.
+    fn assert_publishes_across_a_gather_page(&self) {
+        let crossing = self.ops.iter().any(|op| match *op {
+            DiskOp::Write { offset, ref bytes } => {
+                offset < GATHER_PAGE && offset + bytes.len() as u64 > GATHER_PAGE
+            }
+            DiskOp::SetLen(_) => false,
+        });
+        assert!(
+            crossing,
+            "{}: no write starts inside the first {GATHER_PAGE}-byte gather page and \
+             reaches past it, so the header this sweep publishes into fits in one page \
+             and every publish is atomic whatever the engine does. The fixture needs a \
+             wider object header.",
+            self.label
+        );
+    }
+
     /// Apply one operation to an in-memory image of the file, exactly as the
     /// filesystem would: a positioned write past end-of-file extends it, leaving
     /// the gap reading as zeros, and `set_len` both truncates and extends.
@@ -249,7 +285,6 @@ impl Recording {
     fn replay_every_prefix(
         &self,
         dir: &Path,
-        expect: Expect,
         check: impl Fn(&Path) -> Verdict,
         finished: impl Fn(&Path) -> Result<(), String>,
     ) -> Tally {
@@ -319,45 +354,9 @@ impl Recording {
                 tally.silent.len()
             );
         }
-        tally.assert_sound(&self.label, expect);
+        tally.assert_sound(&self.label);
         tally
     }
-}
-
-/// What a sweep demands of the states it finds.
-#[derive(Clone, Copy)]
-enum Expect {
-    /// **No prefix may fail to read.**
-    ///
-    /// This is the real promise of an operation the crate calls crash-atomic, and
-    /// it is stronger than "never silently wrong". The dataset was readable before
-    /// the operation began; a crash part-way through must leave it readable, as
-    /// the old value. A prefix that refuses to read is a window in which the file
-    /// went from readable to not, which is a regression a caller experiences even
-    /// though nothing is silently wrong.
-    ///
-    /// It is what the ordering barriers buy, though not all of them through this
-    /// rule. Removing the barrier before a fresh *data* block breaks it directly:
-    /// the pointer is issued before the block, and the prefix between them reads
-    /// `UnexpectedEof`, naming an address past end-of-file. The *super* block's
-    /// barrier produces no unreadable prefix at all and is caught by the silent
-    /// rule instead, in
-    /// [`a_crashed_append_can_be_reopened_and_appended_to`].
-    ///
-    /// The rule holds for an object header whose chunk 0 fits inside one gather
-    /// page. Above that, a value and the checksum covering it can land in
-    /// different pages and a crash between them tears the header — issue #307,
-    /// which predates the gathering and is not what these sweeps are about.
-    EveryPrefixReads,
-    /// Some prefixes may refuse to read; at least this fraction must not. For the
-    /// baseline sweeps, run in a mode that deliberately does *not* provide the
-    /// rule above.
-    ///
-    /// The floor is loose on purpose and is not the interesting assertion — the
-    /// unbuffered sweep measures 88% clean against a 0.5 floor. What it bounds
-    /// that nothing else does is the baseline mode itself degenerating to
-    /// all-loud, which the gathered half cannot see.
-    SomeMayRefuse { min_clean: f64 },
 }
 
 /// What one sweep found, kept so a caller can compare two of them.
@@ -372,9 +371,26 @@ struct Tally {
 }
 
 impl Tally {
-    /// Fail on any silent corruption, and on a run that did not meet what its
-    /// sweep expects of it.
-    fn assert_sound(&self, label: &str, expect: Expect) {
+    /// The two rules every sweep is held to.
+    ///
+    /// **Nothing silent.** A prefix that reads cleanly and hands back the wrong
+    /// data is the outcome with no signal at all, and no crash point may produce
+    /// one.
+    ///
+    /// **Nothing unreadable.** Stronger, and the real promise of an operation the
+    /// crate calls crash-atomic: the dataset was readable before the operation
+    /// began, so a crash part-way through must leave it readable, as the old
+    /// value. A prefix that refuses to read is a window in which the file went
+    /// from readable to not — a regression a caller experiences even though
+    /// nothing is silently wrong.
+    ///
+    /// The second is what the ordering barriers buy, though not all of them
+    /// through this rule. Removing the barrier before a fresh *data* block breaks
+    /// it directly: the pointer is issued before the block, and the prefix between
+    /// them reads `UnexpectedEof`, naming an address past end-of-file. The *super*
+    /// block's barrier produces no unreadable prefix at all and is caught by the
+    /// first rule instead, in [`a_crashed_append_can_be_reopened_and_appended_to`].
+    fn assert_sound(&self, label: &str) {
         assert!(
             self.silent.is_empty(),
             "{label}: {} of {} replayed prefixes read cleanly and returned the wrong data:\n  {}",
@@ -382,29 +398,15 @@ impl Tally {
             self.total,
             self.silent.join("\n  ")
         );
-        match expect {
-            Expect::EveryPrefixReads => assert!(
-                self.loud.is_empty(),
-                "{label}: {} of {} replayed prefixes refused to read, though every one \
-                 of them is a crash during an operation that leaves the previous value \
-                 in place and readable:\n  {}",
-                self.loud.len(),
-                self.total,
-                self.loud.join("\n  ")
-            ),
-            // Without a floor, a checker that called every state loud, or a
-            // workload that quietly stopped doing work, would report no silent
-            // corruption and pass.
-            Expect::SomeMayRefuse { min_clean } => assert!(
-                self.clean as f64 >= min_clean * self.total as f64,
-                "{label}: only {} of {} prefixes read cleanly, below the {min_clean} floor, \
-                 so this run proved nothing. The {} that refused:\n  {}",
-                self.clean,
-                self.total,
-                self.loud.len(),
-                self.loud.join("\n  ")
-            ),
-        }
+        assert!(
+            self.loud.is_empty(),
+            "{label}: {} of {} replayed prefixes refused to read, though every one \
+             of them is a crash during an operation that leaves the previous value \
+             in place and readable:\n  {}",
+            self.loud.len(),
+            self.total,
+            self.loud.join("\n  ")
+        );
     }
 }
 
@@ -457,16 +459,37 @@ const WARMUP: i32 = WARMUP_ROUNDS * ROUND;
 /// this harness is about, with the blocks allocated in the order an append
 /// allocates them.
 fn warmed_base(path: &Path, paged: bool) {
+    warmed_base_padded(path, paged, 0);
+}
+
+/// [`warmed_base`], with `pad` bytes of attribute in the dataset's object header.
+///
+/// Padding is a positioning tool, not decoration. `patch_dimension` writes the
+/// dataspace dimension near the front of chunk 0 and the chunk checksum at its
+/// end; the two are joined into one write only when they share a gather page. A
+/// header under [`GATHER_PAGE`] therefore publishes atomically for free and no
+/// prefix can fall between them, which is why the unpadded sweeps below cannot
+/// see issue #307. Above it they split, and the crash state between them is a
+/// new value under its old checksum.
+fn warmed_base_padded(path: &Path, paged: bool, pad: usize) {
     let mut b = FileBuilder::new();
     if paged {
         b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1)
             .with_file_space_page_size(4096);
     }
-    b.create_dataset("d")
-        .with_i32_data(&[0i32])
-        .with_shape(&[1])
-        .with_maxshape(&[u64::MAX])
-        .with_chunks(&[CHUNK]);
+    {
+        let d = b.create_dataset("d");
+        d.with_i32_data(&[0i32])
+            .with_shape(&[1])
+            .with_maxshape(&[u64::MAX])
+            .with_chunks(&[CHUNK]);
+        if pad > 0 {
+            d.set_attr(
+                "pad",
+                crate::type_builders::AttrValue::AsciiString("x".repeat(pad)),
+            );
+        }
+    }
     b.write(path).unwrap();
 
     let mut s = WriteEngine::open_with_locking(path, FileLocking::Enabled).unwrap();
@@ -596,7 +619,6 @@ fn appending_to_a_paged_file_survives_a_crash_at_every_write() {
     let hi = WARMUP + ROUNDS * ROUND;
     rec.replay_every_prefix(
         dir.path(),
-        Expect::EveryPrefixReads,
         |p| appended_prefix_is_intact(p, WARMUP, hi),
         |p| appended_all_the_way(p, hi),
     );
@@ -642,7 +664,6 @@ fn a_crashed_append_can_be_reopened_and_appended_to() {
     let hi = WARMUP + RECOVER_ROUNDS * ROUND;
     rec.replay_every_prefix(
         dir.path(),
-        Expect::EveryPrefixReads,
         |p| {
         // Read it first: a file that will not open is loud, and there is nothing
         // to recover.
@@ -949,7 +970,6 @@ fn committing_survives_a_crash_at_every_write() {
             rec.assert_positioned(1, 0);
             rec.replay_every_prefix(
                 dir.path(),
-                Expect::EveryPrefixReads,
                 commit_state_is_one_or_the_other,
                 every_round_committed,
             );
@@ -961,29 +981,27 @@ fn committing_survives_a_crash_at_every_write() {
 // Gathering against not gathering
 // ---------------------------------------------------------------------------
 
-/// Gathering makes each individual write *larger*, which sounds like it should
-/// widen the window a crash can land in. It does the opposite, and this measures
-/// by how much.
+/// The guarantee does not depend on the write gathering.
 ///
-/// The reason is that the format's publish points are frequently a pair of
-/// writes — a value, and the checksum covering it — and a pair is atomic only
-/// when both land together. Straight-through writing never joins them.
-/// Gathering joins them whenever they share a page, which is every object header
-/// this crate's own writer produces below about 3.9 KB (the residue above that
-/// size is issue #307).
+/// It once did. A publish was a value write followed by a checksum write, joined
+/// into one only where the gatherer found the two in the same page, so an
+/// unbuffered session left this sweep 20 unreadable states in 168 — every one a
+/// checksum torn from the value it covered. Since issue #307 the engine publishes
+/// a checksummed structure as one write itself, and both configurations sweep
+/// clean.
 ///
-/// So the same workload, swept the same way, leaves *fewer* unreadable states
-/// when gathered. Both are run here in one process, from base files built by the
-/// same function with the same arguments, so the comparison is between the two
-/// modes and not between two machines.
+/// Running both is what keeps it that way. A publish point that regressed to two
+/// writes would pass the gathered sweep for as long as the two shared a page, and
+/// fail here at once — which is exactly how #307 hid: it was reachable only on a
+/// dataset whose object header outgrew one page.
 #[test]
-fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
+fn crash_states_read_back_with_and_without_write_gathering() {
     use crate::image::WriteBuffering;
 
     const ROUNDS_EACH: i32 = 20;
     let hi = WARMUP + ROUNDS_EACH * ROUND;
 
-    let sweep = |label: &str, mode: Option<WriteBuffering>, expect: Expect| -> Tally {
+    let sweep = |label: &str, mode: Option<WriteBuffering>| -> Tally {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("compare.h5");
         warmed_base(&path, false);
@@ -1001,49 +1019,225 @@ fn gathering_leaves_fewer_unreadable_crash_states_than_not_gathering() {
         rec.assert_positioned(1, 0);
         rec.replay_every_prefix(
             dir.path(),
-            expect,
             |p| appended_prefix_is_intact(p, WARMUP, hi),
             |p| appended_all_the_way(p, hi),
         )
     };
 
     // `None` keeps the session default, which is the gathering a locked
-    // read-write session takes, and it is held to the full rule.
-    let gathered = sweep("compare-gathered", None, Expect::EveryPrefixReads);
-    // The unbuffered half is *not*, and that is the finding: straight-through
-    // writing does not provide it.
-    let straight = sweep(
-        "compare-unbuffered",
-        Some(WriteBuffering::Unbuffered),
-        Expect::SomeMayRefuse { min_clean: 0.5 },
-    );
+    // read-write session takes.
+    let gathered = sweep("compare-gathered", None);
+    let straight = sweep("compare-unbuffered", Some(WriteBuffering::Unbuffered));
 
-    // `gathered.loud.len() < straight.loud.len()` would read as the headline
-    // claim and assert almost nothing: `Expect::EveryPrefixReads` has already
-    // required the left side to be empty, so it degenerates to "the right side is
-    // not zero". What is worth pinning is the *right* side — that straight-
-    // through writing really does leave unreadable states here, and why.
-    //
-    // Every one of them is a torn publish point: a value written without the
-    // checksum covering it, which gathering merges into one write whenever the
-    // two share a page. Requiring *all* of them to be torn rather than merely one
-    // is what makes this a description of the mechanism rather than a floor.
+    // Both sweeps assert the rule inside `replay_every_prefix`, so what is left
+    // to pin here is that the second one is the *finer* of the two. Unbuffered
+    // writing issues each patch separately, so it stops the machine at instants
+    // the gathered sweep never reaches; if the two ever swept the same number of
+    // prefixes, the mode would be being ignored and this whole comparison would
+    // be one sweep run twice.
     assert!(
-        gathered.loud.is_empty(),
-        "the gathered sweep should have left no unreadable state"
-    );
-    let torn = straight
-        .loud
-        .iter()
-        .filter(|why| why.contains("ChecksumMismatch"))
-        .count();
-    assert!(
-        torn == straight.loud.len() && torn > 0,
-        "straight-through writing should leave unreadable crash states, all of them \
-         a checksum torn from the value it covers; got {torn} torn of {} unreadable \
-         in {} prefixes:\n  {}",
-        straight.loud.len(),
+        straight.total > gathered.total,
+        "the unbuffered sweep should stop at more instants than the gathered one, \
+         but swept {} prefixes against {}",
         straight.total,
-        straight.loud.join("\n  ")
+        gathered.total
+    );
+}
+
+/// Bytes of attribute padding that push the dataspace dimension and its
+/// object-header checksum into different gather pages. Measured threshold on the
+/// default 4096-byte page: 3800 still joins, 3900 splits.
+const HEADER_PAD: usize = 4096;
+
+/// An in-place append publishes its new dimension and the checksum covering it.
+/// A header chunk wider than one gather page splits those into two writes, and a
+/// crash between them leaves the file **unreadable** — the new value under the
+/// old checksum (issue #307).
+#[test]
+fn publishing_a_dimension_in_a_wide_header_survives_a_crash_at_every_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wide_header.h5");
+    warmed_base_padded(&path, true, HEADER_PAD);
+
+    let rec = Recording::of("wide-header", &path, |p| {
+        let mut s = WriteEngine::open_with_locking(p, FileLocking::Enabled).unwrap();
+        s.set_sync_policy(SyncPolicy::OnClose);
+        for r in 0..ROUNDS {
+            append(&mut s, WARMUP + r * ROUND, ROUND);
+        }
+        s.finalize_persist().unwrap();
+        drop(s);
+    });
+
+    rec.assert_publishes_across_a_gather_page();
+    let hi = WARMUP + ROUNDS * ROUND;
+    rec.replay_every_prefix(
+        dir.path(),
+        |p| appended_prefix_is_intact(p, WARMUP, hi),
+        |p| appended_all_the_way(p, hi),
+    );
+}
+
+/// Publishing costs the same number of writes whether or not the structure being
+/// published spans a gather page — which is the defect of issue #307 stated as a
+/// rule rather than as one of its consequences.
+///
+/// The sweep above catches the consequence, and only for the object header: it
+/// reads the file back, so it sees a torn publish only where a reader follows the
+/// torn field. This sees the split itself, so it covers every publish an append
+/// makes — the array header's statistics, an index block's element and its data-
+/// block pointers, a data block's element — without needing a workload that
+/// reads each one.
+///
+/// Measured before the fix: 5 writes at 3800 bytes of padding against 6 at 3900,
+/// the extra one being the checksum stranded in the next page. Both buffering
+/// modes are checked, because the unbuffered one splits every publish regardless
+/// of where the pages fall.
+#[test]
+fn a_publish_costs_the_same_whether_or_not_it_spans_a_page() {
+    use crate::image::WriteBuffering;
+
+    for mode in [None, Some(WriteBuffering::Unbuffered)] {
+        let mut counts = Vec::new();
+        // A sweep rather than the two sides of the measured threshold: picking
+        // the boundary by hand is how a fixture ends up just short of the case it
+        // was written for, and stepping across it costs milliseconds.
+        for pad in [0usize, 2000, 3800, 3900, 4200, 8300] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("pad.h5");
+            warmed_base_padded(&path, true, pad);
+
+            let mut s = WriteEngine::open_with_locking(&path, FileLocking::Enabled).unwrap();
+            s.set_sync_policy(SyncPolicy::OnClose);
+            if let Some(mode) = mode {
+                s.set_write_buffering(mode).unwrap();
+            }
+            let before = s.issued_write_order().len();
+            append(&mut s, WARMUP, ROUND);
+            let made = s.issued_write_order()[before..].to_vec();
+            drop(s);
+            // Whether this padding put the publish across a page: a write that
+            // starts inside the first gather page and reaches past it.
+            let wide = made
+                .iter()
+                .any(|&(off, len)| off < GATHER_PAGE && off + len > GATHER_PAGE);
+            counts.push((pad, made.len(), wide));
+        }
+        // The comparison is only meaningful across the boundary. All-narrow or
+        // all-wide passes with the defect present — measured — so the sweep has to
+        // say it landed on both sides rather than be trusted to.
+        assert!(
+            counts.iter().any(|&(_, _, w)| w) && counts.iter().any(|&(_, _, w)| !w),
+            "{mode:?}: every padding fell on the same side of the {GATHER_PAGE}-byte \
+             page, so this comparison holds nothing: {counts:?}"
+        );
+        let (_, first, _) = counts[0];
+        assert!(
+            counts.iter().all(|&(_, n, _)| n == first),
+            "{mode:?}: one append must cost the same writes at every header width, \
+             but cost {counts:?}"
+        );
+    }
+}
+
+/// A publish being one write leaves the gathering almost nothing to merge inside
+/// an append, so the two buffering modes must cost writes that differ by a
+/// **constant** rather than by a per-append one.
+///
+/// This is the half [`a_publish_costs_the_same_whether_or_not_it_spans_a_page`]
+/// cannot see. That one compares header widths, so a publish that splits at
+/// *every* width — the array header's six statistics and its checksum are fifty
+/// bytes apart and share a page whatever the dataset looks like — changes both
+/// sides of its comparison and passes. Splitting shows up here instead, as a gap
+/// that grows with the number of appends.
+///
+/// Measured: 5 writes against 5 for one append and 40 against 40 for eight,
+/// unpaged; one more on the unbuffered side throughout when the file is paged,
+/// from padding a page at the raw/metadata boundary. Before issue #307 the same
+/// eight appends were 40 against 64, and the excess was three writes per append.
+#[test]
+fn buffering_saves_a_constant_number_of_writes_not_one_per_append() {
+    use crate::image::WriteBuffering;
+
+    /// Room for the handful of writes gathering merges that are *not* per-append:
+    /// a paged file's boundary padding, and the joins around an allocation round.
+    const SLACK: usize = 4;
+
+    for paged in [false, true] {
+        let cost = |rounds: i32, unbuffered: bool| -> usize {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("gap.h5");
+            warmed_base(&path, paged);
+            let mut s = WriteEngine::open_with_locking(&path, FileLocking::Enabled).unwrap();
+            s.set_sync_policy(SyncPolicy::OnClose);
+            if unbuffered {
+                s.set_write_buffering(WriteBuffering::Unbuffered).unwrap();
+            }
+            for i in 0..rounds {
+                append(&mut s, WARMUP + i * ROUND, ROUND);
+            }
+            let n = s.issued_write_order().len();
+            drop(s);
+            n
+        };
+
+        // Two append counts an order of magnitude apart: a per-append excess
+        // grows between them and a constant one does not, which is the whole
+        // distinction. Comparing one count against an absolute would pin a number
+        // that every unrelated change to the append path moves.
+        let (few, many) = (2i32, 24i32);
+        let gap = |rounds: i32| cost(rounds, true).saturating_sub(cost(rounds, false));
+        let (gap_few, gap_many) = (gap(few), gap(many));
+        // A floor as well as a ceiling. If `set_write_buffering` silently did
+        // nothing, both sides would be the same session and every gap would be
+        // zero, which satisfies the rule below without measuring anything.
+        assert!(
+            gap_many > 0,
+            "paged={paged}: unbuffered writing must cost more writes than gathered \
+             over {many} appends, but the two were equal — the buffering mode is \
+             not taking effect and nothing below is being measured"
+        );
+        assert!(
+            gap_many <= gap_few + SLACK,
+            "paged={paged}: buffering must save a constant number of writes, but saved \
+             {gap_few} over {few} appends and {gap_many} over {many} — a gap that grows \
+             with the appends is a publish that is still two writes"
+        );
+    }
+}
+
+/// A publish writes back from the byte it changed, not from the front of the
+/// structure that byte sits in.
+///
+/// Two appends into the same Extensible-Array data block touch a slot one
+/// element further along each time, so the second writes strictly fewer bytes
+/// than the first. Rewriting the whole block would make the two equal — which is
+/// what this test exists to fail on, since the write *count* is the same either
+/// way and every other check here counts writes.
+///
+/// Measured on this fixture: 531 bytes then 523, against 992 and 992 when the
+/// publish starts at the structure instead. The block, not the object header, is
+/// where the saving is: 534 bytes of index block against the 116 the first of
+/// these appends actually changes.
+#[test]
+fn a_publish_writes_from_the_byte_it_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("from.h5");
+    warmed_base(&path, false);
+
+    let mut s = WriteEngine::open_with_locking(&path, FileLocking::Enabled).unwrap();
+    s.set_sync_policy(SyncPolicy::OnClose);
+    let written = |s: &WriteEngine| -> u64 { s.issued_write_order().iter().map(|&(_, n)| n).sum() };
+    let mut cost = Vec::new();
+    for i in 0..2 {
+        let before = written(&s);
+        append(&mut s, WARMUP + i * ROUND, ROUND);
+        cost.push(written(&s) - before);
+    }
+    drop(s);
+    assert!(
+        cost[1] < cost[0],
+        "an append that touches a later slot of the same block must write fewer \
+         bytes than one that touches an earlier slot, but the two cost {cost:?}"
     );
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -2311,6 +2311,15 @@ impl WriteEngine {
         self.image.set_write_buffering(mode)
     }
 
+    /// Every write this session issued, as `(offset, length)` in the order it
+    /// went out. Same reasoning as [`set_write_buffering`](Self::set_write_buffering):
+    /// the image is private, and a test that asks whether a publish left the
+    /// engine as one write has nowhere else to look.
+    #[cfg(test)]
+    pub(crate) fn issued_write_order(&self) -> Vec<(u64, u64)> {
+        self.image.issued_write_order()
+    }
+
     /// The durability barrier a write path calls for, data and metadata both —
     /// issued unless this session's [`SyncPolicy`] leaves the `fsync` cadence to
     /// the application.
@@ -11293,10 +11302,13 @@ mod tests {
         b.write(path).unwrap();
     }
 
-    /// Run the same appends and the same commit on `session`, and report what it
-    /// cost in writes. The file it leaves is the other half of what the callers
-    /// compare, and they read it off the path themselves.
-    fn gather_workload(session: &mut WriteEngine) -> u64 {
+    /// Run the same appends and the same commit on `session`, and report what
+    /// each cost in writes: the in-place appends, then the staged commit that
+    /// follows them. They are counted apart because the gathering earns its keep
+    /// in only one of them — see the caller. The file the workload leaves is the
+    /// other half of what the callers compare, and they read it off the path
+    /// themselves.
+    fn gather_workload(session: &mut WriteEngine) -> (u64, u64) {
         let before = session.image.issued_writes();
         for round in 0..4 {
             for t in 0..4 {
@@ -11312,8 +11324,12 @@ mod tests {
                 .stage_created_dataset(&std::format!("/n{t}"), db)
                 .unwrap();
         }
+        let after_appends = session.image.issued_writes();
         session.commit().unwrap();
-        session.image.issued_writes() - before
+        (
+            after_appends - before,
+            session.image.issued_writes() - after_appends,
+        )
     }
 
     /// Gathering a session's writes lowers what it costs and changes nothing
@@ -11345,30 +11361,42 @@ mod tests {
             a.image
                 .set_write_buffering(WriteBuffering::Unbuffered)
                 .unwrap();
-            let straight_writes = gather_workload(&mut a);
+            let (straight_appends, straight_commit) = gather_workload(&mut a);
             a.force_sync().unwrap();
             drop(a);
 
             let mut b = WriteEngine::open_with_locking(&gathered, FileLocking::Enabled).unwrap();
             b.set_sync_policy(SyncPolicy::OnClose);
-            let gathered_writes = gather_workload(&mut b);
+            let (gathered_appends, gathered_commit) = gather_workload(&mut b);
             b.force_sync().unwrap();
             drop(b);
 
-            // Measured at 86 against 154. Not the 160-against-256 the module docs
-            // and the changelog quote: those are the same workload over *eight*
-            // datasets, and this fixture builds four. The ratio is the claim
-            // either way, which is why the assertion below is a ratio.
-            //
-            // The margin is what it is because every
-            // barrier still issues what it has gathered — see `WriteEngine::barrier`
-            // — so the gathering merges within a phase and never across one.
-            // Merging across barriers would go further and is issue #308, which
-            // is held back on what it would cost a crashed session.
+            // The commit tail is where the gathering earns its keep, and the half
+            // to assert a ratio on. Measured: 2 writes against 10 unpaged, 4
+            // against 16 paged. A commit rebuilds a group, repoints a root and
+            // re-homes the free-space managers, all inside one phase and all into
+            // a handful of pages, which is what merging within a barrier is for.
+            // Merging *across* barriers would go further and is issue #308, held
+            // back on what it would cost a crashed session.
             assert!(
-                gathered_writes * 4 < straight_writes * 3,
-                "paged={paged}: gathering must cost meaningfully fewer writes, \
-                 but cost {gathered_writes} against {straight_writes}"
+                gathered_commit * 3 < straight_commit,
+                "paged={paged}: gathering must cost meaningfully fewer writes for a \
+                 commit, but cost {gathered_commit} against {straight_commit}"
+            );
+            // The appends are the other half, and since issue #307 they are a
+            // near-tie: 88 against 92 unpaged, 92 against 92 paged. Publishing a
+            // checksummed structure is one write from the engine now rather than
+            // two the gatherer had to rejoin, so the buffering has almost nothing
+            // left to merge here — before that fix this half was 92 against 144.
+            // What is still worth pinning is that it never costs *more*. Note the
+            // limit of that: a publish write made wider still merges the same way,
+            // so widening one to the whole structure it sits in changes no count
+            // here or anywhere — `a_publish_writes_from_the_byte_it_changed` is
+            // what holds that, by counting bytes rather than writes.
+            assert!(
+                gathered_appends <= straight_appends,
+                "paged={paged}: gathering must not cost more writes for the appends, \
+                 but cost {gathered_appends} against {straight_appends}"
             );
             assert_eq!(
                 std::fs::read(&straight).unwrap(),
@@ -11649,7 +11677,9 @@ mod tests {
     /// writer is the regime where it still shows: it gathers nothing by design,
     /// so every write the engine makes is a syscall. Stated as a ceiling on the
     /// count rather than as an exact figure, since what an append needs is free to
-    /// fall — six statistics written singly puts it five over.
+    /// fall — and it has: 12 before issue #307 published each checksummed
+    /// structure in one write, 8 after. Six statistics written singly puts it five
+    /// over; a checksum written apart from the value it covers, four.
     #[test]
     fn an_unbuffered_append_costs_a_small_constant_number_of_writes() {
         use tempfile::tempdir;
@@ -11668,9 +11698,10 @@ mod tests {
             "the append issued nothing, so the ceiling below proves nothing"
         );
         assert!(
-            cost <= 14,
+            cost <= 10,
             "an unbuffered append costs {cost} writes; the array header's six \
-             statistics belong in one write, not six (measured at 12)"
+             statistics belong in one write, not six, and each checksum belongs in \
+             the write that changed what it covers (measured at 8)"
         );
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -102,11 +102,13 @@ pub(crate) enum WriteBuffering {
     /// them — but it is why the argument above rests on the contract rather than
     /// on the lock.
     ///
-    /// One thing it does not repair, because it never held: a publish point that
-    /// is itself two writes — a value and the checksum covering it — is atomic
-    /// only when both land in one page. Gathering makes that *more* often true
-    /// than straight-through writing did, and true for every object header this
-    /// crate's own writer produces, but not universally.
+    /// It is not what makes a publish point atomic, and was never able to be. A
+    /// value and the checksum covering it, written separately, would join here
+    /// only when both landed in one page; a structure wider than that published
+    /// the new value under the old checksum whichever mode was in force. That was
+    /// issue #307, and the fix was to write such a structure once from the engine
+    /// rather than to widen what this merges — so the guarantee now holds under
+    /// [`Unbuffered`](WriteBuffering::Unbuffered) too.
     Operation { page_size: u64, max_bytes: usize },
 }
 


### PR DESCRIPTION
Closes #307.

## The defect

A publish point that is a value write followed by a checksum write is atomic only when both land in the same page. The write gathering from #306 joins them whenever they do, which is every object header this crate's own writer produces below about 3.9 KB, so the defect was narrow rather than absent: a dataset whose object-header chunk 0 exceeded one gather page published its new dataspace dimension under the *old* checksum, and a crash between the two writes left the dataset unreadable.

Measured threshold, matching the issue:

```
pad=3800  tail=[(8534, 284), (8460, 60), (135, 3901)]   one write
pad=3900  tail=[(8460, 60), (135, 8), (4132, 4)]        two, torn
```

It predates the gathering. Before #306 every write went to the operating system on its own, so the two were never joined at any header size.

## The fix

`Store::publish_checksummed(start, cks_off, at, value)` replaces `rechecksum_range`: it validates `at` against the structure, reads it, places `value`, recomputes the checksum, and writes back from `at` through the checksum field with a single `write_at`. All seven sites move onto it: the dataspace dimension, the array header's six statistics, an index block's inline element and its data-block and super-block pointers, a data block's element, and a paged super block's page-init bit.

One write is not crash-atomicity, since a wide enough `pwrite` may still tear at a device boundary. It is the window the superblock repoint has always had, which is this crate's bar, and every other publish point already met it.

## On the cost

The issue priced this as "a full header-chunk write on every append where today it costs twelve bytes", and that turns out not to hold. The read was already being made to compute the checksum, and under gathering the gatherer was already merging those two writes into one run spanning the same span. Same workload, same file bytes:

| | writes | bytes |
| --- | --- | --- |
| gathered, before | 40 | 4024 |
| gathered, after | 40 | 4024 |
| unbuffered, before | 64 | 3040 |
| unbuffered, after | 40 | 4024 |

Gathered is unchanged on both axes. Unbuffered drops 24 writes for about 1 KB more bytes, because the engine now does what the gatherer used to have to redo. An unbuffered SWMR append issues 8 writes where it issued 12.

Starting the write at `at` rather than at the structure's start is worth 48.5% of the bytes an unpaged append writes and 8.5% of a paged one's, at the same write count, mostly in the extensible array's index block rather than in the object header.

## A pre-existing panic, also fixed

`locate` refused an Extensible-Array `element_size` too small to hold its three fields but not one too large, so a filtered element whose stored-size field was named wider than the `u64` filling it indexed past that array. Reachable from `Dataset::append` on a corrupt file:

```
thread panicked at src/chunk_index_inplace.rs:1004:73:
range end index 18 out of range for slice of length 8
```

`main` has the identical expression in the code this replaces. The guard is two-sided now, matching what the whole-file read path already refused, and the width arithmetic below it is a `debug_assert!` rather than a second refusal.

## Tests

`publishing_a_dimension_in_a_wide_header_survives_a_crash_at_every_write` is the consequence, a crash-replay sweep over a header padded past one gather page; before the fix every append in it left an unreadable prefix. `a_publish_costs_the_same_whether_or_not_it_spans_a_page` is the rule, swept across header widths. `buffering_saves_a_constant_number_of_writes_not_one_per_append` catches the sites that split at *every* width, which the width comparison structurally cannot see: the array header's statistics sit fifty bytes from their checksum and share a page whatever the dataset looks like. Reverting that one site alone fails this test and nothing else. `a_publish_writes_from_the_byte_it_changed` holds the narrowed write span by counting bytes, where everything else here counts writes. `an_element_width_wider_than_a_u64_is_refused_not_a_panic` covers the width guard.

Each fixture also states what it has to be, because three of them could pass while proving nothing:

- the wide-header sweep sat 200 bytes above a threshold nothing pinned, and passed with the padding set to zero;
- the width sweep passes with the defect present if every padding lands on one side of the page;
- `buffering_saves_a_constant` passed if `set_write_buffering` silently did nothing.

## Two tests this invalidated

`gathering_leaves_fewer_unreadable_crash_states_than_not_gathering` asserted that straight-through writing leaves torn states. It does not any more, so it became `crash_states_read_back_with_and_without_write_gathering`, which sweeps both modes clean. Running the unbuffered one is what keeps a regressed publish from hiding behind a shared page. `Expect` collapsed to one variant with it and is gone; its floor guarded a checker that called every state loud, which requiring every prefix to read subsumes arithmetically.

`gathering_writes_costs_fewer_of_them_and_changes_no_byte` now counts the appends and the commit tail apart, because the fix moved the appends to a near-tie (88 writes against 92, from 88 against 144) and left the commit tail as where gathering earns its keep (2 against 10). One blurred ratio over both would have had to sag to 11% to keep passing; the two rules it splits into are 5x and "never worse".

## A finding for a separate issue

This crate's reader validates no Extensible-Array checksum: not the header, not the index block, not the data block. `extensible_array.rs` says so in two comments. So six of the seven publish sites moved here have no crash-consistency coverage *possible* today, since the sweep's only failure signal for a torn structure is a reader that refuses. The two that are covered are caught by the write-counting tests rather than by a read. All six uncovered sites are live, not dead code. Beyond this PR it is an interop gap, because libhdf5 rejects a torn Extensible-Array header that this crate reads without complaint. Worth its own issue rather than bolting onto this one.

## Gate

2,215 nextest tests and 45 doctests at `--all-features`, clippy clean at `--all-targets --all-features`, `cargo fmt --check` clean, rustdoc clean under `-D warnings`, release check clean, and the allocation baseline unmoved.
