### PR TITLE
Refuse a zero-element shape staged with element data (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Breaking:** `FileBuilder` refuses a dataset that stages element data under a zero-element shape, instead of writing a file the reference library refuses to open as corrupt (or, chunked, silently dropping the data). Staging no data for such a shape is unchanged ([#332](https://github.com/stephenberry/hdf5-pure/issues/332)).
 - **Breaking:** Reading a dataset whose data lives in external files (`H5Pset_external`) is refused with `FormatError::UnsupportedExternalStorage` instead of answering the fill value for every element of data this crate never looked at. Its shape, datatype, and layout still read ([#331](https://github.com/stephenberry/hdf5-pure/issues/331)).
 - **Breaking:** Overwriting or appending to such a dataset is refused too, instead of writing the new elements into the HDF5 file and leaving it disagreeing with the external files about where the data is — a write that reported `Ok` and was then visible to neither library. Attribute edits are unaffected, and deleting and recreating the dataset in one commit replaces it ([#331](https://github.com/stephenberry/hdf5-pure/issues/331)).
 - **Breaking:** `repack` refuses a dataset whose data lives in external files (`H5Pset_external`) instead of returning `Ok` having written a copy with none of it. Such a dataset carries the same undefined data address a never-written one does, and this crate does not follow the external files ([#293](https://github.com/stephenberry/hdf5-pure/issues/293)).

--- a/docs/guide/writing.md
+++ b/docs/guide/writing.md
@@ -176,6 +176,8 @@ builder
 
 `with_chunks` is required here rather than optional: auto-chunking derives the chunk from the shape, and a zero-element shape has nothing to derive from. Leaving it out is refused with `FormatError::InvalidChunkGeometry`.
 
+A zero-element shape and staged element data are refused together, with `FormatError::ShapeDataMismatch`: the shape declares nowhere for the data to go. Pass an empty slice or leave the data out entirely, as both examples above do.
+
 ## Serializing: `finish()` vs `write(path)`
 
 When the file is fully assembled, choose how to materialize it:

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1732,11 +1732,27 @@ impl FileWriter {
             let declared_contiguous_len = if unallocated { extent } else { region_len };
             // Guard against a shape that disagrees with the supplied data:
             // without this, a mismatch (data for 3 elements with shape `[2, 2]`)
-            // would produce a file that fails to read back. A verbatim-chunk
+            // would produce a file that fails to read back. A zero-element shape
+            // is held to that rule rather than exempted from it (issue #332): its
+            // extent is 0, so bytes staged beside it disagree with it like any
+            // other mismatch, and exempting them wrote a file the reference
+            // library refuses to open — twelve bytes of elements at a defined
+            // address under a dataspace declaring none, which our own reader
+            // answers `Ok([])` for without ever looking at the region. A chunked
+            // dataset of that shape had the milder version of the same fault: an
+            // empty chunk grid, so the staged bytes went nowhere and the caller
+            // was told `Ok`. The in-place writer refuses both already
+            // (`edit::flatten_dataset`, which shares this function's name and
+            // holds the same invariant with its own error type), and this is the
+            // same refusal on the whole-file path.
+            //
+            // Staging *no* data for a zero-element shape stays legal, which is
+            // what the `is_empty` bypass above is for: `region_len` and `extent`
+            // are both 0 there, so this comparison passes. A verbatim-chunk
             // dataset has no flat region to compare, and an unallocated one
             // stages no bytes to disagree with its shape — the whole point is
             // that the two do not have to match.
-            if !is_empty && !unallocated && raw_chunks.is_none() && region_len != extent {
+            if !unallocated && raw_chunks.is_none() && region_len != extent {
                 #[expect(
                     clippy::cast_possible_truncation,
                     reason = "byte counts reported in a shape-mismatch error; display-only"

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -2320,6 +2320,14 @@ impl DatasetBuilder {
         self
     }
 
+    /// Declare the dataset's dimensions.
+    ///
+    /// The shape and the staged element data have to agree on the element
+    /// count, or the write is refused with
+    /// [`FormatError::ShapeDataMismatch`](crate::FormatError::ShapeDataMismatch).
+    /// A shape holding a zero dimension declares no elements and is held to that
+    /// same rule: stage an empty slice, or no data at all beside a
+    /// [`with_dtype`](Self::with_dtype), rather than data with nowhere to go.
     pub fn with_shape(&mut self, shape: &[u64]) -> &mut Self {
         self.shape = Some(shape.to_vec());
         self

--- a/tests/write_read_roundtrip.rs
+++ b/tests/write_read_roundtrip.rs
@@ -1,6 +1,6 @@
 use hdf5_pure::{
     AttrValue, CompoundTypeBuilder, DType, Datatype, Error, File, FileBuilder, FormatError,
-    make_f64_type,
+    make_f64_type, make_i32_type,
 };
 
 #[test]
@@ -1230,6 +1230,150 @@ fn shape_data_mismatch_is_rejected() {
         }
         other => panic!("expected ShapeDataMismatch, got {other:?}"),
     }
+}
+
+/// A zero-element shape is held to the same shape/data agreement every other
+/// shape is (issue #332), rather than exempted from it.
+///
+/// The exemption wrote the one combination that cannot be written correctly.
+/// Contiguously it put the staged bytes at a defined address under a dataspace
+/// declaring no elements, which the reference library calls corruption and
+/// refuses to open, and which this crate's own reader answers `Ok([])` for
+/// without ever looking at the region. Chunked it produced a grid of no chunks,
+/// so the bytes went nowhere and the caller was told `Ok`.
+///
+/// Swept over every way to reach the shape rather than over one picked case:
+/// the guard is a single condition, and each arm has to land on the same side
+/// of it. The reference library's verdict on the file the exemption wrote is
+/// recorded in the issue rather than kept as a fixture here — the writer can no
+/// longer produce it, which is the point.
+#[test]
+fn zero_element_shape_with_data_is_rejected() {
+    for shape in [&[0u64][..], &[0, 3][..], &[3, 0][..]] {
+        for chunked in [false, true] {
+            let mut builder = FileBuilder::new();
+            {
+                let db = builder
+                    .create_dataset("bad")
+                    .with_i32_data(&[1, 2, 3])
+                    .with_shape(shape);
+                if chunked {
+                    db.with_chunks(&[2, 2][..shape.len()]);
+                }
+            }
+            let case = format!("shape {shape:?}, chunked {chunked}");
+            match builder.finish() {
+                Err(Error::Format(FormatError::ShapeDataMismatch {
+                    expected,
+                    actual,
+                    element_size,
+                })) => {
+                    assert_eq!(expected, 0, "{case}: the shape holds no elements");
+                    assert_eq!(actual, 3 * 4, "{case}: three i32 were supplied");
+                    assert_eq!(element_size.get(), 4, "{case}");
+                }
+                other => panic!("{case}: expected ShapeDataMismatch, got {other:?}"),
+            }
+        }
+    }
+}
+
+/// Staging no data for a zero-element shape stays legal, which is the half of
+/// the guard the refusal above must not take with it: both the extent and the
+/// staged region are zero bytes there, so they agree.
+///
+/// Swept over how the emptiness is declared as well as over the shape. The two
+/// are not the same case: staging an empty slice satisfies the writer's
+/// "a dataset has data" requirement outright, while omitting the data reaches it
+/// through the zero-element exemption, and only the second reads the shape to
+/// decide. A sweep that fixed this axis at the empty slice passed unchanged
+/// with the exemption narrowed to the *first* dimension, which would have made
+/// a `[3, 0]` dataset with no data fail as one missing its data.
+#[test]
+fn zero_element_shape_without_data_is_accepted() {
+    for shape in [&[0u64][..], &[0, 3][..], &[3, 0][..]] {
+        for chunked in [false, true] {
+            for staged_empty_slice in [false, true] {
+                let mut builder = FileBuilder::new();
+                {
+                    let db = builder.create_dataset("empty");
+                    if staged_empty_slice {
+                        db.with_i32_data(&[]);
+                    } else {
+                        db.with_dtype(make_i32_type());
+                    }
+                    db.with_shape(shape);
+                    if chunked {
+                        db.with_chunks(&[2, 2][..shape.len()]);
+                    }
+                }
+                let case =
+                    format!("shape {shape:?}, chunked {chunked}, slice {staged_empty_slice}");
+                let bytes = builder.finish().unwrap_or_else(|e| panic!("{case}: {e}"));
+                let file = File::from_bytes(bytes).unwrap();
+                let ds = file.dataset("empty").unwrap();
+                assert_eq!(ds.shape().unwrap(), shape.to_vec(), "{case}");
+                assert_eq!(ds.read_i32().unwrap(), Vec::<i32>::new(), "{case}");
+                if !chunked {
+                    // The contrast with the refused case, stated as a layout: an
+                    // empty dataset names no data region at all. The exempted write
+                    // named one of twelve bytes at a defined address, which is the
+                    // thing the reference library refuses to open.
+                    assert_eq!(
+                        ds.layout().unwrap(),
+                        hdf5_pure::Layout::Contiguous {
+                            address: None,
+                            size: 0
+                        },
+                        "{case}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The refusal lands before any byte reaches the filesystem, which is what
+/// decides whether it destroys the file it was overwriting.
+///
+/// `FileBuilder::write` creates its path on the first byte emitted rather than
+/// up front, so a build refused before that point leaves the destination alone
+/// while one refused during layout still leaves a partial file. That mechanism
+/// is pinned elsewhere (`file_properties`, `attr_message_size_limit`); what this
+/// adds is that *this* guard is among the refusals that reach it, which nothing
+/// about where it sits in `flatten_dataset` says on its own.
+#[test]
+fn a_rejected_zero_element_write_leaves_the_destination_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("target.h5");
+
+    let mut good = FileBuilder::new();
+    good.create_dataset("keep").with_i32_data(&[1, 2, 3]);
+    good.write(&path).unwrap();
+    let before = std::fs::read(&path).unwrap();
+
+    let mut bad = FileBuilder::new();
+    bad.create_dataset("bad")
+        .with_i32_data(&[1, 2, 3])
+        .with_shape(&[0]);
+    bad.write(&path).unwrap_err();
+
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        before,
+        "a refused write must not disturb the file it was overwriting"
+    );
+
+    let fresh = dir.path().join("never.h5");
+    let mut bad = FileBuilder::new();
+    bad.create_dataset("bad")
+        .with_i32_data(&[1, 2, 3])
+        .with_shape(&[0]);
+    bad.write(&fresh).unwrap_err();
+    assert!(
+        !fresh.exists(),
+        "a refused write must not leave a stub behind"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #332.

`FileBuilder` exempted a shape holding a `0` from the check that the staged element data agrees with it, and so accepted the one combination that cannot be written correctly.

Contiguously it wrote the staged bytes at a defined address under a dataspace declaring no elements — `layout()` reported `Contiguous { address: Some(174), size: 12 }` for a shape of `[0]` — which the reference library refuses to open with "invalid dataset size, likely file corruption". This crate's own reader answers `Ok([])` from the dataspace and never looks at the region, so nothing in the suite noticed. Chunked, the same staging produced a grid of no chunks: the three staged values went nowhere and the caller was told `Ok`.

## The fix

Dropping `!is_empty &&` from the guard in `file_writer.rs::flatten_dataset` is the whole change. A zero-element shape has an extent of 0, so bytes staged beside it are a disagreement like any other, and `ShapeDataMismatch` already carries the right fields (`expected: 0, actual: 12`).

Two things this deliberately leaves alone. The separate `is_empty` bypass above the guard — the one that lets an empty dataset stage no data — is untouched, since extent and region are both zero bytes there and they agree. And the in-place writer's own `flatten_dataset` (same function name, its own error type) has refused both cases since empty datasets became addable in place in #133, so this brings the whole-file path in line with an existing rule rather than inventing one.

## Mutation results

Every arm was verified by breaking the code and watching the right test fail, across all 2,323 tests:

| mutation | failures |
| --- | --- |
| restore the `is_empty` exemption | 2, both new |
| also refuse an empty shape with *no* data | 100+ — the over-refusal direction was already well guarded |
| give an empty contiguous region a defined address | 3, one new (the layout assertion) |
| narrow `is_empty` to the first dimension | **1, mine alone** |

That last row is why the acceptance test sweeps *how* emptiness is declared and not only the shape. The first version fixed that axis at `with_i32_data(&[])` and passed the mutation unchanged: an empty slice satisfies the writer's "has data" requirement outright, so only the no-data-at-all arm consults the shape, and a `[3, 0]` dataset with no data would have begun failing as one missing its data. Nothing else in the suite covers that.

## Tests

Three in `tests/write_read_roundtrip.rs`: the refusal (3 shapes × 2 layouts), its converse (3 shapes × 2 layouts × 2 ways of declaring empty, pinning `Contiguous { address: None, size: 0 }` as the contrast with the 12-byte region), and one that a refused `write` leaves the file it was overwriting byte-identical.

Not added: a crosscheck proving the C library rejects what is now refused. The writer can no longer produce that file, so it would need a hand-built fixture asserting a fact about libhdf5 rather than about this crate; the measurement is in #332 and in the commit message instead.

No version bump — the break is behavioral, not an API-shape change.