### PR TITLE
Replace an object at its own path in one commit (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- A `File::open_rw` commit accepts a delete and a create at the same path, so replacing an object is one commit and one linearization point instead of two commits with the object missing in between. A dataset may replace a group or the reverse, replacing a group discards its subtree, and a staged edit to the object being replaced is still refused ([#305](https://github.com/stephenberry/hdf5-pure/issues/305)).
+
 ### Changed
 
 - A read-write session issues far fewer writes for the same file: one per dirty page, gathered across the many small writes a commit or in-place append makes. A session of 32 chunk appends issued 160 writes where it once made 448, with no change to the bytes on disk or to what a failed write leaves behind, and the SWMR writer gathers nothing ([#288](https://github.com/stephenberry/hdf5-pure/issues/288)).

--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -133,6 +133,34 @@ file.commit().unwrap();
 
 Unlike `copy`, the source subtree is read and validated **eagerly** (the `File` borrow need not outlive the call), so `copy_from` returns a `Result`; the destination still changes only on `commit()`. Because the copy is byte-for-byte verbatim, anything whose stored bytes embed a *source-file* absolute address — which would dangle in another file — is refused up front: variable-length and reference datasets and attributes (whether compact or dense), and any shared header message (a committed datatype, or an SOHM-shared dataspace, fill value, or filter pipeline). The same-file `copy` keeps these forms valid instead, by sharing the source file's global heaps and objects. The `source` must be a buffered file (`File::open` or `File::from_bytes`, not `File::open_streaming`) using 8-byte offsets and no userblock.
 
+### Replacing an object
+
+Deleting a path and creating something new at that same path in one commit replaces it. The removal is applied before the addition, and the commit's single superblock write publishes both, so a rotating store — a ring buffer of tables, a rolling window of daily datasets — expresses a rotation as one commit rather than two, and the path is never momentarily absent:
+
+```rust
+let file = File::open_rw("ring.h5").unwrap();
+let root = file.root();
+
+root.delete("t0").unwrap();
+root.create_dataset("t0", |b| { b.with_i32_data(&[1, 2, 3]); }).unwrap();
+file.commit().unwrap();
+```
+
+The replacement need not resemble the original: a dataset may replace a group or the reverse, and replacing a group discards its whole subtree rather than inheriting it.
+
+Everything the commit adds *below* a replaced path lands in the replacement, whatever order the calls were made in — staging `create_dataset("g/x")` and then replacing `g` puts `x` in the new group, not the one being removed. What is refused is a staged edit that could only mean the *original*:
+
+| staged beside `delete("g")` | |
+| --- | --- |
+| `create_dataset("g/x")` with no replacement of `g` | refused — it would add into a group whose own link the commit removes |
+| a group under `g` that the commit does not itself create | refused |
+| an attribute set on `g`, or a value overwrite inside it | refused |
+| `copy("g/inner", "backup")` — a copy reading from the replaced subtree | refused: a copy takes its bytes from the pre-commit file, so this would place the original at `backup` while the replacement lands at `g` |
+
+A source that is deleted but *not* replaced is unambiguous — that is a move — and stays allowed.
+
+The new object's storage is appended rather than laid over the original's: the original stays live until the superblock is repointed, which is what makes a crash mid-rotation land on one side or the other. The space the deletion released is therefore what a *later* commit draws on, by the two mechanisms [Space reuse and truncation](#space-reuse-and-truncation) describes — reuse for an interior region, truncation for one that reaches the end of the file. A rotation loop in one session reaches a steady file size rather than growing.
+
 ## Appending to an unlimited dataset
 
 `Dataset::append_staged` grows an existing **chunked, unlimited** dataset in place along its first (axis-0) dimension, **including filtered** datasets (deflate, shuffle, fletcher32, scale-offset, LZF, and ZFP with the `zfp` feature). It is the general, non-SWMR counterpart to the [SWMR writer](swmr.md), which appends only to *unfiltered*, chunk-aligned datasets. It returns an `AppendBuilder` whose typed and generic methods mirror the writer's; repeated calls concatenate in call order.

--- a/src/crash_replay.rs
+++ b/src/crash_replay.rs
@@ -747,6 +747,15 @@ fn doomed_values(r: i32) -> Vec<i32> {
     (0..1024 + r).map(|i| i * 3 + r).collect()
 }
 
+/// Elements of `slot` after `g` rounds have committed. `slot` is deleted and
+/// recreated at its own path in one commit (issue #305), so unlike `added`/
+/// `doomed` it is never absent — the generation is what says which commit a
+/// prefix caught. Lengths differ per generation, so a prefix that resurrected
+/// the previous object reads as the wrong length rather than as plausible data.
+fn slot_values(g: i32) -> Vec<i32> {
+    (0..512 + 37 * g).map(|i| i * 11 + g).collect()
+}
+
 /// Build the file the commit workload churns: one growable dataset, and one
 /// `doomed{r}` per round for the delete half to consume.
 fn commit_base(path: &Path, paged: bool) {
@@ -766,6 +775,10 @@ fn commit_base(path: &Path, paged: bool) {
             .with_i32_data(&v)
             .with_shape(&[v.len() as u64]);
     }
+    let v = slot_values(0);
+    b.create_dataset("slot")
+        .with_i32_data(&v)
+        .with_shape(&[v.len() as u64]);
     b.write(path).unwrap();
 }
 
@@ -785,8 +798,14 @@ fn read_optional(f: &crate::reader::File, path: &str) -> Result<Option<Vec<i32>>
 }
 
 /// `d`'s elements, then each round's `added{r}` and `doomed{r}` — `None` where
-/// the path is not in the file at all.
-type CommitState = (Vec<i32>, Vec<Option<Vec<i32>>>, Vec<Option<Vec<i32>>>);
+/// the path is not in the file at all — and finally `slot`, which every prefix
+/// must have.
+type CommitState = (
+    Vec<i32>,
+    Vec<Option<Vec<i32>>>,
+    Vec<Option<Vec<i32>>>,
+    Vec<i32>,
+);
 
 /// A commit publishes at its superblock write, so every object must read as
 /// either its pre-commit or its post-commit state — never a mixture, and never
@@ -807,10 +826,21 @@ fn commit_state_is_one_or_the_other(path: &Path) -> Verdict {
             added.push(read_optional(&f, &std::format!("added{r}"))?);
             doomed.push(read_optional(&f, &std::format!("doomed{r}"))?);
         }
-        Ok((d, added, doomed))
+        // Not `read_optional`: a replacement leaves the path occupied at every
+        // instant, so "no such path" is a failure here rather than a state, and
+        // it has to reach the judge as one. `dataset` returning `PathNotFound`
+        // is an `Error`, which `Verdict::of` would file as `Loud` — which
+        // `Tally::assert_sound` also fails on, but under a reason about the file
+        // refusing to read rather than about the path being gone.
+        let slot = match f.dataset("slot") {
+            Ok(ds) => ds.read_i32()?,
+            Err(Error::Format(FormatError::PathNotFound { .. })) => Vec::new(),
+            Err(e) => return Err(e),
+        };
+        Ok((d, added, doomed, slot))
     })();
 
-    Verdict::of(read, |(d, added, doomed)| {
+    Verdict::of(read, |(d, added, doomed, slot)| {
         // `d` is judged on its own. An in-place append publishes at its own
         // phase 4, before the staged commit in the same round runs, so its length
         // says nothing about whether that commit landed — the two are separate
@@ -872,6 +902,36 @@ fn commit_state_is_one_or_the_other(path: &Path) -> Verdict {
                 r - 1
             ));
         }
+
+        // `slot` is deleted and recreated at its own path in the same commit, so
+        // it is occupied at every instant: a prefix where the path is gone is a
+        // window in which a replacement was two operations rather than one.
+        if slot.is_empty() {
+            return Err("`slot` is not in the file, though every commit that \
+                        removes it puts its replacement back in the same commit"
+                .to_string());
+        }
+        // And it is occupied by the generation this prefix's *other* evidence
+        // says: rounds commit in order and each round replaces `slot` once, so
+        // after `c` committed rounds `slot` holds generation `c`. This is the
+        // rule that makes a replacement one linearization point rather than
+        // merely an atomic-looking pair — a `slot` a generation ahead of or
+        // behind the round count would mean the delete and the create were
+        // published at different instants.
+        let c = committed.iter().filter(|&&b| b).count() as i32;
+        if slot != slot_values(c) {
+            let found = (0..=CHURN).find(|&g| slot == slot_values(g));
+            return Err(match found {
+                Some(g) => {
+                    std::format!("`slot` holds generation {g} while {c} round(s) have committed")
+                }
+                None => std::format!(
+                    "`slot` holds {} elements, which is no generation this session writes \
+                     ({c} round(s) have committed, so generation {c} was expected)",
+                    slot.len()
+                ),
+            });
+        }
         Ok(())
     })
 }
@@ -901,6 +961,17 @@ fn every_round_committed(path: &Path) -> Result<(), String> {
             return Err(std::format!("`doomed{r}` was never deleted"));
         }
     }
+    let slot = f
+        .dataset("slot")
+        .and_then(|d| d.read_i32())
+        .map_err(|e| std::format!("the finished `slot` does not read: {e:?}"))?;
+    if slot != slot_values(CHURN) {
+        return Err(std::format!(
+            "`slot` holds {} elements rather than generation {CHURN}'s {}",
+            slot.len(),
+            slot_values(CHURN).len()
+        ));
+    }
     Ok(())
 }
 
@@ -921,6 +992,17 @@ fn churn(s: &mut WriteEngine, r: i32) {
     s.stage_created_dataset(&std::format!("/added{r}"), db)
         .unwrap();
     s.delete(&std::format!("doomed{r}")).unwrap();
+
+    // Delete and recreate one path in the *same* commit (issue #305), beside the
+    // unrelated create and delete above. This is the edit that has no two-commit
+    // intermediate state to fall into, so a prefix where `slot` is missing is a
+    // real failure rather than a legitimate half-done rotation.
+    s.delete("slot").unwrap();
+    let v = slot_values(r + 1);
+    let mut sb = DatasetBuilder::new("slot");
+    sb.with_i32_data(&v).with_shape(&[v.len() as u64]);
+    s.stage_created_dataset("/slot", sb).unwrap();
+
     s.commit().unwrap();
 
     // The workload has to have done all three, or the sweep is judging a session

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -21,7 +21,16 @@
 //! Deletion ([`Group::delete`](crate::Group::delete), the HDF5 `H5Ldelete`) is the mirror image:
 //! the parent group's header is rebuilt without the removed link, relocated up
 //! the tree the same way, and the unlinked object (and its subtree) is freed —
-//! its blocks are returned to a session-local free list (see below).
+//! its blocks are returned to a session-local free list (see below). A deletion
+//! and an addition at the *same* path in one commit is a **replacement** (issue
+//! #305): the link is removed from the rebuilt parent before the new object's is
+//! appended, and the one superblock write publishes both, so a rotating store
+//! expresses a rotation as one commit and the path is never momentarily absent.
+//! The new object's storage is still appended rather than laid over the old
+//! one's — the original stays live until the superblock repoint, which is what
+//! makes a crash during the rotation land on one side or the other — so the
+//! space the deletion released is what a *later* commit draws on, by reuse or by
+//! truncation.
 //! Object copy ([`File::copy`](crate::File::copy), the HDF5 `H5Ocopy`) deep-copies
 //! a source subtree — appending fresh copies of every object, repointing internal
 //! links and the contiguous data address — and links the copy in like an
@@ -2870,11 +2879,37 @@ impl WriteEngine {
     /// on close. After reuse, an object reference to a deleted object may resolve
     /// to an unrelated object (deleting a referenced object is undefined in HDF5).
     ///
-    /// The path must exist. A deletion may not overlap another staged change in
-    /// the same commit (e.g. delete `/a` while adding `/a/b`); split such
-    /// edits into separate commits. The link's parent group must itself be
-    /// editable in place (compact links, single-chunk header); the target being
-    /// removed has no such restriction.
+    /// The path must exist. The link's parent group must itself be editable in
+    /// place (compact links, single-chunk header); the target being removed has
+    /// no such restriction.
+    ///
+    /// # Replacing an object
+    ///
+    /// Deleting a path and creating a new object at that same path in one commit
+    /// is a *replacement*, and is accepted (issue #305): the removal is applied
+    /// before the addition, and the commit's single superblock write publishes
+    /// both, so the path is occupied at every instant a crash could interrupt.
+    /// The new object need not resemble the old one — a dataset may replace a
+    /// group, or the reverse — and replacing a group discards its whole subtree
+    /// rather than inheriting it.
+    ///
+    /// Everything this commit adds *below* a replaced path lands in the
+    /// replacement, whatever order the calls were made in: staging
+    /// `create_dataset("g/x")` and then replacing `g` puts `x` in the new group,
+    /// not the one being removed. A staged edit that could only mean the
+    /// *original* is refused instead — a group under the replaced path that this
+    /// commit does not itself create, an attribute set on the object being
+    /// removed, a value overwrite inside it, or a [`copy`](crate::File::copy)
+    /// reading from it.
+    ///
+    /// See [`Group::delete`](crate::Group::delete) for the public form and a
+    /// worked example.
+    ///
+    /// A deletion may not overlap a staged change at a *different* path
+    /// (deleting `/a` while adding `/a/b`, unless `/a` is itself replaced in the
+    /// same commit), nor an edit to the object being removed (an attribute set
+    /// on it, or a value overwrite of something inside it); split those into
+    /// separate commits.
     pub fn delete(&mut self, path: &str) -> Result<(), Error> {
         let comps = split_path(path);
         self.refuse_if_claimed(&comps)?;
@@ -3331,6 +3366,12 @@ impl WriteEngine {
         let mut nodes: BTreeMap<PathKey, Node> = BTreeMap::new();
         nodes.entry(PathKey::new()).or_default(); // root is always dirty
         let mut add_targets: Vec<PathKey> = Vec::new();
+        // Where each in-file `copy` reads from. A copy takes its bytes from the
+        // *pre-commit* file, so a source this same commit replaces would copy the
+        // object being removed while the replacement lands at the same path — see
+        // the delete-staging loop, which refuses that. Cross-file copies are not
+        // tracked: their source is in another file, so no path here can name it.
+        let mut copy_sources: Vec<PathKey> = Vec::new();
         let mut attr_targets: Vec<PathKey> = Vec::new();
 
         // Mark explicitly-created new groups, ensuring their ancestor chain.
@@ -3397,6 +3438,7 @@ impl WriteEngine {
             // userblock file the stored addresses are base-relative, so pass this
             // session's base for the read to absolutize them.
             let tree = Self::read_copy_subtree(&self.image(), src_addr as u64, 0, false, base)?;
+            copy_sources.push(src);
             add_targets.push(dst.clone());
             let leaf = dst.last().unwrap().clone();
             let parent = dst[..dst.len() - 1].to_vec();
@@ -3420,9 +3462,10 @@ impl WriteEngine {
         }
 
         // Stage deletions: each must exist, must not overlap any other staged
-        // change, and is recorded against its parent group (which becomes dirty).
-        // `deleted_addrs` keeps each removed object's header address so its owned
-        // blocks can be reclaimed after the commit lands (issue #21).
+        // change *unless* this commit replaces what it removes, and is recorded
+        // against its parent group (which becomes dirty). `deleted_addrs` keeps
+        // each removed object's header address so its owned blocks can be
+        // reclaimed after the commit lands (issue #21).
         let delete_targets = std::mem::take(&mut self.pending_deletes);
         let mut deleted_addrs: Vec<usize> = Vec::new();
         for (i, d) in delete_targets.iter().enumerate() {
@@ -3439,14 +3482,79 @@ impl WriteEngine {
             if let Ok(a) = usize::try_from(del_addr) {
                 deleted_addrs.push(a);
             }
+            // A deletion may overlap other staged work when this commit
+            // *replaces* what it removes: an addition names exactly `d`, so the
+            // removal and the new object at the same path are one rotation
+            // rather than an edit of something being deleted (issue #305).
+            let recreated = add_targets.iter().any(|t| t == d);
+            // A replacement also requires that every group node at or below `d`
+            // is one this commit builds fresh. A node that is *not* new is
+            // rebuilt from the old object's on-disk header — the object being
+            // replaced — and both ways that lands are wrong, in the two shapes
+            // this guard was measured against:
+            //
+            // * At `d` itself (a group attribute set on a path this commit
+            //   replaces with a *dataset*), the node and the replacement share a
+            //   `path_addr` key. The replacement's address overwrites the group's,
+            //   the parent's link is then patched to the address it already had,
+            //   and the rebuilt group header is left orphaned — a commit that
+            //   returns `Ok` having **silently discarded** the staged attribute.
+            // * Strictly below `d`, the parent is a freshly built region with no
+            //   existing link to patch, so `patch_link_target` reports a missing
+            //   child link partway through the apply. That leaves a valid file
+            //   (the superblock is never repointed) but appends dead bytes and
+            //   reports the wrong thing.
+            //
+            // Refusing here keeps both in the preflight, where the commit is
+            // all-or-nothing and the message can name the actual conflict.
+            if recreated
+                && !nodes
+                    .iter()
+                    .all(|(key, node)| !is_prefix(d, key) || node.is_new)
+            {
+                return Err(Error::EditUnsupported(
+                    "a staged edit names a group at or under a replaced path that this \
+                     commit does not itself create; create it in the same commit, or use \
+                     separate commits",
+                ));
+            }
+            // A copy reading from a path this commit replaces is the same conflict
+            // seen from the other side: `read_copy_subtree` already took its bytes
+            // from the pre-commit file, so the commit would place the *original*
+            // at the copy's destination while placing something else at `d` — two
+            // different objects from one path, in one commit, with no error. A
+            // source that is merely deleted and not replaced is unambiguous (it is
+            // a move) and stays allowed.
+            if recreated {
+                for t in &copy_sources {
+                    if is_prefix(d, t) {
+                        return Err(Error::EditUnsupported(
+                            "a copy in this commit reads from a path the same commit \
+                             replaces; use separate commits",
+                        ));
+                    }
+                }
+            }
+            // Past that return `recreated` means the whole touched subtree is
+            // fresh, so an addition at or below `d` lands in the replacement. The
+            // apply loop already removes a group's deleted links before appending
+            // any new one (`remove_link_from_region` runs first), so a
+            // replacement needs no further sequencing here.
             for t in &add_targets {
+                if recreated && is_prefix(d, t) {
+                    continue;
+                }
                 if is_prefix(d, t) || is_prefix(t, d) {
                     return Err(Error::EditUnsupported(
-                        "a deletion overlaps an addition in the same commit; use separate commits",
+                        "a deletion overlaps an addition in the same commit; \
+                         replace the path instead, or use separate commits",
                     ));
                 }
             }
             for t in &attr_targets {
+                if recreated && is_prefix(d, t) {
+                    continue;
+                }
                 if is_prefix(d, t) {
                     return Err(Error::EditUnsupported(
                         "a deletion overlaps a group-attribute edit in the same commit; use separate commits",
@@ -3455,8 +3563,13 @@ impl WriteEngine {
             }
             for t in &write_targets {
                 if is_prefix(d, t) {
+                    // `write_targets` holds three kinds — a value overwrite, a
+                    // dataset-attribute edit, and a staged append — so the
+                    // message names what they have in common rather than only
+                    // the first of them.
                     return Err(Error::EditUnsupported(
-                        "a deletion overlaps a value overwrite in the same commit; use separate commits",
+                        "a deletion overlaps a staged edit to a dataset in the same \
+                         commit; use separate commits",
                     ));
                 }
             }
@@ -3535,7 +3648,10 @@ impl WriteEngine {
         }
 
         // Validate names: no addition may collide with an existing link or with
-        // another addition under the same parent.
+        // another addition under the same parent. A link this same commit
+        // deletes is not one of the existing ones — the apply loop removes it
+        // from the region before any addition is appended, so replacing an
+        // object at its own path is a rotation, not a collision (issue #305).
         for key in &keys {
             let node = &nodes[key];
             let mut adding: Vec<&str> = Vec::new();
@@ -3551,7 +3667,9 @@ impl WriteEngine {
                 adding.push(leaf);
             }
             for (i, name) in adding.iter().enumerate() {
-                if node.existing_links.iter().any(|n| n == name) || adding[..i].contains(name) {
+                let survives = node.existing_links.iter().any(|n| n == name)
+                    && !node.deletes.iter().any(|n| n == name);
+                if survives || adding[..i].contains(name) {
                     return Err(Error::EditUnsupported(
                         "a link with this name already exists in the target group",
                     ));
@@ -3749,6 +3867,16 @@ impl WriteEngine {
             };
 
             // Remove deleted links first (verbatim-preserving the rest).
+            //
+            // First is a correctness requirement rather than a convention, and
+            // has been since a replacement became one commit (issue #305):
+            // `remove_link_from_region` matches by *name*, so a removal running
+            // after the additions below would take the replacement's link with
+            // the original's and leave the path gone. Every link this loop could
+            // collide with — a copy's, a dataset's, a new child group's — is
+            // appended after it, which is what keeps that unreachable. (A
+            // relocating write and an existing child group *patch* a link rather
+            // than appending one, so neither can be a replacement's.)
             for name in &deletes {
                 region = remove_link_from_region(&region, name)?;
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2882,6 +2882,22 @@ impl Group {
     /// Delete the object named `name` from this group, staged until
     /// [`File::commit`]. See [`create_group`](Self::create_group) for the
     /// file-mode rules.
+    ///
+    /// Creating a new object at the same path in the same commit *replaces* it:
+    /// the removal is applied before the addition and one superblock write
+    /// publishes both, so a rotation costs one commit and the path is never
+    /// momentarily absent.
+    ///
+    /// ```no_run
+    /// # use hdf5_pure::File;
+    /// # fn main() -> Result<(), hdf5_pure::Error> {
+    /// let file = File::open_rw("ring.h5")?;
+    /// file.root().delete("t0")?;
+    /// file.root().create_dataset("t0", |b| { b.with_i32_data(&[1, 2, 3]); })?;
+    /// file.commit()?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn delete(&self, name: &str) -> Result<(), Error> {
         self.with_child_session(name, |session, child| session.delete(child))
     }

--- a/tests/edit_crosscheck.rs
+++ b/tests/edit_crosscheck.rs
@@ -1664,3 +1664,81 @@ fn write_dataset_relocate_with_multiple_hard_links_is_refused() {
         "file modified on refusal"
     );
 }
+
+/// A delete and a create at the same path in one commit (issue #305), on files
+/// the C library wrote in both formats, read back by the C library.
+///
+/// The replacement changes the dataset's length, so a file where the original
+/// survived — or where its link was left beside the replacement's — reads as the
+/// wrong length rather than as plausible data. The *datatype* does no work here:
+/// the C library converts silently, and `read_raw::<i32>()` on a surviving f64
+/// original returns values rather than an error. `h5py` and `h5dump` go through
+/// this same reader.
+#[test]
+fn a_replaced_object_is_read_by_the_c_library() {
+    for (name, low, high, want_sb) in [
+        ("replace_v2.h5", LibraryVersion::V18, LibraryVersion::V18, 2),
+        (
+            "replace_v3.h5",
+            LibraryVersion::V110,
+            LibraryVersion::latest(),
+            3,
+        ),
+    ] {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(name);
+        write_c_starter(&path, low, high);
+        assert_eq!(File::open(&path).unwrap().superblock().version, want_sb);
+
+        {
+            let session = File::open_rw(&path).unwrap();
+            // A dataset replaced at its own path, and a group replaced with its
+            // whole subtree — the two shapes a rotation takes.
+            session.root().delete("alpha").unwrap();
+            session
+                .root()
+                .create_dataset("alpha", |b| {
+                    b.with_i32_data(&[11, 22]);
+                })
+                .unwrap();
+            session.root().delete("grp").unwrap();
+            session
+                .root()
+                .create_group_with("grp", |g| {
+                    g.set_attr("generation", AttrValue::I64(2));
+                    g.create_dataset("delta", |b| {
+                        b.with_f64_data(&[9.5]);
+                    });
+                })
+                .unwrap();
+            session.commit().unwrap();
+        } // drop the editor (release its exclusive lock) before reading back
+
+        let c = hdf5::File::open(&path).unwrap();
+        assert_eq!(
+            c.dataset("alpha").unwrap().read_raw::<i32>().unwrap(),
+            vec![11, 22],
+            "{name}: the C library sees the original rather than the replacement"
+        );
+        assert_eq!(
+            c.dataset("grp/delta").unwrap().read_raw::<f64>().unwrap(),
+            vec![9.5]
+        );
+        assert_c_absent(&c.dataset("grp/beta").unwrap_err(), "grp/beta");
+        assert_eq!(
+            c.group("grp")
+                .unwrap()
+                .attr("generation")
+                .unwrap()
+                .read_scalar::<i64>()
+                .unwrap(),
+            2
+        );
+        // The untouched neighbour, to show the rotation did not disturb the rest
+        // of the group it rebuilt.
+        assert_eq!(
+            c.dataset("doomed").unwrap().read_raw::<i32>().unwrap(),
+            vec![7, 8]
+        );
+    }
+}

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -3896,3 +3896,458 @@ fn add_empty_chunked_datasets_of_every_flavor() {
     drop(file);
     std::fs::remove_file(&path).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Replacing an object at its own path in one commit (issue #305)
+// ---------------------------------------------------------------------------
+
+/// A file holding one dataset and one populated group, both at the root, for the
+/// replacement tests below to rotate.
+fn write_rotation_starter(path: &std::path::Path) {
+    let mut b = FileBuilder::new();
+    b.create_dataset("slot").with_f64_data(&[1.0, 2.0, 3.0]);
+    b.create_dataset("bystander").with_i32_data(&[42]);
+    b.write(path).unwrap();
+
+    let session = File::open_rw(path).unwrap();
+    session.root().create_group("g").unwrap();
+    session.root().create_group("g/sub").unwrap();
+    session
+        .root()
+        .create_dataset("g/inner", |b| {
+            b.with_i32_data(&[7, 8]);
+        })
+        .unwrap();
+    session.commit().unwrap();
+}
+
+#[test]
+fn a_dataset_is_replaced_at_its_own_path_in_one_commit() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_dataset.h5");
+    write_rotation_starter(&path);
+
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("slot").unwrap();
+        session
+            .root()
+            .create_dataset("slot", |b| {
+                b.with_i32_data(&[9, 8, 7, 6]);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // The new object, not the old one, and not both: the datatype changed from
+    // f64 to i32 and the length from 3 to 4, so a surviving original reads as
+    // the wrong shape rather than as plausible data.
+    let slot = file.dataset("slot").unwrap();
+    assert_eq!(slot.shape().unwrap(), vec![4]);
+    assert_eq!(slot.read_i32().unwrap(), vec![9, 8, 7, 6]);
+    // Exactly one link named `slot` — a replacement removes the original's link
+    // rather than adding a second one beside it.
+    assert_eq!(
+        file.root()
+            .iter_datasets()
+            .unwrap()
+            .filter(|(n, _)| n == "slot")
+            .count(),
+        1
+    );
+    assert_eq!(
+        file.dataset("bystander").unwrap().read_i32().unwrap(),
+        vec![42]
+    );
+    assert_eq!(
+        file.dataset("g/inner").unwrap().read_i32().unwrap(),
+        vec![7, 8]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn replacing_a_group_replaces_its_whole_subtree() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_group.h5");
+    write_rotation_starter(&path);
+
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g").unwrap();
+        session
+            .root()
+            .create_group_with("g", |g| {
+                g.set_attr("generation", AttrValue::I64(2));
+                g.create_dataset("fresh", |b| {
+                    b.with_i32_data(&[1, 2, 3]);
+                });
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    // The replacement is a new, empty group configured in the same commit: the
+    // original's child is gone rather than inherited.
+    assert!(
+        file.dataset("g/inner").is_err(),
+        "the replaced group kept the original's child"
+    );
+    assert_eq!(
+        file.dataset("g/fresh").unwrap().read_i32().unwrap(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        file.group("g").unwrap().attrs().unwrap()["generation"],
+        AttrValue::I64(2)
+    );
+    assert_eq!(
+        file.root()
+            .iter_groups()
+            .unwrap()
+            .filter(|(n, _)| n == "g")
+            .count(),
+        1
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn a_dataset_is_replaced_below_the_root_too() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_nested.h5");
+    write_rotation_starter(&path);
+
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g/inner").unwrap();
+        session
+            .root()
+            .create_dataset("g/inner", |b| {
+                b.with_i32_data(&[5, 5, 5]);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("g/inner").unwrap().read_i32().unwrap(),
+        vec![5, 5, 5]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rotating_one_path_in_a_session_stops_growing_the_file() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_rotation_bounded.h5");
+    write_rotation_starter(&path);
+
+    let mut sizes = Vec::new();
+    {
+        let session = File::open_rw(&path).unwrap();
+        for round in 0..12u32 {
+            session.root().delete("slot").unwrap();
+            session
+                .root()
+                .create_dataset("slot", |b| {
+                    b.with_i32_data(&vec![round as i32; 256]);
+                })
+                .unwrap();
+            session.commit().unwrap();
+            sizes.push(session.file_size());
+        }
+    }
+
+    // A rotation is what the refusal used to cost two commits, and the point of
+    // paying it once is that the file reaches a steady state instead of growing
+    // by a dataset per round: each commit frees the object the previous one
+    // placed, and the next reuses that space. Judged against the *second* round
+    // rather than the first, because the first has nothing freed to draw on yet.
+    let ceiling = sizes[1];
+    assert!(
+        sizes[2..].iter().all(|&s| s <= ceiling),
+        "the file grew past its second-round size under rotation: {sizes:?}"
+    );
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("slot").unwrap().read_i32().unwrap(),
+        vec![11i32; 256]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn an_addition_below_a_path_needs_that_path_replaced_too() {
+    // Replacing `g` makes an addition below it unambiguous: `g/added` is placed
+    // in the group this commit builds, not in the one it removes.
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_descendant_ok.h5");
+    write_rotation_starter(&path);
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g").unwrap();
+        session.root().create_group("g").unwrap();
+        session
+            .root()
+            .create_dataset("g/added", |b| {
+                b.with_i32_data(&[1, 2]);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("g/added").unwrap().read_i32().unwrap(),
+        vec![1, 2]
+    );
+    assert!(
+        file.dataset("g/inner").is_err(),
+        "the addition landed in the group being removed rather than its replacement"
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+
+    // Without that replacement it is the ambiguity the refusal exists for: the
+    // addition names a group whose own link this commit removes.
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_descendant.h5");
+    write_rotation_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+    let session = File::open_rw(&path).unwrap();
+    session.root().delete("g").unwrap();
+    session
+        .root()
+        .create_dataset("g/added", |b| {
+            b.with_i32_data(&[1]);
+        })
+        .unwrap();
+    let err = session.commit().unwrap_err();
+    assert!(
+        matches!(&err, Error::EditUnsupported(m) if m.contains("overlaps an addition")),
+        "unexpected error: {err:?}"
+    );
+    // The refusal is a preflight, so not a byte of the file changed.
+    drop(session);
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn a_group_and_a_dataset_replace_each_other() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_kind_swap.h5");
+    write_rotation_starter(&path);
+
+    // A dataset over a group: the whole subtree goes with the link.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g").unwrap();
+        session
+            .root()
+            .create_dataset("g", |b| {
+                b.with_i32_data(&[4, 5, 6]);
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+    {
+        let file = File::open(&path).unwrap();
+        assert_eq!(
+            file.dataset("g").unwrap().read_i32().unwrap(),
+            vec![4, 5, 6]
+        );
+        // `File::group` hands back a handle for any resolvable path without
+        // checking the object's kind, so the group-ness of `g` is judged by
+        // what the handle can do rather than by whether it exists.
+        assert!(
+            file.group("g").unwrap().iter_datasets().is_err(),
+            "`g` still reads as a group"
+        );
+        assert!(file.dataset("g/inner").is_err());
+        assert!(file.group("g/sub").is_err());
+    }
+
+    // And a group back over that dataset.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g").unwrap();
+        session
+            .root()
+            .create_group_with("g", |g| {
+                g.create_dataset("back", |b| {
+                    b.with_i32_data(&[7]);
+                });
+            })
+            .unwrap();
+        session.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert!(
+        file.dataset("g").is_err(),
+        "`g` still resolves as a dataset"
+    );
+    assert_eq!(file.dataset("g/back").unwrap().read_i32().unwrap(), vec![7]);
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn a_staged_edit_to_a_replaced_object_is_refused() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_edited.h5");
+    write_rotation_starter(&path);
+
+    // `g` is replaced by a *dataset*, so the group-attribute edit at the same
+    // path can only mean the group being removed. A replacement makes every
+    // path under it name the new object, and there is no new group here to
+    // carry the attribute.
+    let session = File::open_rw(&path).unwrap();
+    session.root().delete("g").unwrap();
+    session
+        .root()
+        .create_dataset("g", |b| {
+            b.with_i32_data(&[1]);
+        })
+        .unwrap();
+    session
+        .group("g")
+        .unwrap()
+        .set_attr("generation", AttrValue::I64(1))
+        .unwrap();
+    let err = session.commit().unwrap_err();
+    assert!(
+        matches!(&err, Error::EditUnsupported(m) if m.contains("at or under a replaced path")),
+        "unexpected error: {err:?}"
+    );
+    drop(session);
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("g/inner").unwrap().read_i32().unwrap(),
+        vec![7, 8]
+    );
+    drop(file);
+    std::fs::remove_file(&path).ok();
+
+    // The same rule one level down: `g` is replaced by a group this time, but
+    // `g/sub` names the *original's* subgroup, which the replacement does not
+    // create. Refused for the same reason and by the same guard.
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_edited_child.h5");
+    write_rotation_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+    let session = File::open_rw(&path).unwrap();
+    session.root().delete("g").unwrap();
+    session.root().create_group("g").unwrap();
+    session
+        .group("g/sub")
+        .unwrap()
+        .set_attr("generation", AttrValue::I64(1))
+        .unwrap();
+    let err = session.commit().unwrap_err();
+    assert!(
+        matches!(&err, Error::EditUnsupported(m) if m.contains("at or under a replaced path")),
+        "unexpected error: {err:?}"
+    );
+    drop(session);
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn a_copy_replaces_an_object_at_its_own_path() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_by_copy.h5");
+    write_rotation_starter(&path);
+
+    // A copy is linked into its parent by the same apply-loop step as a created
+    // dataset, and after the same removal, so it replaces a path too.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("slot").unwrap();
+        session.copy("g/inner", "slot").unwrap();
+        session.commit().unwrap();
+    }
+
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("slot").unwrap().read_i32().unwrap(),
+        vec![7, 8]
+    );
+    // The copy's source is untouched, and the replaced original is gone rather
+    // than shadowed: it held f64, so a surviving link reads as the wrong type.
+    assert_eq!(
+        file.dataset("g/inner").unwrap().read_i32().unwrap(),
+        vec![7, 8]
+    );
+    assert_eq!(file.dataset("slot").unwrap().shape().unwrap(), vec![2]);
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn a_copy_reading_from_a_replaced_path_is_refused() {
+    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_copy_source.h5");
+    write_rotation_starter(&path);
+    let before = std::fs::read(&path).unwrap();
+
+    // A copy takes its bytes from the pre-commit file. Reading from a path this
+    // same commit replaces would put the *original* at `backup` while the
+    // replacement lands at `slot`, so one commit would produce two different
+    // objects from one path with nothing to say so.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("slot").unwrap();
+        session
+            .root()
+            .create_dataset("slot", |b| {
+                b.with_i32_data(&[9, 9, 9, 9]);
+            })
+            .unwrap();
+        session.copy("slot", "backup").unwrap();
+        let err = session.commit().unwrap_err();
+        assert!(
+            matches!(&err, Error::EditUnsupported(m) if m.contains("reads from a path the same commit replaces")),
+            "unexpected error: {err:?}"
+        );
+        drop(session);
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+    }
+
+    // Reading from inside a replaced *group* is the same conflict one level down.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.root().delete("g").unwrap();
+        session
+            .root()
+            .create_group_with("g", |g| {
+                g.create_dataset("inner", |b| {
+                    b.with_i32_data(&[7, 7, 7, 7, 7]);
+                });
+            })
+            .unwrap();
+        session.copy("g/inner", "backup").unwrap();
+        let err = session.commit().unwrap_err();
+        assert!(
+            matches!(&err, Error::EditUnsupported(m) if m.contains("reads from a path the same commit replaces")),
+            "unexpected error: {err:?}"
+        );
+        drop(session);
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+    }
+
+    // A source that is deleted but *not* replaced is unambiguous — that is a
+    // move — and stays allowed.
+    {
+        let session = File::open_rw(&path).unwrap();
+        session.copy("slot", "moved").unwrap();
+        session.root().delete("slot").unwrap();
+        session.commit().unwrap();
+    }
+    let file = File::open(&path).unwrap();
+    assert_eq!(
+        file.dataset("moved").unwrap().read_f64().unwrap(),
+        vec![1.0, 2.0, 3.0]
+    );
+    assert!(file.dataset("slot").is_err());
+    drop(file);
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
Closes #305.

A read-write session refused a commit that both deleted an object and created one at the same path, so a rotating store — a ring buffer of tables, a rolling window of daily datasets — spent two commits expressing one rotation, and the file passed through a state in which the object did not exist. That state is also what a crash between the two commits leaves behind.

An overlap is now permitted when the commit **replaces** what it removes: some addition names exactly the deleted path, and every group node at or below it is one this commit builds fresh. The apply loop already removed a group's deleted links before appending any new one, so the delete-then-create ordering the issue asks for was there; what changed is the preflight, plus the name-collision check, which no longer counts a link this same commit deletes as one already present. No new API — `delete` beside `create_dataset` / `create_group_with` / `copy` is the whole surface, so the `replace_dataset` fallback the issue offered is not needed.

The replacement need not resemble the original: a dataset may replace a group or the reverse, and replacing a group discards its whole subtree rather than inheriting it.

## What is accepted, and what stays refused

Each refusal now carries its own message rather than the one blanket text:

| staged | verdict |
| --- | --- |
| `delete("g")` + `create_dataset("g", …)` | replacement |
| `delete("g")` + `create_group_with("g", …)` incl. children and attributes | replacement |
| `delete("g")` + `copy(src, "g")` | replacement |
| `delete("g")` + `create_group("g")` + `create_dataset("g/x", …)` | replacement, and `x` lands in the new `g` |
| `delete("g")` + `create_dataset("g/x", …)`, with no replacement of `g` | refused — *a deletion overlaps an addition* |
| `delete("g")` + `create_dataset("g", …)` + `group("g").set_attr(…)` | refused — *a staged edit names a group at or under a replaced path* |
| `delete("g")` + `create_group("g")` + `dataset("g/inner").write_staged(…)` | refused — *a deletion overlaps a staged edit to a dataset* |
| `delete("slot")` + `create_dataset("slot", …)` + `copy("slot", "backup")` | refused — *a copy reads from a path the same commit replaces* |

Everything the commit adds *below* a replaced path lands in the replacement, whatever order the calls were made in. The first refusal is the ambiguity the rule exists for: the addition would be linked into a group whose own link the commit removes. The second is the case where a node under the replaced path is *not* new — it would be rebuilt from the old object's header and then linked into its parent by patching a link the fresh parent does not have, so it could only fail partway through the apply. Catching it in the preflight keeps the all-or-nothing contract.

## Crash consistency

This is the property the issue is really asking for, so it is measured rather than argued. The commit workload in `src/crash_replay.rs` gains a `slot` dataset that each round deletes and recreates in the same commit, and two rules: `slot` is in the file at **every** replayed prefix, and it holds the generation the round count says it should. The sweep runs over both backings and both file-space strategies.

Written as two commits instead — the form the refusal used to force — the same workload goes silent at a third of its crash points, and both rules earn their place. Measured over a 86-prefix sweep: **21 prefixes have `slot` missing from the file**, and a further **12 have it present at the wrong generation** — a rotation whose delete landed while its create did not. The second dozen is invisible to the first rule.

```
after op 10 (write 0..48): `slot` is not in the file, though every commit that
removes it puts its replacement back in the same commit
after op 11 (write 48..234): `slot` holds generation 0 while 1 round(s) have committed
```

The one-commit form issues 56 disk operations for six rounds where the two-commit form issues 73.

## Size

Measured over 20 rotations of a 256-byte dataset in one session:

| | one commit | two commits |
| --- | --- | --- |
| default strategy | oscillates 558–814 B | settles at 470 B |
| persisting free space | 6,329 B (275 B/rotation) | 11,485 B (550 B/rotation) |

The issue expected the single commit to be the smaller one, on the reasoning that a commit seeing both halves "could place the new object in the old one's space". It deliberately does not, and that is why the default-strategy figure is the *higher* of the two: the original stays live until the superblock repoint, so a crash lands on one side of the rotation or the other. Overwriting it in place would destroy the pre-commit state before the linearization point. The space a deletion releases is therefore what a *later* commit draws on, by reuse or by truncation — bounded either way, at a slightly higher water mark.

Where one commit does win is the tail. Each commit rebuilds the parent group, writes a new root, repoints the superblock, and on a persisting file re-homes the free-space managers; a rotation now pays that once, which halves the growth rate of a persisting file exactly.

## Verification

- 2,229 tests at `--all-features`, 46 doctests, `allocation_baseline` unchanged, clippy `-D warnings` and fmt clean, `--no-default-features` builds.
- Nine new tests in `tests/edit_in_place.rs` and one in `tests/edit_crosscheck.rs`, which replaces both a dataset and a group in files the C library wrote in the 1.8 and 1.10+ formats and reads the result back through libhdf5 — the reader `h5py` and `h5dump` go through.
- Every branch of the rule was mutation-checked:

  | mutation | caught by |
  | --- | --- |
  | permit no overlap (the pre-#305 refusal) | 6 in-place, the crosscheck, and the crash sweep |
  | permit every overlap | `an_addition_below_a_path_needs_that_path_replaced_too` + 2 pre-existing |
  | permit an addition below a path that is not itself replaced | `an_addition_below_a_path_needs_that_path_replaced_too` + 1 pre-existing |
  | permit an addition at the replaced path but not below it | `an_addition_below_a_path_needs_that_path_replaced_too`, `a_group_and_a_dataset_replace_each_other`, `replacing_a_group_replaces_its_whole_subtree` |
  | drop the fresh-subtree refusal | `a_staged_edit_to_a_replaced_object_is_refused`, alone |
  | drop the attribute permit | `replacing_a_group_replaces_its_whole_subtree` + the crosscheck |
  | let a deleted name still count as a collision | 5 in-place, the crosscheck, and the crash sweep |
  | drop the copy-source refusal, or make it unconditional | `a_copy_reading_from_a_replaced_path_is_refused`, alone, in both directions |
- Reordering the apply loop so removal follows the additions fails four in-place tests and `committing_survives_a_crash_at_every_write`, and nothing else in the library. That one is worth knowing about: `remove_link_from_region` matches by *name*, so a removal running after the additions takes the replacement's link along with the original's and leaves the path gone. The ordering is now a stated requirement at the call site rather than an incidental one.

## Not bumping the version

Additive: a refusal removed, no public API changed.

## One thing not fixed here

The correctness review turned up a pre-existing bug next door, reproduced byte-identically on `main`: an object reference to a *child* of a deleted group is written pointing into space the same commit frees, while a reference to the deleted path itself is correctly refused. Filed as #314 rather than folded in — this branch does not touch `resolve_reference_target`, and the replacement path is unaffected, since `add_targets` already covers everything at or below a replaced path with a prefix test.

## Review

Two agents reviewed the first draft in isolated worktrees. Their findings are folded in above; the ones worth naming:

- **A copy reading from a replaced path silently copied the original.** Staging `delete("slot")`, `create_dataset("slot", [9,9,9,9])` and `copy("slot", "backup")` committed cleanly and left `slot = [9,9,9,9]` beside `backup = [1,1,1]` — one commit, two different objects from one path, no error. `read_copy_subtree` takes its bytes from the pre-commit file, and the relaxed overlap rule only asked where the copy's *destination* was. This was refused before the change (by the blanket refusal) and is now refused by name. A source that is merely deleted and not replaced is a move, and stays allowed.

- The `is_new` guard's comment described the wrong failure mode. Deleting the guard and running the case its test covers returns `Ok(())` and **silently discards** the staged attribute — the rebuilt group header and its replacement collide on a `path_addr` key, so the parent's link is patched to the address it already had and the group header is orphaned. The mid-apply failure the comment described is real only one level down. The comment now states both, and which is which.
- The changelog said an addition below a deletion "is still refused". It is accepted when the deleted path is itself replaced, which is what `docs/` and the rustdoc already said and what `an_addition_below_a_path_needs_that_path_replaced_too` now tests on both sides.
- `an_addition_below_a_deleted_path_is_still_refused` was subsumed by a pre-existing test with a strictly stronger assertion, and never reached the new code at all (`recreated` is false throughout it). Replaced with the boundary test above.
- The refusal message misfiled a common mistake: staging `create_dataset("g/sub/x")` under a replaced `g` without creating `g/sub` reported "a replaced path also carries a staged edit to the object being replaced". Reworded to name the group.
- The `### Replacing an object` heading in the editing guide was inserted mid-section and nested ~60 lines of unrelated content — the `create_dataset` prose, `set_attr`, `copy`, `copy_from` — under it in the page and its table of contents. Moved to the end of Operations.
- "the next commit reuses that space" is half the mechanism; truncation is the other half, and the page's own later section already said so.
