### PR TITLE
Fix the Rust 1.98 clippy lint that fails CI on main

### DIFF
--- a/examples/compound_types.rs
+++ b/examples/compound_types.rs
@@ -67,7 +67,9 @@ fn main() {
 /// Decode a `{real: f64, imag: f64}` compound dataset's raw record bytes into
 /// `(real, imag)` pairs (16 little-endian bytes per element).
 fn decode_complex64(raw: &[u8]) -> Vec<(f64, f64)> {
-    raw.chunks_exact(16)
+    raw.as_chunks::<16>()
+        .0
+        .iter()
         .map(|rec| {
             let re = f64::from_le_bytes(rec[0..8].try_into().unwrap());
             let im = f64::from_le_bytes(rec[8..16].try_into().unwrap());

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -2170,8 +2170,10 @@ mod tests {
         .unwrap();
 
         let decoded: Vec<f64> = out
-            .chunks_exact(8)
-            .map(|b| f64::from_le_bytes(b.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|b| f64::from_le_bytes(*b))
             .collect();
         assert_eq!(
             decoded,

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -4633,8 +4633,10 @@ mod tests {
             .map(|o| match o {
                 VlByteObject::Null => Vec::new(),
                 VlByteObject::Bytes(b) => b
-                    .chunks_exact(4)
-                    .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|c| i32::from_le_bytes(*c))
                     .collect(),
             })
             .collect();

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -665,19 +665,19 @@ fn deflate_compress(
 /// unrolled): gather byte `j` of element `i` from plane `j` and write the `N`
 /// reconstructed bytes of the element as one contiguous store.
 fn unshuffle_n<const N: usize>(data: &[u8], result: &mut [u8], num_elements: usize) {
-    for (i, out) in result.chunks_exact_mut(N).enumerate() {
+    for (i, out) in result.as_chunks_mut::<N>().0.iter_mut().enumerate() {
         let mut elem = [0u8; N];
         for (j, b) in elem.iter_mut().enumerate() {
             *b = data[j * num_elements + i];
         }
-        out.copy_from_slice(&elem);
+        *out = elem;
     }
 }
 
 /// Shuffle one element width `N` (const-generic): read the `N` contiguous bytes
 /// of element `i` and scatter byte `j` into plane `j`.
 fn shuffle_n<const N: usize>(data: &[u8], result: &mut [u8], num_elements: usize) {
-    for (i, elem) in data.chunks_exact(N).enumerate() {
+    for (i, elem) in data.as_chunks::<N>().0.iter().enumerate() {
         for (j, &b) in elem.iter().enumerate() {
             result[j * num_elements + i] = b;
         }

--- a/src/mat/string_object.rs
+++ b/src/mat/string_object.rs
@@ -87,7 +87,7 @@ pub fn encode_string_saveobj_payload(
     // Pad to a multiple of 4 u16s so we can pack 4 per u64 word.
     units.resize(units.len().next_multiple_of(4), 0);
 
-    for chunk in units.chunks_exact(4) {
+    for chunk in units.as_chunks::<4>().0 {
         let v = (chunk[0] as u64)
             | ((chunk[1] as u64) << 16)
             | ((chunk[2] as u64) << 32)

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -1509,8 +1509,8 @@ fn emit_object_reference_dataset(
             .into());
         }
         let mut targets = Vec::with_capacity(n_elements);
-        for chunk in raw[..needed].chunks_exact(8) {
-            let v = u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8) yields 8 bytes"));
+        for chunk in raw[..needed].as_chunks::<8>().0 {
+            let v = u64::from_le_bytes(*chunk);
             targets.push(resolve_reference_address(v, path, drop, addr_map)?);
         }
         targets

--- a/src/scaleoffset.rs
+++ b/src/scaleoffset.rs
@@ -1887,8 +1887,10 @@ mod tests {
         let comp = compress(&raw, &f).unwrap();
         let dec = decompress(&comp, &f, None).unwrap();
         let got: Vec<f64> = dec
-            .chunks_exact(8)
-            .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|c| f64::from_le_bytes(*c))
             .collect();
         let tol = 0.5 * 10f64.powi(-decimals);
         for (g, v) in got.iter().zip(vals.iter()) {
@@ -1908,8 +1910,10 @@ mod tests {
         let comp = compress(&raw, &f).unwrap();
         let dec = decompress(&comp, &f, None).unwrap();
         let got: Vec<f32> = dec
-            .chunks_exact(4)
-            .map(|c| f32::from_be_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_be_bytes(*c))
             .collect();
         let tol = 0.5 * 10f32.powi(-decimals);
         for (g, v) in got.iter().zip(vals.iter()) {
@@ -2174,8 +2178,10 @@ mod tests {
             let comp = compress(&raw, &f).unwrap();
             let dec = decompress(&comp, &f, None).unwrap();
             let got: Vec<f64> = dec
-                .chunks_exact(8)
-                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| f64::from_le_bytes(*c))
                 .collect();
             // 0.5 ULP rounding + a few ULP of float arithmetic noise.
             let tol = 0.501 * 10f64.powi(-decimals);
@@ -2231,8 +2237,10 @@ mod tests {
         chunk.push(0);
         let out = decompress(&chunk, &f, None).unwrap();
         let got: Vec<u32> = out
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| u32::from_le_bytes(*c))
             .collect();
         assert_eq!(
             got,
@@ -2276,8 +2284,10 @@ mod tests {
         chunk.extend_from_slice(&pack_offsets(&[0, 1, 7, 2], 3, 4).unwrap());
         let out = decompress(&chunk, &f, None).unwrap();
         let got: Vec<u32> = out
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| u32::from_le_bytes(*c))
             .collect();
         assert_eq!(got, vec![10u32, 11, 999, 12]);
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -565,8 +565,10 @@ mod streaming_tests {
     fn read_back_f64(bytes: &[u8], path: &str) -> Vec<f64> {
         let file = crate::reader::File::from_bytes(bytes.to_vec()).unwrap();
         let raw = file.dataset(path).unwrap().read_raw().unwrap();
-        raw.chunks_exact(8)
-            .map(|b| f64::from_le_bytes(b.try_into().unwrap()))
+        raw.as_chunks::<8>()
+            .0
+            .iter()
+            .map(|b| f64::from_le_bytes(*b))
             .collect()
     }
 

--- a/src/zfp_crosscheck.rs
+++ b/src/zfp_crosscheck.rs
@@ -108,15 +108,19 @@ fn decode_tolerance(fix: &Fixture, raw: &[u8]) -> f64 {
         "f32" | "f64" => 2f64.powi(-(fix.rate as i32 / 2)),
         "i32" => {
             let max_abs = raw
-                .chunks_exact(4)
-                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]).unsigned_abs() as f64)
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| i32::from_le_bytes(*c).unsigned_abs() as f64)
                 .fold(0f64, f64::max);
             (max_abs / 2.0).max(1.0)
         }
         "i64" => {
             let max_abs = raw
-                .chunks_exact(8)
-                .map(|c| i64::from_le_bytes(c.try_into().unwrap()).unsigned_abs() as f64)
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| i64::from_le_bytes(*c).unsigned_abs() as f64)
                 .fold(0f64, f64::max);
             (max_abs / 2.0).max(1.0)
         }
@@ -143,12 +147,16 @@ fn decode_and_max_err(
     match dtype {
         "f32" => {
             let expected: Vec<f32> = raw
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| f32::from_le_bytes(*c))
                 .collect();
             let got: Vec<f32> = decoded
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| f32::from_le_bytes(*c))
                 .collect();
             if got.len() != expected.len() {
                 return Err(format!(
@@ -161,12 +169,16 @@ fn decode_and_max_err(
         }
         "f64" => {
             let expected: Vec<f64> = raw
-                .chunks_exact(8)
-                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| f64::from_le_bytes(*c))
                 .collect();
             let got: Vec<f64> = decoded
-                .chunks_exact(8)
-                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| f64::from_le_bytes(*c))
                 .collect();
             if got.len() != expected.len() {
                 return Err(format!(
@@ -179,12 +191,16 @@ fn decode_and_max_err(
         }
         "i32" => {
             let expected: Vec<i32> = raw
-                .chunks_exact(4)
-                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| i32::from_le_bytes(*c))
                 .collect();
             let got: Vec<i32> = decoded
-                .chunks_exact(4)
-                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| i32::from_le_bytes(*c))
                 .collect();
             if got.len() != expected.len() {
                 return Err(format!(
@@ -202,12 +218,16 @@ fn decode_and_max_err(
         }
         "i64" => {
             let expected: Vec<i64> = raw
-                .chunks_exact(8)
-                .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| i64::from_le_bytes(*c))
                 .collect();
             let got: Vec<i64> = decoded
-                .chunks_exact(8)
-                .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|c| i64::from_le_bytes(*c))
                 .collect();
             if got.len() != expected.len() {
                 return Err(format!(

--- a/tests/layout_introspection_crosscheck.rs
+++ b/tests/layout_introspection_crosscheck.rs
@@ -38,8 +38,10 @@ fn chunk_i32_at(path: &std::path::Path, chunk: &Chunk) -> Vec<i32> {
     let start = chunk.address as usize;
     let end = start + chunk.storage_size as usize;
     bytes[start..end]
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect()
 }
 

--- a/tests/lzf_roundtrip.rs
+++ b/tests/lzf_roundtrip.rs
@@ -297,8 +297,10 @@ fn reads_h5py_shuffle_lzf() {
     assert_eq!(ds.filters(), vec![2, 32000]);
     let raw = std::fs::read(fixture("f64_shuffle_lzf.raw.bin")).unwrap();
     let expected: Vec<f64> = raw
-        .chunks_exact(8)
-        .map(|b| f64::from_le_bytes(b.try_into().unwrap()))
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|b| f64::from_le_bytes(*b))
         .collect();
     assert_eq!(ds.read_f64().unwrap(), expected);
 }
@@ -310,8 +312,10 @@ fn reads_h5py_lzf_multichunk() {
     let ds = file.dataset("v").unwrap();
     let raw = std::fs::read(fixture("i64_multichunk.raw.bin")).unwrap();
     let expected: Vec<i64> = raw
-        .chunks_exact(8)
-        .map(|b| i64::from_le_bytes(b.try_into().unwrap()))
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|b| i64::from_le_bytes(*b))
         .collect();
     assert_eq!(ds.read_i64().unwrap(), expected);
 }


### PR DESCRIPTION
`main` does not build under Rust **1.98.0** (released 2026-08-18). It added `clippy::chunks_exact_to_as_chunks`, and two jobs turn a clippy warning into a build failure — `Lint (fmt, clippy)` and `Check (i686-unknown-linux-gnu)`, both `-D warnings`. Every open PR is red on those two checks, whatever it changes.

Nothing here is behavioural. `chunks_exact(N)` and `as_chunks::<N>().0` divide a slice the same way and drop the same trailing remainder; the difference is that `as_chunks` yields `&[T; N]` instead of `&[T]`.

That type is why this is worth taking rather than allowing: **20 of the 26 sites lose a `try_into().unwrap()` or an `expect()`** — a panic path each, present only because the element width was invisible to the compiler. `emit_object_reference_dataset` is representative:

```rust
-        for chunk in raw[..needed].chunks_exact(8) {
-            let v = u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8) yields 8 bytes"));
+        for chunk in raw[..needed].as_chunks::<8>().0 {
+            let v = u64::from_le_bytes(*chunk);
```

The shuffle filter's inner loop drops a `copy_from_slice` for a plain assignment, both sides now being `[u8; N]`.

Sites: `filters.rs` (2), `repack.rs`, `mat/string_object.rs`, `chunked_read.rs`, `file_writer.rs`, `writer.rs`, `scaleoffset.rs` (5), `zfp_crosscheck.rs` (10), plus `examples/compound_types.rs` and two test files.

## MSRV

`as_chunks` and `as_chunks_mut` are available on the crate's declared `rust-version = "1.89"` — checked, not assumed: `cargo +1.89.0 check --locked --lib` is clean. No bump needed, and the promise to dependents is unaffected.

## Verification

The four commands that fail on `main` all pass here — `cargo fmt --all -- --check`, the Lint job's clippy, and both i686 clippy invocations. 2243 tests at `--all-features` and 46 doctests pass.
