### PR TITLE
Give every fixture a directory of its own (#334)

### DIFF
--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -4825,7 +4825,8 @@ mod tests {
             .with_shape(&[30])
             .with_chunks(&[10]);
         let bytes = fw.finish().unwrap();
-        let path = std::env::temp_dir().join("rustyhdf5_chunked_multi.h5");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rustyhdf5_chunked_multi.h5");
         std::fs::write(&path, &bytes).unwrap();
         let script = "import sys,h5py,json; f=h5py.File(sys.argv[1],'r'); print(json.dumps({'a':f['a'][:].tolist(),'b':f['b'][:].tolist()}))";
         let Some(out) = h5py_run(&path, script) else {
@@ -4850,7 +4851,8 @@ mod tests {
             .with_chunks(&[25])
             .set_attr("units", AttrValue::String("meters".to_string()));
         let bytes = fw.finish().unwrap();
-        let path = std::env::temp_dir().join("rustyhdf5_chunked_attrs.h5");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rustyhdf5_chunked_attrs.h5");
         std::fs::write(&path, &bytes).unwrap();
         let script = "import sys,h5py,json; f=h5py.File(sys.argv[1],'r'); d=f['data']; print(json.dumps({'values':d[:].tolist(),'units':d.attrs['units'].decode() if isinstance(d.attrs['units'],bytes) else str(d.attrs['units'])}))";
         let Some(out) = h5py_run(&path, script) else {

--- a/src/mat/builder.rs
+++ b/src/mat/builder.rs
@@ -1921,12 +1921,15 @@ mod tests {
     use crate::reader::File;
     use crate::types::AttrValue as ReaderAttr;
 
-    fn temp_path(name: &str) -> std::path::PathBuf {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("hdf5pure-mat-{name}-{nanos}.mat"))
+    /// A `.mat` fixture in a directory of its own. The directory goes away with
+    /// the returned value, so bind it for as long as the file is needed.
+    ///
+    /// Replaces a nanosecond-stamped name in the shared temporary directory,
+    /// which no two runs collided on but no run ever cleaned up (issue #334).
+    fn temp_path(name: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("hdf5pure-mat-{name}.mat"));
+        (dir, path)
     }
 
     fn read_class(file: &File, ds_path: &str) -> String {
@@ -1944,7 +1947,7 @@ mod tests {
         mb.write_scalar_f64("x", 1.5).unwrap();
         let bytes = mb.finish().unwrap();
 
-        let path = temp_path("scalar-f64");
+        let (_dir, path) = temp_path("scalar-f64");
         std::fs::write(&path, &bytes).unwrap();
         let file = File::open(&path).unwrap();
         let ds = file.dataset("x").unwrap();
@@ -1964,7 +1967,7 @@ mod tests {
         .unwrap();
         let bytes = mb.finish().unwrap();
 
-        let path = temp_path("struct");
+        let (_dir, path) = temp_path("struct");
         std::fs::write(&path, &bytes).unwrap();
         let file = File::open(&path).unwrap();
         let group = file.group("payload").unwrap();
@@ -1989,7 +1992,7 @@ mod tests {
         .unwrap();
         let bytes = mb.finish().unwrap();
 
-        let path = temp_path("cell");
+        let (_dir, path) = temp_path("cell");
         std::fs::write(&path, &bytes).unwrap();
         let file = File::open(&path).unwrap();
         let cls = read_class(&file, "c");

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -1857,7 +1857,8 @@ mod tests {
         use crate::reader::File;
         use crate::writer::FileBuilder;
 
-        let dir = std::env::temp_dir();
+        let dir = tempfile::tempdir().unwrap();
+        let dir = dir.path();
         let src = dir.join("hdf5_pure_repack_time_src.h5");
         let dst = dir.join("hdf5_pure_repack_time_dst.h5");
 

--- a/tests/common/temp_fixture.rs
+++ b/tests/common/temp_fixture.rs
@@ -1,0 +1,83 @@
+//! Fixture paths that two concurrent runs of the suite cannot collide on
+//! (issue #334).
+//!
+//! Included with `#[path = "common/temp_fixture.rs"] mod temp_fixture;` rather
+//! than through `common/mod.rs`, for the reason `common/allocation.rs` gives: a
+//! binary that names that module links a static libhdf5 it has no use for. This
+//! one is `std` plus `tempfile`.
+//!
+//! A fixture named directly in the shared system temporary directory resolves to
+//! the same path in every process, so two runs of the same test binary at once —
+//! two agents, two terminals, a `cargo test` beside a `cargo nextest run` — write
+//! over each other's files. The tests then fail in ways that read like real
+//! defects: measured before this helper landed, two concurrent runs of
+//! `edit_free_space` failed 16 and 19 of their 26 tests, every one of which
+//! passes alone. [`temp_path`] gives each call a directory of its own, so a
+//! fixture name only has to be unique within its test, and removes that
+//! directory when the test ends whether it passed, failed, or panicked.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+/// A fixture path inside a temporary directory owned by the test.
+///
+/// Stands in for the [`PathBuf`] a test would otherwise hold: it derefs to
+/// [`Path`] and implements `AsRef<Path>`, so `&path` reaches both the `&Path`
+/// parameters and the `impl AsRef<Path>` ones without a conversion at the call
+/// site.
+pub struct TempPath {
+    /// Held for its `Drop`, which removes the directory and everything written
+    /// inside it. Never read — the `path` beside it already names the fixture.
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+/// A path named `name` in a temporary directory created for this call.
+///
+/// Bind the result for as long as the file is needed. The directory is removed
+/// when the returned value drops, so passing this straight into a call rather
+/// than through a `let` leaves nothing behind for the next statement to open.
+pub fn temp_path(name: &str) -> TempPath {
+    let dir = tempfile::tempdir().expect("create a temporary directory for a fixture");
+    fixture_in(dir, name)
+}
+
+/// The same, with the temporary directory created inside `parent`.
+///
+/// For the tests that keep their fixtures in the repository's gitignored `tmp/`
+/// rather than the system temporary directory. `parent` has to exist.
+pub fn temp_path_in(parent: &Path, name: &str) -> TempPath {
+    let dir = tempfile::TempDir::new_in(parent).unwrap_or_else(|e| {
+        panic!(
+            "create a temporary directory under {}: {e}",
+            parent.display()
+        )
+    });
+    fixture_in(dir, name)
+}
+
+fn fixture_in(dir: tempfile::TempDir, name: &str) -> TempPath {
+    let path = dir.path().join(name);
+    TempPath { _dir: dir, path }
+}
+
+impl std::ops::Deref for TempPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for TempPath {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::fmt::Debug for TempPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.path, f)
+    }
+}

--- a/tests/edit_free_space.rs
+++ b/tests/edit_free_space.rs
@@ -11,9 +11,9 @@ use hdf5_pure::{
     MemoryStrategy,
 };
 
-fn tmp(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(name)
-}
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
 
 /// The superblock's end-of-file must equal the actual file length after every
 /// commit, including ones that truncate.
@@ -29,7 +29,7 @@ fn assert_eof_matches_file(path: &std::path::Path) {
 
 #[test]
 fn delete_then_truncate_shrinks_within_session() {
-    let path = tmp("hdf5_pure_fs_shrink.h5");
+    let path = temp_path("hdf5_pure_fs_shrink.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep")
         .with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
@@ -67,12 +67,11 @@ fn delete_then_truncate_shrinks_within_session() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert!(file.dataset("big").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn churn_within_session_stays_bounded() {
-    let path = tmp("hdf5_pure_fs_churn.h5");
+    let path = temp_path("hdf5_pure_fs_churn.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.write(&path).unwrap();
@@ -111,12 +110,11 @@ fn churn_within_session_stays_bounded() {
         file.dataset("keep").unwrap().read_i32().unwrap(),
         vec![1, 2, 3]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn reuse_keeps_survivors_byte_exact() {
-    let path = tmp("hdf5_pure_fs_reuse_exact.h5");
+    let path = temp_path("hdf5_pure_fs_reuse_exact.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("a").with_i32_data(&[10, 20, 30]);
     b.create_dataset("b").with_f64_data(&[1.5, 2.5]);
@@ -150,12 +148,11 @@ fn reuse_keeps_survivors_byte_exact() {
         vec![7, 8, 9, 10]
     );
     assert!(file.dataset("b").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn delete_subtree_reclaims_all_members() {
-    let path = tmp("hdf5_pure_fs_subtree.h5");
+    let path = temp_path("hdf5_pure_fs_subtree.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1]);
     b.write(&path).unwrap();
@@ -191,7 +188,6 @@ fn delete_subtree_reclaims_all_members() {
     let file = File::open(&path).unwrap();
     assert!(file.group("grp").is_err());
     assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![1]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -206,7 +202,7 @@ fn trailing_slack_past_recorded_eof_stays_readable() {
     // (It exercises the *outcome* of the ordering, not the ordering itself —
     // fault-injecting between the superblock sync and `set_len` would need a seam
     // File::open_rw does not yet expose, and remains future work.)
-    let path = tmp("hdf5_pure_fs_trailing_slack.h5");
+    let path = temp_path("hdf5_pure_fs_trailing_slack.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[11, 22, 33]);
     b.write(&path).unwrap();
@@ -268,7 +264,6 @@ fn trailing_slack_past_recorded_eof_stays_readable() {
         vec![11, 22, 33]
     );
     assert!(f.dataset("scratch").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -277,7 +272,7 @@ fn deleting_filtered_chunked_dataset_reclaims_storage() {
     // blocks plus the FAHD/FADB index — is now reclaimed on delete. Deleting it
     // shrinks the file below its size with the dataset present, the survivor
     // stays byte-exact, and the file stays valid.
-    let path = tmp("hdf5_pure_fs_chunked_filtered.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_filtered.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[42, 43, 44]);
     b.write(&path).unwrap();
@@ -317,7 +312,6 @@ fn deleting_filtered_chunked_dataset_reclaims_storage() {
         vec![42, 43, 44]
     );
     assert!(file.dataset("comp").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -326,7 +320,7 @@ fn deleting_unfiltered_chunked_dataset_truncates_fully() {
     // data followed by the Fixed Array index, nothing between). Adding it at
     // end-of-file then deleting it in the same session reclaims the whole blob as
     // a trailing run, truncating the file back to essentially its prior size.
-    let path = tmp("hdf5_pure_fs_chunked_unfiltered.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_unfiltered.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.write(&path).unwrap();
@@ -365,7 +359,6 @@ fn deleting_unfiltered_chunked_dataset_truncates_fully() {
         vec![1, 2, 3]
     );
     assert!(file.dataset("big").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -374,7 +367,7 @@ fn deleting_paged_fixed_array_dataset_reclaims_storage() {
     // layout (a page-init bitmap and per-page checksums). 1100 chunks of 16 f64
     // exercise that index-sizing path end to end: the whole index plus chunk
     // data is reclaimed on delete.
-    let path = tmp("hdf5_pure_fs_paged_fa.h5");
+    let path = temp_path("hdf5_pure_fs_paged_fa.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[7]);
     b.write(&path).unwrap();
@@ -408,7 +401,6 @@ fn deleting_paged_fixed_array_dataset_reclaims_storage() {
     assert_eq!(file.root().datasets().unwrap(), vec!["keep".to_string()]);
     assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![7]);
     assert!(file.dataset("paged").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -416,7 +408,7 @@ fn deleting_extensible_dataset_reclaims_storage() {
     // A dataset with an unlimited maximum dimension uses an Extensible Array chunk
     // index (EAHD/EAIB and, past the inline slots, data blocks). Deleting it
     // reclaims the whole index plus its chunk data.
-    let path = tmp("hdf5_pure_fs_extensible.h5");
+    let path = temp_path("hdf5_pure_fs_extensible.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[9]);
     b.write(&path).unwrap();
@@ -452,7 +444,6 @@ fn deleting_extensible_dataset_reclaims_storage() {
     assert_eq!(file.root().datasets().unwrap(), vec!["keep".to_string()]);
     assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![9]);
     assert!(file.dataset("ext").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -460,7 +451,7 @@ fn deleting_single_chunk_dataset_reclaims_storage() {
     // A dataset whose single chunk covers the whole shape uses the single-chunk
     // index (the chunk address lives in the layout message, no separate index
     // structure). Deleting it reclaims that one chunk block.
-    let path = tmp("hdf5_pure_fs_single_chunk.h5");
+    let path = temp_path("hdf5_pure_fs_single_chunk.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[5, 6]);
     b.write(&path).unwrap();
@@ -500,14 +491,13 @@ fn deleting_single_chunk_dataset_reclaims_storage() {
         vec![5, 6]
     );
     assert!(file.dataset("one").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn chunked_churn_within_session_stays_bounded() {
     // Repeatedly add then delete a sizable chunked dataset in one session. With
     // chunk + index reclaim and reuse the file must not grow without bound.
-    let path = tmp("hdf5_pure_fs_chunked_churn.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_churn.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.write(&path).unwrap();
@@ -543,14 +533,13 @@ fn chunked_churn_within_session_stays_bounded() {
         file.dataset("keep").unwrap().read_i32().unwrap(),
         vec![1, 2, 3]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn deleting_subtree_with_chunked_members_reclaims() {
     // Deleting a group reclaims its chunked-dataset members' storage too (the
     // free walk descends the subtree).
-    let path = tmp("hdf5_pure_fs_chunked_subtree.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_subtree.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1]);
     b.write(&path).unwrap();
@@ -587,14 +576,13 @@ fn deleting_subtree_with_chunked_members_reclaims() {
     let file = File::open(&path).unwrap();
     assert!(file.group("grp").is_err());
     assert_eq!(file.dataset("keep").unwrap().read_i32().unwrap(), vec![1]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn persisted_chunked_reclaim_is_disjoint_and_reusable() {
     // With persistence on, deleting a chunked dataset records its storage as
     // free sections that stay disjoint and are reused across reopen.
-    let path = tmp("hdf5_pure_fs_chunked_persist.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_persist.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1; 50]);
     b.create_dataset("comp")
@@ -623,7 +611,6 @@ fn persisted_chunked_reclaim_is_disjoint_and_reusable() {
     }
     assert_eq!(f.dataset("keep").unwrap().read_i32().unwrap(), vec![1; 50]);
     assert!(f.dataset("comp").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -632,7 +619,7 @@ fn persisted_free_space_survives_reopen_and_is_reused() {
     // (the FSHD/FSSE managers), so a freed region survives close/reopen and a
     // later session reuses it instead of growing the file. This is the cross-
     // session counterpart to the within-session reuse above.
-    let path = tmp("hdf5_pure_fs_persist_roundtrip.h5");
+    let path = temp_path("hdf5_pure_fs_persist_roundtrip.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("a").with_i32_data(&[1; 100]);
     b.create_dataset("big").with_i32_data(&[7; 400]); // 1600 bytes of raw data
@@ -690,7 +677,6 @@ fn persisted_free_space_survives_reopen_and_is_reused() {
     assert_eq!(f.dataset("c").unwrap().read_i32().unwrap(), vec![3; 100]);
     // Persistence remains armed: the file still records its free space on disk.
     assert!(f.file_space_info().unwrap().persist);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -699,7 +685,7 @@ fn persisted_managers_stay_consistent_across_many_commits() {
     // managers and extension, recording them as free, so the file stays valid and
     // its tracked free space never double-counts or loses a region. Both this
     // crate and a fresh reader must agree on the result after every step.
-    let path = tmp("hdf5_pure_fs_persist_multi.h5");
+    let path = temp_path("hdf5_pure_fs_persist_multi.h5");
     let mut b = FileBuilder::new();
     for i in 0..6 {
         b.create_dataset(&format!("d{i}"))
@@ -749,7 +735,6 @@ fn persisted_managers_stay_consistent_across_many_commits() {
         );
     }
     assert!(f.dataset("d0").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 /// The bytes a chunked dataset of `elems` `f64` elements occupies, near enough:
@@ -768,7 +753,7 @@ fn chunked_dataset_reuses_the_hole_a_chunked_delete_left() {
     //
     // The hole is interior on purpose: `tail` sits above the deleted dataset, so
     // truncation cannot be what keeps the file small.
-    let path = tmp("hdf5_pure_fs_chunked_reuse.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_reuse.h5");
     const ELEMS: usize = 32768; // 256 KiB of raw data
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
@@ -810,7 +795,6 @@ fn chunked_dataset_reuses_the_hole_a_chunked_delete_left() {
     );
     assert_eq!(f.dataset("tail").unwrap().read_i32().unwrap(), vec![9; 16]);
     assert!(f.dataset("big").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -818,7 +802,7 @@ fn filtered_chunked_dataset_reuses_freed_space() {
     // Same as above for a *filtered* dataset, whose compressed size is not known
     // until the pipeline has run: the placement is chosen from the compressed
     // set's size, so the filter pass still happens exactly once.
-    let path = tmp("hdf5_pure_fs_chunked_reuse_filtered.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_reuse_filtered.h5");
     const ELEMS: usize = 32768;
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
@@ -859,7 +843,6 @@ fn filtered_chunked_dataset_reuses_freed_space() {
         (0..ELEMS).map(|i| i as f64).collect::<Vec<f64>>()
     );
     assert_eq!(f.dataset("tail").unwrap().read_i32().unwrap(), vec![9; 16]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -868,7 +851,7 @@ fn reusing_a_chunked_hole_keeps_its_neighbors_byte_exact() {
     // happens to the *live* bytes on either side of it. Both neighbors — one
     // below the hole, one above — must read back exactly, and every chunk of the
     // dataset written into the hole must too.
-    let path = tmp("hdf5_pure_fs_chunked_reuse_neighbors.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_reuse_neighbors.h5");
     const ELEMS: usize = 16384;
     let below: Vec<f64> = (0..2048).map(|i| i as f64 * 0.5).collect();
     let above: Vec<i32> = (0..2048).map(|i| i * 3).collect();
@@ -898,7 +881,6 @@ fn reusing_a_chunked_hole_keeps_its_neighbors_byte_exact() {
     assert_eq!(f.dataset("below").unwrap().read_f64().unwrap(), below);
     assert_eq!(f.dataset("above").unwrap().read_i32().unwrap(), above);
     assert_eq!(f.dataset("fresh").unwrap().read_f64().unwrap(), replacement);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -910,7 +892,7 @@ fn paged_commit_reuses_freed_space_within_its_page_type() {
     // The file stays valid and every page stays homogeneous — the crosscheck
     // suite reads these files with the reference C library, which is where a
     // mixed page would show up.
-    let path = tmp("hdf5_pure_fs_paged_reuse.h5");
+    let path = temp_path("hdf5_pure_fs_paged_reuse.h5");
     const ELEMS: usize = 32768;
     let mut b = FileBuilder::new();
     b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1);
@@ -952,7 +934,6 @@ fn paged_commit_reuses_freed_space_within_its_page_type() {
         vec![1, 2, 3]
     );
     assert_eq!(f.dataset("tail").unwrap().read_i32().unwrap(), vec![9; 16]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -961,7 +942,7 @@ fn persisted_chunked_free_space_is_reused_after_a_reopen() {
     // one writes a fresh one. The second session only knows about the hole from
     // the on-disk managers it seeds its free list from, so this pins the seeding
     // and the chunked placement together.
-    let path = tmp("hdf5_pure_fs_chunked_persist_reuse.h5");
+    let path = temp_path("hdf5_pure_fs_chunked_persist_reuse.h5");
     const ELEMS: usize = 32768;
     let mut b = FileBuilder::new();
     b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
@@ -1005,7 +986,6 @@ fn persisted_chunked_free_space_is_reused_after_a_reopen() {
         f.dataset("keep").unwrap().read_i32().unwrap(),
         vec![1, 2, 3]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -1020,7 +1000,7 @@ fn both_read_write_backings_reuse_a_freed_hole_alike() {
         ("hdf5_pure_fs_backing_bounded.h5", MemoryStrategy::Bounded),
         ("hdf5_pure_fs_backing_mirrored.h5", MemoryStrategy::Mirrored),
     ] {
-        let path = tmp(name);
+        let path = temp_path(name);
         let mut b = FileBuilder::new();
         b.create_dataset("big")
             .with_f64_data(&vec![1.0; ELEMS])
@@ -1066,7 +1046,6 @@ fn both_read_write_backings_reuse_a_freed_hole_alike() {
             vec![2.0; ELEMS]
         );
         assert_eq!(f.dataset("tail").unwrap().read_i32().unwrap(), vec![9; 16]);
-        std::fs::remove_file(&path).ok();
     }
 }
 
@@ -1081,7 +1060,7 @@ fn churn_of_groups_attributes_and_datasets_stays_bounded() {
     // A "ceiling" dataset written above the first round is what makes this a test
     // of *reuse*. Without it every freed round would reach end-of-file and be
     // truncated away, which keeps the file just as small while reusing nothing.
-    let path = tmp("hdf5_pure_fs_full_churn.h5");
+    let path = temp_path("hdf5_pure_fs_full_churn.h5");
     const ROUNDS: usize = 5;
     const GROUPS: usize = 4;
     const ELEMS: usize = 8192; // 64 KiB per dataset
@@ -1185,7 +1164,6 @@ fn churn_of_groups_attributes_and_datasets_stays_bounded() {
             );
         }
     }
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -1194,7 +1172,7 @@ fn corrupt_persisted_section_is_skipped_not_fatal() {
     // section claims a region past end-of-file, seeding it and later handing it
     // out would write out of bounds. The editor skips such a section instead, so
     // the open + commit still succeeds and the live data stays intact.
-    let path = tmp("hdf5_pure_fs_persist_corrupt.h5");
+    let path = temp_path("hdf5_pure_fs_persist_corrupt.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[5; 50]);
     b.create_dataset("victim").with_i32_data(&[6; 300]); // 1200-byte data block
@@ -1255,7 +1233,6 @@ fn corrupt_persisted_section_is_skipped_not_fatal() {
         f.dataset("added").unwrap().read_i32().unwrap(),
         vec![9; 250]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A paged file under delete-and-recreate churn stops growing rather than
@@ -1279,8 +1256,7 @@ fn paged_churn_reaches_a_steady_size() {
     const ROUNDS: usize = 12;
     const LIVE: usize = 2;
 
-    let path = tmp("hdf5_pure_fs_paged_churn.h5");
-    let _ = std::fs::remove_file(&path);
+    let path = temp_path("hdf5_pure_fs_paged_churn.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("seed").with_i32_data(&[0i32; 4]);
     b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1)
@@ -1356,7 +1332,6 @@ fn paged_churn_reaches_a_steady_size() {
     }
     drop(f);
     assert_eof_matches_file(&path);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A paged commit's tail — the rewritten extension and manager blocks — is
@@ -1372,8 +1347,7 @@ fn paged_churn_reaches_a_steady_size() {
 #[test]
 fn a_paged_commit_tail_is_placed_in_free_space() {
     const PAGE: u64 = 16384;
-    let path = tmp("hdf5_pure_fs_paged_tail_reuse.h5");
-    let _ = std::fs::remove_file(&path);
+    let path = temp_path("hdf5_pure_fs_paged_tail_reuse.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("seed").with_i32_data(&[0i32; 4]);
     b.with_file_space_strategy(FileSpaceStrategy::Page, true, 1)
@@ -1431,7 +1405,6 @@ fn a_paged_commit_tail_is_placed_in_free_space() {
         }
     }
     assert_eof_matches_file(&path);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Across a sweep of layouts, a paged commit that rewrites only its tail
@@ -1450,8 +1423,7 @@ fn a_paged_commit_tail_is_placed_in_free_space() {
 fn a_paged_tail_conserves_free_space_across_layouts() {
     const PAGE: u64 = 16384;
     for filler in 0..64usize {
-        let path = tmp(&format!("hdf5_pure_fs_paged_sweep_{filler}.h5"));
-        let _ = std::fs::remove_file(&path);
+        let path = temp_path(&format!("hdf5_pure_fs_paged_sweep_{filler}.h5"));
         let mut b = FileBuilder::new();
         b.create_dataset("seed")
             .with_i32_data(&(0..100 + filler as i32).collect::<Vec<i32>>());
@@ -1482,6 +1454,5 @@ fn a_paged_tail_conserves_free_space_across_layouts() {
             "filler {filler}: rewriting the tail must conserve free space, not \
              quietly retire some of it (totals {totals:?})"
         );
-        std::fs::remove_file(&path).ok();
     }
 }

--- a/tests/edit_in_place.rs
+++ b/tests/edit_in_place.rs
@@ -6,6 +6,10 @@ use hdf5_pure::{
     FormatError, Object, ReferenceType, ScaleOffset, StringPadding,
 };
 
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
+
 /// Write a starter file with one dataset, returning its path.
 fn write_starter(path: &std::path::Path) {
     let mut b = FileBuilder::new();
@@ -16,7 +20,7 @@ fn write_starter(path: &std::path::Path) {
 
 #[test]
 fn add_dataset_preserves_original_and_adds_new() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_one.h5");
+    let path = temp_path("hdf5_pure_edit_add_one.h5");
     write_starter(&path);
     let size_before = std::fs::metadata(&path).unwrap().len();
 
@@ -49,13 +53,11 @@ fn add_dataset_preserves_original_and_adds_new() {
     let mut names = file.root().datasets().unwrap();
     names.sort();
     assert_eq!(names, vec!["added".to_string(), "original".to_string()]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_multiple_datasets_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_many.h5");
+    let path = temp_path("hdf5_pure_edit_add_many.h5");
     write_starter(&path);
 
     {
@@ -88,12 +90,11 @@ fn add_multiple_datasets_in_one_commit() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn successive_commits_accumulate() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_successive.h5");
+    let path = temp_path("hdf5_pure_edit_successive.h5");
     write_starter(&path);
 
     {
@@ -121,12 +122,11 @@ fn successive_commits_accumulate() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_dataset_with_multidim_shape() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_2d.h5");
+    let path = temp_path("hdf5_pure_edit_2d.h5");
     write_starter(&path);
 
     {
@@ -145,12 +145,11 @@ fn add_dataset_with_multidim_shape() {
     let m = file.dataset("matrix").unwrap();
     assert_eq!(m.shape().unwrap(), vec![2, 3]);
     assert_eq!(m.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn commit_without_staged_datasets_is_noop() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_noop.h5");
+    let path = temp_path("hdf5_pure_edit_noop.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -161,12 +160,11 @@ fn commit_without_staged_datasets_is_noop() {
 
     let after = std::fs::read(&path).unwrap();
     assert_eq!(before, after, "empty commit must not modify the file");
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn create_group_at_root() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_group.h5");
+    let path = temp_path("hdf5_pure_edit_group.h5");
     write_starter(&path);
 
     {
@@ -190,12 +188,11 @@ fn create_group_at_root() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_dataset_into_new_nested_group() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_nested.h5");
+    let path = temp_path("hdf5_pure_edit_nested.h5");
     write_starter(&path);
 
     {
@@ -223,12 +220,11 @@ fn add_dataset_into_new_nested_group() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_into_existing_group_across_commits() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_existing_group.h5");
+    let path = temp_path("hdf5_pure_edit_existing_group.h5");
     write_starter(&path);
 
     {
@@ -257,12 +253,11 @@ fn add_into_existing_group_across_commits() {
     let mut names = file.group("g").unwrap().datasets().unwrap();
     names.sort();
     assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_into_two_sibling_groups_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_siblings.h5");
+    let path = temp_path("hdf5_pure_edit_siblings.h5");
     write_starter(&path);
 
     {
@@ -287,12 +282,11 @@ fn add_into_two_sibling_groups_one_commit() {
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("x/d").unwrap().read_i32().unwrap(), vec![1]);
     assert_eq!(file.dataset("y/d").unwrap().read_i32().unwrap(), vec![2]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn dataset_into_missing_group_is_rejected() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_missing_group.h5");
+    let path = temp_path("hdf5_pure_edit_missing_group.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -308,12 +302,11 @@ fn dataset_into_missing_group_is_rejected() {
         assert!(err.to_string().contains("does not exist"), "got: {err}");
     }
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn duplicate_name_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_dup.h5");
+    let path = temp_path("hdf5_pure_edit_dup.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -349,13 +342,11 @@ fn duplicate_name_is_rejected_without_writing() {
         assert!(session.commit().is_err());
     }
     assert_eq!(std::fs::read(&path).unwrap(), before);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn delete_dataset_from_root() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_del_root.h5");
+    let path = temp_path("hdf5_pure_edit_del_root.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.create_dataset("remove").with_i32_data(&[9, 9]);
@@ -374,12 +365,11 @@ fn delete_dataset_from_root() {
         vec![1, 2, 3]
     );
     assert!(file.dataset("remove").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn delete_nested_group_subtree() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_del_nested.h5");
+    let path = temp_path("hdf5_pure_edit_del_nested.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -422,12 +412,11 @@ fn delete_nested_group_subtree() {
     roots.sort();
     assert_eq!(roots, vec!["original".to_string(), "sibling".to_string()]);
     assert!(file.root().groups().unwrap().is_empty());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn delete_one_of_nested_then_keep_group() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_del_one.h5");
+    let path = temp_path("hdf5_pure_edit_del_one.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -459,12 +448,11 @@ fn delete_one_of_nested_then_keep_group() {
         file.group("g").unwrap().datasets().unwrap(),
         vec!["b".to_string()]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_and_delete_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_del.h5");
+    let path = temp_path("hdf5_pure_edit_add_del.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("old").with_i32_data(&[1]);
     b.write(&path).unwrap();
@@ -485,12 +473,11 @@ fn add_and_delete_in_one_commit() {
     assert_eq!(file.root().datasets().unwrap(), vec!["new".to_string()]);
     assert_eq!(file.dataset("new").unwrap().read_i32().unwrap(), vec![2]);
     assert!(file.dataset("old").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn delete_missing_or_overlapping_is_rejected() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_del_reject.h5");
+    let path = temp_path("hdf5_pure_edit_del_reject.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -523,12 +510,11 @@ fn delete_missing_or_overlapping_is_rejected() {
         assert!(err.to_string().contains("overlaps"), "got: {err}");
     }
     assert_eq!(std::fs::read(&path).unwrap(), mid);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_dataset_to_new_name() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_ds.h5");
+    let path = temp_path("hdf5_pure_edit_copy_ds.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("src").with_f64_data(&[1.5, 2.5, 3.5]);
     b.write(&path).unwrap();
@@ -550,12 +536,11 @@ fn copy_dataset_to_new_name() {
         vec![1.5, 2.5, 3.5]
     );
     assert_eq!(file.dataset("dup").unwrap().dtype().unwrap(), DType::F64);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_group_subtree() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_grp.h5");
+    let path = temp_path("hdf5_pure_edit_copy_grp.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -602,12 +587,11 @@ fn copy_group_subtree() {
         file.dataset("template/a").unwrap().read_i32().unwrap(),
         vec![1, 2]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_into_subgroup() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_into.h5");
+    let path = temp_path("hdf5_pure_edit_copy_into.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("payload").with_i32_data(&[7, 8, 9]);
     b.write(&path).unwrap();
@@ -630,12 +614,11 @@ fn copy_into_subgroup() {
         file.dataset("payload").unwrap().read_i32().unwrap(),
         vec![7, 8, 9]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_rejects_missing_source_and_cycle() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_reject.h5");
+    let path = temp_path("hdf5_pure_edit_copy_reject.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -664,12 +647,11 @@ fn copy_rejects_missing_source_and_cycle() {
         assert!(err.to_string().contains("itself"), "got: {err}");
     }
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_dataset_with_attributes() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_attrs.h5");
+    let path = temp_path("hdf5_pure_edit_add_attrs.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -690,12 +672,11 @@ fn add_dataset_with_attributes() {
     let attrs = ds.attrs().unwrap();
     assert_eq!(attrs.get("count"), Some(&AttrValue::I64(2)));
     assert_eq!(attrs.get("unit"), Some(&AttrValue::String("m/s".into())));
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn create_group_with_attributes() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_group_attrs.h5");
+    let path = temp_path("hdf5_pure_edit_group_attrs.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -720,12 +701,11 @@ fn create_group_with_attributes() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn edit_existing_group_attributes() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_existing_group_attrs.h5");
+    let path = temp_path("hdf5_pure_edit_existing_group_attrs.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     g.set_attr("status", AttrValue::String("old".into()));
@@ -770,12 +750,11 @@ fn edit_existing_group_attributes() {
         file.root().attrs().unwrap().get("root_tag"),
         Some(&AttrValue::U64(9))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn group_attribute_edit_uses_final_compact_count() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_group_attr_final_count.h5");
+    let path = temp_path("hdf5_pure_edit_group_attr_final_count.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     for i in 0..8 {
@@ -804,12 +783,11 @@ fn group_attribute_edit_uses_final_compact_count() {
     assert_eq!(attrs.len(), 8);
     assert!(!attrs.contains_key("a0"));
     assert_eq!(attrs.get("new"), Some(&AttrValue::I64(99)));
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn remove_missing_group_attribute_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_missing_group_attr.h5");
+    let path = temp_path("hdf5_pure_edit_missing_group_attr.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     g.set_attr("present", AttrValue::I64(1));
@@ -829,12 +807,11 @@ fn remove_missing_group_attribute_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_variable_length_root_attribute_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_vlen_group_attr.h5");
+    let path = temp_path("hdf5_pure_edit_vlen_group_attr.h5");
     write_starter(&path);
 
     {
@@ -860,7 +837,6 @@ fn add_variable_length_root_attribute_via_edit_session() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -870,7 +846,7 @@ fn add_variable_length_group_attribute_then_remove_then_reset_in_one_commit() {
     // variable-length — exercising `apply_group_attr_ops`'s pending-VL-attr
     // bookkeeping (a plain region edit alone cannot represent an unresolved
     // variable-length attribute).
-    let path = std::env::temp_dir().join("hdf5_pure_edit_vlen_group_attr_sequence.h5");
+    let path = temp_path("hdf5_pure_edit_vlen_group_attr_sequence.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     g.set_attr(
@@ -911,7 +887,6 @@ fn add_variable_length_group_attribute_then_remove_then_reset_in_one_commit() {
             "new3".into()
         ]))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A `Set` with a variable-length value must correctly drop a *fixed-size*
@@ -921,7 +896,7 @@ fn add_variable_length_group_attribute_then_remove_then_reset_in_one_commit() {
 /// variable-length `Set` replacing a fixed-size value.
 #[test]
 fn set_variable_length_group_attribute_over_existing_fixed_attribute_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_vlen_group_attr_over_fixed.h5");
+    let path = temp_path("hdf5_pure_edit_vlen_group_attr_over_fixed.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     g.set_attr("fields", AttrValue::I64(42));
@@ -953,7 +928,6 @@ fn set_variable_length_group_attribute_over_existing_fixed_attribute_in_one_comm
             "new2".into()
         ]))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// The compact-attribute budget check counts *pending* variable-length
@@ -963,7 +937,7 @@ fn set_variable_length_group_attribute_over_existing_fixed_attribute_in_one_comm
 /// still succeed, with every value intact.
 #[test]
 fn add_variable_length_group_attributes_at_budget_boundary_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_vlen_group_attr_at_budget.h5");
+    let path = temp_path("hdf5_pure_edit_vlen_group_attr_at_budget.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     for i in 0..6i64 {
@@ -1010,7 +984,6 @@ fn add_variable_length_group_attributes_at_budget_boundary_in_one_commit() {
         attrs.get("b1"),
         Some(&AttrValue::VarLenAsciiArray(vec!["y0".into(), "y1".into()]))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// One variable-length attribute past the boundary above (6 existing fixed +
@@ -1021,7 +994,7 @@ fn add_variable_length_group_attributes_at_budget_boundary_in_one_commit() {
 /// own counting logic).
 #[test]
 fn add_variable_length_group_attributes_over_budget_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_vlen_group_attr_over_budget.h5");
+    let path = temp_path("hdf5_pure_edit_vlen_group_attr_over_budget.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     for i in 0..6i64 {
@@ -1048,7 +1021,6 @@ fn add_variable_length_group_attributes_over_budget_is_rejected_without_writing(
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -1057,7 +1029,7 @@ fn dense_group_attribute_storage_is_still_rejected_without_writing() {
     // whether the edit is fixed-size or variable-length; this guards that the
     // variable-length `Set` path added for issue #105 still refuses it rather
     // than silently mishandling it.
-    let path = std::env::temp_dir().join("hdf5_pure_edit_dense_group_attr.h5");
+    let path = temp_path("hdf5_pure_edit_dense_group_attr.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     for i in 0..12 {
@@ -1082,12 +1054,11 @@ fn dense_group_attribute_storage_is_still_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn deleting_group_with_attribute_edit_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_delete_group_attr_overlap.h5");
+    let path = temp_path("hdf5_pure_edit_delete_group_attr_overlap.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("grp");
     g.set_attr("tag", AttrValue::I64(1));
@@ -1108,14 +1079,13 @@ fn deleting_group_with_attribute_edit_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_preserves_dataset_attributes() {
     // Exercises the "verbatim message bytes" claim: a copied dataset's
     // attributes (separate header messages) must survive byte-for-byte.
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_attrs.h5");
+    let path = temp_path("hdf5_pure_edit_copy_attrs.h5");
     let mut b = FileBuilder::new();
     let ds = b.create_dataset("src");
     ds.with_i32_data(&[5, 6, 7]);
@@ -1139,14 +1109,13 @@ fn copy_preserves_dataset_attributes() {
         dup.attrs().unwrap().get("label"),
         Some(&AttrValue::String("alpha".into()))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// An unfiltered 2-D chunked dataset is copied: the values round-trip and the
 /// copy is still chunked (the index is rebuilt at the new location).
 #[test]
 fn copy_unfiltered_chunked_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_copy_chunked.h5");
     let data: Vec<i32> = (0..24).collect();
     {
         let mut b = FileBuilder::new();
@@ -1171,7 +1140,6 @@ fn copy_unfiltered_chunked_dataset() {
         dup.chunk_cache_stats().index_loaded(),
         "copied dataset must still be chunked"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A filtered (shuffle + deflate) chunked dataset is copied verbatim: the chunk
@@ -1180,7 +1148,7 @@ fn copy_unfiltered_chunked_dataset() {
 /// the dataset's attributes are carried over.
 #[test]
 fn copy_filtered_chunked_dataset_preserves_pipeline_and_attrs() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_filtered_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_copy_filtered_chunked.h5");
     let data: Vec<i32> = (0..4096).map(|i| i % 4).collect(); // highly compressible
     {
         let mut b = FileBuilder::new();
@@ -1216,7 +1184,6 @@ fn copy_filtered_chunked_dataset_preserves_pipeline_and_attrs() {
         dup.attrs().unwrap().get("units"),
         Some(&AttrValue::String("counts".into()))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// An extensible (unlimited-dimension) chunked dataset copied within the file
@@ -1224,7 +1191,7 @@ fn copy_filtered_chunked_dataset_preserves_pipeline_and_attrs() {
 /// source's unlimited maxshape).
 #[test]
 fn copy_extensible_chunked_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_extensible.h5");
+    let path = temp_path("hdf5_pure_edit_copy_extensible.h5");
     let data: Vec<f64> = (0..80).map(|i| i as f64 * 0.25).collect();
     write_starter(&path);
     {
@@ -1249,14 +1216,13 @@ fn copy_extensible_chunked_dataset() {
     let dup = file.dataset("dup").unwrap();
     assert_eq!(dup.read_f64().unwrap(), data);
     assert!(dup.chunk_cache_stats().index_loaded());
-    std::fs::remove_file(&path).ok();
 }
 
 /// A single-chunk dataset is copied (the chunk address lives in the layout
 /// message; the verbatim path re-emits a single-chunk layout).
 #[test]
 fn copy_single_chunk_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_copy_single_chunk.h5");
+    let path = temp_path("hdf5_pure_edit_copy_single_chunk.h5");
     let data: Vec<i32> = (0..16).collect();
     {
         let mut b = FileBuilder::new();
@@ -1273,12 +1239,11 @@ fn copy_single_chunk_dataset() {
     }
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("dup").unwrap().read_i32().unwrap(), data);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn edit_preserves_multiple_root_datasets() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_multi_root.h5");
+    let path = temp_path("hdf5_pure_edit_multi_root.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d0").with_i32_data(&[0]);
     b.create_dataset("d1").with_i32_data(&[1]);
@@ -1299,12 +1264,11 @@ fn edit_preserves_multiple_root_datasets() {
         assert_eq!(file.dataset(n).unwrap().read_i32().unwrap(), vec![i as i32]);
     }
     assert_eq!(file.root().groups().unwrap(), vec!["extra".to_string()]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn mixed_add_delete_copy_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_mixed.h5");
+    let path = temp_path("hdf5_pure_edit_mixed.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 1]);
     b.create_dataset("remove").with_i32_data(&[9]);
@@ -1338,14 +1302,13 @@ fn mixed_add_delete_copy_in_one_commit() {
         file.dataset("keep").unwrap().read_i32().unwrap(),
         vec![1, 1]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn copy_from_file_dataset() {
     // Cross-file H5Ocopy: copy a dataset out of a separate open file.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_ds.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_ds.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_ds.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_ds.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("payload").with_f64_data(&[1.5, 2.5, 3.5]);
@@ -1378,16 +1341,13 @@ fn copy_from_file_dataset() {
     );
     // The source file was not modified at all.
     assert_eq!(std::fs::read(&src_path).unwrap(), src_bytes_before);
-
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_group_subtree() {
     // A whole group subtree copied across files keeps its deep structure.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_grp.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_grp.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_grp.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_grp.h5");
     write_starter(&src_path);
     {
         // Build the nested source subtree (FileBuilder::create_dataset does not
@@ -1429,15 +1389,13 @@ fn copy_from_file_group_subtree() {
         file.group("run1").unwrap().groups().unwrap(),
         vec!["inner".to_string()]
     );
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_into_subgroup_created_same_session() {
     // The destination parent may be a group created earlier in this session.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_into.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_into.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_into.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_into.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("payload").with_i32_data(&[7, 8, 9]);
@@ -1463,15 +1421,13 @@ fn copy_from_file_into_subgroup_created_same_session() {
             .unwrap(),
         vec![7, 8, 9]
     );
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_preserves_attributes() {
     // Fixed-size attributes survive a cross-file copy byte-for-byte.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_attrs.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_attrs.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_attrs.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_attrs.h5");
     {
         let mut b = FileBuilder::new();
         let ds = b.create_dataset("src");
@@ -1495,16 +1451,14 @@ fn copy_from_file_preserves_attributes() {
     let dup = file.dataset("dup").unwrap();
     assert_eq!(dup.read_i32().unwrap(), vec![5, 6, 7]);
     assert_eq!(dup.attrs().unwrap(), src_attrs);
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_rejects_variable_length() {
     // A variable-length attribute stores global-heap references into the source
     // file; a verbatim cross-file copy cannot translate them, so it is refused.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_vlen.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_vlen.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_vlen.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_vlen.h5");
     {
         let mut b = FileBuilder::new();
         let ds = b.create_dataset("src");
@@ -1533,8 +1487,6 @@ fn copy_from_file_rejects_variable_length() {
     // The destination is byte-unchanged; the same-file `copy` would have allowed
     // this (shared heap), but the cross-file path refuses it up front.
     assert_eq!(std::fs::read(&dst_path).unwrap(), dst_before);
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
@@ -1543,8 +1495,8 @@ fn copy_from_file_rejects_reference_dataset() {
     // verbatim cross-file copy cannot translate them. This exercises the
     // datatype-message refusal branch (the variable-length test above covers the
     // attribute branch).
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_ref.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_ref.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_ref.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_ref.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("target").with_i32_data(&[1, 2, 3]);
@@ -1564,14 +1516,12 @@ fn copy_from_file_rejects_reference_dataset() {
         );
     }
     assert_eq!(std::fs::read(&dst_path).unwrap(), dst_before);
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_rejects_missing_source() {
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_missing.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_missing.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_missing.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_missing.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("present").with_i32_data(&[1]);
@@ -1583,17 +1533,14 @@ fn copy_from_file_rejects_missing_source() {
     let session = File::open_rw(&dst_path).unwrap();
     let err = session.copy_from(&source, "ghost", "x").unwrap_err();
     assert!(err.to_string().contains("does not exist"), "got: {err}");
-
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_rejects_destination_collision() {
     // A destination name already present in the parent group is refused at commit,
     // leaving the file untouched.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_collide.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_collide.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_collide.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_collide.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("payload").with_i32_data(&[1]);
@@ -1610,17 +1557,14 @@ fn copy_from_file_rejects_destination_collision() {
         assert!(err.to_string().contains("already exists"), "got: {err}");
     }
     assert_eq!(std::fs::read(&dst_path).unwrap(), dst_before);
-
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
 fn copy_from_file_rejects_streaming_source() {
     // The source must be buffered so its bytes are addressable; a streaming reader
     // is refused with a clear message.
-    let src_path = std::env::temp_dir().join("hdf5_pure_xcopy_src_stream.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_xcopy_dst_stream.h5");
+    let src_path = temp_path("hdf5_pure_xcopy_src_stream.h5");
+    let dst_path = temp_path("hdf5_pure_xcopy_dst_stream.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("payload").with_i32_data(&[1, 2, 3]);
@@ -1632,9 +1576,6 @@ fn copy_from_file_rejects_streaming_source() {
     let session = File::open_rw(&dst_path).unwrap();
     let err = session.copy_from(&source, "payload", "dup").unwrap_err();
     assert!(err.to_string().contains("buffered source"), "got: {err}");
-
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 #[test]
@@ -1642,7 +1583,7 @@ fn copy_same_file_still_allows_variable_length_attribute() {
     // Regression guard: the foreign-address refusal is cross-file only. An in-file
     // `copy` of a dataset carrying a variable-length attribute still works (the
     // copy shares the source file's global heap).
-    let path = std::env::temp_dir().join("hdf5_pure_xcopy_infile_vlen.h5");
+    let path = temp_path("hdf5_pure_xcopy_infile_vlen.h5");
     {
         let mut b = FileBuilder::new();
         let ds = b.create_dataset("src");
@@ -1667,12 +1608,11 @@ fn copy_same_file_still_allows_variable_length_attribute() {
         file.dataset("dup").unwrap().read_i32().unwrap(),
         vec![1, 2, 3]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn superblock_eof_matches_file_size_after_edit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_eof.h5");
+    let path = temp_path("hdf5_pure_edit_eof.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -1690,14 +1630,13 @@ fn superblock_eof_matches_file_size_after_edit() {
     // The edit updates the superblock's logical end-of-file to the new size.
     assert_eq!(file.file_size(), on_disk);
     assert_eq!(file.superblock().eof_address, on_disk);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A chunked (but unfiltered) dataset can be added in place and read back, and
 /// the original dataset is left intact.
 #[test]
 fn add_chunked_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_add_chunked.h5");
     write_starter(&path);
 
     let data: Vec<f64> = (0..100).map(|i| i as f64 * 0.5).collect();
@@ -1724,14 +1663,13 @@ fn add_chunked_dataset() {
     // The superblock's end-of-file matches the physical size after appending the
     // chunk data, index, and header.
     assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
-    std::fs::remove_file(&path).ok();
 }
 
 /// Deflate, shuffle+deflate, and fletcher32 filtered datasets each round-trip
 /// through the in-place editor and the reader.
 #[test]
 fn add_filtered_datasets() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_filtered.h5");
+    let path = temp_path("hdf5_pure_edit_add_filtered.h5");
     write_starter(&path);
 
     let data: Vec<f64> = (0..200).map(|i| i as f64).collect();
@@ -1770,13 +1708,12 @@ fn add_filtered_datasets() {
         );
     }
     assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
-    std::fs::remove_file(&path).ok();
 }
 
 /// A lossless integer scale-offset dataset round-trips.
 #[test]
 fn add_scale_offset_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_scaleoffset.h5");
+    let path = temp_path("hdf5_pure_edit_add_scaleoffset.h5");
     write_starter(&path);
 
     let data: Vec<i32> = (0..120).map(|i| 1000 + (i % 7)).collect();
@@ -1795,14 +1732,13 @@ fn add_scale_offset_dataset() {
 
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("counts").unwrap().read_i32().unwrap(), data);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A 2-D chunked dataset whose chunks don't evenly divide the shape round-trips
 /// (exercises edge chunks and the fixed-array index used for >1 chunk).
 #[test]
 fn add_2d_chunked_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_2d_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_add_2d_chunked.h5");
     write_starter(&path);
 
     let data: Vec<i32> = (0..(7 * 5)).collect();
@@ -1823,7 +1759,6 @@ fn add_2d_chunked_dataset() {
     let grid = file.dataset("grid").unwrap();
     assert_eq!(grid.shape().unwrap(), vec![7, 5]);
     assert_eq!(grid.read_i32().unwrap(), data);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An extensible (unlimited-dimension) dataset can be added in place; its data
@@ -1831,7 +1766,7 @@ fn add_2d_chunked_dataset() {
 /// Extensible-Array chunk index.
 #[test]
 fn add_extensible_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_extensible.h5");
+    let path = temp_path("hdf5_pure_edit_add_extensible.h5");
     write_starter(&path);
 
     let data: Vec<i32> = (0..64).collect();
@@ -1854,14 +1789,13 @@ fn add_extensible_dataset() {
     assert_eq!(stream.shape().unwrap(), vec![64]);
     assert_eq!(stream.read_i32().unwrap(), data);
     assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
-    std::fs::remove_file(&path).ok();
 }
 
 /// One commit can mix a contiguous dataset and a chunked/compressed dataset
 /// into a nested group, alongside the original.
 #[test]
 fn add_mixed_contiguous_and_chunked_in_group() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_mixed.h5");
+    let path = temp_path("hdf5_pure_edit_add_mixed.h5");
     write_starter(&path);
 
     let wave: Vec<f64> = (0..512).map(|i| (i as f64 * 0.1).cos()).collect();
@@ -1897,14 +1831,13 @@ fn add_mixed_contiguous_and_chunked_in_group() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_eq!(file.file_size(), std::fs::metadata(&path).unwrap().len());
-    std::fs::remove_file(&path).ok();
 }
 
 /// A chunked dataset whose datatype is `f64` still reports the right dtype after
 /// an in-place add, confirming the header is a faithful chunked dataset header.
 #[test]
 fn added_chunked_dataset_reports_dtype() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_chunked_dtype.h5");
+    let path = temp_path("hdf5_pure_edit_chunked_dtype.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -1920,7 +1853,6 @@ fn added_chunked_dataset_reports_dtype() {
     }
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("c").unwrap().dtype().unwrap(), DType::F64);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A ZFP fixed-rate compressed dataset can be added in place and reads back
@@ -1928,7 +1860,7 @@ fn added_chunked_dataset_reports_dtype() {
 #[test]
 #[cfg(feature = "zfp")]
 fn add_zfp_dataset() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_zfp.h5");
+    let path = temp_path("hdf5_pure_edit_add_zfp.h5");
     write_starter(&path);
 
     let data: Vec<f64> = (0..256).map(|i| (i as f64 * 0.05).sin()).collect();
@@ -1952,7 +1884,6 @@ fn add_zfp_dataset() {
         .map(|(&a, &b)| (a - b).abs())
         .fold(0f64, f64::max);
     assert!(max_err < 1e-6, "ZFP max_err {max_err} > 1e-6");
-    std::fs::remove_file(&path).ok();
 }
 
 /// Malformed chunked-dataset requests are refused before any byte is written,
@@ -2029,7 +1960,7 @@ fn malformed_chunked_requests_are_rejected_without_writing() {
     ];
 
     for (label, configure, expected) in bad {
-        let path = std::env::temp_dir().join(format!(
+        let path = temp_path(&format!(
             "hdf5_pure_edit_reject_{}.h5",
             label.replace(' ', "_")
         ));
@@ -2055,7 +1986,6 @@ fn malformed_chunked_requests_are_rejected_without_writing() {
             before,
             "[{label}] file modified"
         );
-        std::fs::remove_file(&path).ok();
     }
 }
 
@@ -2063,7 +1993,7 @@ fn malformed_chunked_requests_are_rejected_without_writing() {
 
 #[test]
 fn write_dataset_same_size_overwrites_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_same_size.h5");
+    let path = temp_path("hdf5_pure_write_same_size.h5");
     write_starter(&path); // "original" = [1.0, 2.0, 3.0, 4.0] (contiguous f64)
     let size_before = std::fs::metadata(&path).unwrap().len();
 
@@ -2090,7 +2020,6 @@ fn write_dataset_same_size_overwrites_in_place() {
     let ds = file.dataset("original").unwrap();
     assert_eq!(ds.dtype().unwrap(), DType::F64);
     assert_eq!(ds.read_f64().unwrap(), vec![9.0, 8.0, 7.0, 6.0]);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -2100,7 +2029,7 @@ fn write_dataset_resize_keeping_shape_is_a_reshape_and_refused() {
     // reshape, not a value overwrite, and is refused. (The genuine relocation
     // path — overwriting a never-written, undefined-address dataset — is exercised
     // in the crosscheck against the C library, which can create one.)
-    let path = std::env::temp_dir().join("hdf5_pure_write_resize_refused.h5");
+    let path = temp_path("hdf5_pure_write_resize_refused.h5");
     write_starter(&path); // "original" = 4 f64
     let before = std::fs::read(&path).unwrap();
     {
@@ -2123,12 +2052,11 @@ fn write_dataset_resize_keeping_shape_is_a_reshape_and_refused() {
         before,
         "file modified on refusal"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_in_a_nested_group() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_nested.h5");
+    let path = temp_path("hdf5_pure_write_nested.h5");
     {
         let mut b = FileBuilder::new();
         let mut g = b.create_group("grp");
@@ -2153,12 +2081,11 @@ fn write_dataset_in_a_nested_group() {
         file.dataset("grp/inner").unwrap().read_i32().unwrap(),
         vec![10, 20, 30]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_rejects_datatype_mismatch() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_type_mismatch.h5");
+    let path = temp_path("hdf5_pure_write_type_mismatch.h5");
     write_starter(&path); // f64
     let before = std::fs::read(&path).unwrap();
     {
@@ -2182,12 +2109,11 @@ fn write_dataset_rejects_datatype_mismatch() {
         before,
         "file modified on refusal"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_rejects_shape_mismatch() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_shape_mismatch.h5");
+    let path = temp_path("hdf5_pure_write_shape_mismatch.h5");
     {
         let mut b = FileBuilder::new();
         // A 2-D dataset, so a 1-D replacement of the same element count is a
@@ -2218,12 +2144,11 @@ fn write_dataset_rejects_shape_mismatch() {
         before,
         "file modified on refusal"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_rejects_missing_target() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_missing.h5");
+    let path = temp_path("hdf5_pure_write_missing.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -2236,7 +2161,6 @@ fn write_dataset_rejects_missing_target() {
         );
         assert!(!session.has_staged_edits());
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// An unfiltered chunked dataset is overwritten chunk-by-chunk straight in its
@@ -2244,7 +2168,7 @@ fn write_dataset_rejects_missing_target() {
 /// and the new values read back.
 #[test]
 fn write_dataset_overwrites_unfiltered_chunked_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_chunked.h5");
+    let path = temp_path("hdf5_pure_write_chunked.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("c")
@@ -2280,14 +2204,13 @@ fn write_dataset_overwrites_unfiltered_chunked_in_place() {
         c.chunk_cache_stats().index_loaded(),
         "dataset must still be chunked"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A 2-D chunked dataset whose chunks do not evenly divide the shape (edge
 /// chunks, Fixed-Array index) is overwritten in place.
 #[test]
 fn write_dataset_overwrites_2d_edge_chunked_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_2d_edge_chunked.h5");
+    let path = temp_path("hdf5_pure_write_2d_edge_chunked.h5");
     let orig: Vec<i32> = (0..35).collect();
     {
         let mut b = FileBuilder::new();
@@ -2315,14 +2238,13 @@ fn write_dataset_overwrites_2d_edge_chunked_in_place() {
     let g = file.dataset("g").unwrap();
     assert_eq!(g.shape().unwrap(), vec![7, 5]);
     assert_eq!(g.read_i32().unwrap(), updated);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An extensible (unlimited-dimension, Extensible-Array index) chunked dataset is
 /// overwritten in place.
 #[test]
 fn write_dataset_overwrites_extensible_chunked_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_extensible_chunked.h5");
+    let path = temp_path("hdf5_pure_write_extensible_chunked.h5");
     let orig: Vec<f64> = (0..60).map(|i| i as f64).collect();
     write_starter(&path);
     {
@@ -2352,7 +2274,6 @@ fn write_dataset_overwrites_extensible_chunked_in_place() {
     }
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("ext").unwrap().read_f64().unwrap(), updated);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A size-preserving filter (Fletcher32 always appends a 4-byte checksum, so the
@@ -2360,7 +2281,7 @@ fn write_dataset_overwrites_extensible_chunked_in_place() {
 /// overwritten in place even when the values change.
 #[test]
 fn write_dataset_overwrites_fletcher32_chunked_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_fletcher_chunked.h5");
+    let path = temp_path("hdf5_pure_write_fletcher_chunked.h5");
     let orig: Vec<f64> = (0..128).map(|i| i as f64).collect();
     write_starter(&path);
     {
@@ -2398,14 +2319,13 @@ fn write_dataset_overwrites_fletcher32_chunked_in_place() {
     let ck = file.dataset("ck").unwrap();
     assert_eq!(ck.read_f64().unwrap(), updated);
     assert!(ck.chunk_cache_stats().index_loaded());
-    std::fs::remove_file(&path).ok();
 }
 
 /// Rewriting a deflate dataset with the *same* values reproduces identical
 /// compressed bytes, so the overwrite fits the existing slots and stays in place.
 #[test]
 fn write_dataset_overwrites_deflate_chunked_equal_size_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_deflate_equal.h5");
+    let path = temp_path("hdf5_pure_write_deflate_equal.h5");
     let data: Vec<f64> = (0..200).map(|i| i as f64).collect();
     {
         let mut b = FileBuilder::new();
@@ -2435,7 +2355,6 @@ fn write_dataset_overwrites_deflate_chunked_equal_size_in_place() {
     );
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("d").unwrap().read_f64().unwrap(), data);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A deflate dataset overwritten with values of different compressibility
@@ -2443,7 +2362,7 @@ fn write_dataset_overwrites_deflate_chunked_equal_size_in_place() {
 /// new values still read back and the dataset stays chunked + compressed.
 #[test]
 fn write_dataset_overwrites_deflate_chunked_relocates_on_size_change() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_deflate_relocate.h5");
+    let path = temp_path("hdf5_pure_write_deflate_relocate.h5");
     // Highly compressible original, then incompressible-ish replacement.
     let orig: Vec<i32> = vec![0; 4096];
     {
@@ -2476,7 +2395,6 @@ fn write_dataset_overwrites_deflate_chunked_relocates_on_size_change() {
         d.chunk_cache_stats().index_loaded(),
         "relocated dataset must still be chunked"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A relocating chunked overwrite returns the old chunk storage to the session's
@@ -2486,7 +2404,7 @@ fn write_dataset_overwrites_deflate_chunked_relocates_on_size_change() {
 /// (a double-free or stale span would corrupt one of them).
 #[test]
 fn write_dataset_chunked_relocate_then_reuse_stays_valid() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_chunked_reclaim.h5");
+    let path = temp_path("hdf5_pure_write_chunked_reclaim.h5");
     {
         let mut b = FileBuilder::new();
         // Highly compressible start => tiny chunk slots.
@@ -2527,7 +2445,6 @@ fn write_dataset_chunked_relocate_then_reuse_stays_valid() {
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("d").unwrap().read_i32().unwrap(), updated);
     assert_eq!(file.dataset("filler").unwrap().read_f64().unwrap(), filler);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A filtered (deflate, Fixed-Array index) overwrite whose re-encoded chunks are
@@ -2537,7 +2454,7 @@ fn write_dataset_chunked_relocate_then_reuse_stays_valid() {
 /// be impossible if the index still recorded the old, larger sizes).
 #[test]
 fn write_dataset_overwrites_filtered_chunked_fits_with_slack_in_place() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_fits_slack_fa.h5");
+    let path = temp_path("hdf5_pure_write_fits_slack_fa.h5");
     // Incompressible start => large chunk slots (Fixed Array: 4 finite chunks).
     let orig: Vec<i32> = (0..2048i32)
         .map(|i| i.wrapping_mul(2_654_435_761u32 as i32) ^ (i << 3))
@@ -2575,7 +2492,6 @@ fn write_dataset_overwrites_filtered_chunked_fits_with_slack_in_place() {
     let d = file.dataset("d").unwrap();
     assert_eq!(d.read_i32().unwrap(), updated);
     assert!(d.chunk_cache_stats().index_loaded(), "still chunked");
-    std::fs::remove_file(&path).ok();
 }
 
 /// The fits-with-slack in-place path also covers an extensible (unlimited,
@@ -2584,7 +2500,7 @@ fn write_dataset_overwrites_filtered_chunked_fits_with_slack_in_place() {
 /// back.
 #[test]
 fn write_dataset_overwrites_filtered_extensible_fits_with_slack() {
-    let path = std::env::temp_dir().join("hdf5_pure_write_fits_slack_ea.h5");
+    let path = temp_path("hdf5_pure_write_fits_slack_ea.h5");
     let orig: Vec<i32> = (0..2048i32)
         .map(|i| i.wrapping_mul(2_654_435_761u32 as i32) ^ (i << 3))
         .collect();
@@ -2626,7 +2542,6 @@ fn write_dataset_overwrites_filtered_extensible_fits_with_slack() {
     let d = file.dataset("d").unwrap();
     assert_eq!(d.read_i32().unwrap(), updated);
     assert!(d.chunk_cache_stats().index_loaded(), "still chunked");
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -2634,7 +2549,7 @@ fn write_dataset_rejects_filtered_request() {
     // A builder that itself requests chunking/filtering is refused as "not a
     // value overwrite" before the on-disk dataset is even consulted — which is
     // why the refusal arrives from `write_staged` and not from the commit.
-    let path = std::env::temp_dir().join("hdf5_pure_write_filtered_request.h5");
+    let path = temp_path("hdf5_pure_write_filtered_request.h5");
     write_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -2656,14 +2571,13 @@ fn write_dataset_rejects_filtered_request() {
             "a refused overwrite must not be left staged"
         );
     }
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_rejects_staged_attributes() {
     // Attributes set on the write_dataset builder cannot be applied by a value
     // overwrite, so they must be refused rather than silently dropped.
-    let path = std::env::temp_dir().join("hdf5_pure_write_attr_refused.h5");
+    let path = temp_path("hdf5_pure_write_attr_refused.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
     {
@@ -2690,13 +2604,12 @@ fn write_dataset_rejects_staged_attributes() {
         before,
         "file modified on refusal"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_alongside_other_edits() {
     // A value overwrite coexists with an addition and a delete in one commit.
-    let path = std::env::temp_dir().join("hdf5_pure_write_mixed.h5");
+    let path = temp_path("hdf5_pure_write_mixed.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("keep").with_f64_data(&[1.0, 2.0]);
@@ -2731,14 +2644,13 @@ fn write_dataset_alongside_other_edits() {
         vec![3, 4]
     );
     assert!(file.dataset("doomed").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn write_dataset_with_no_other_edits_takes_inplace_fast_path() {
     // A lone same-size overwrite must not rewrite headers or flip the root: the
     // only on-disk bytes that change are the data block itself.
-    let path = std::env::temp_dir().join("hdf5_pure_write_fastpath.h5");
+    let path = temp_path("hdf5_pure_write_fastpath.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
     {
@@ -2758,7 +2670,6 @@ fn write_dataset_with_no_other_edits_takes_inplace_fast_path() {
         before,
         "in-place rewrite of identical data changed the file"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A zero-element (empty) contiguous dataset — the on-disk equivalent of the
@@ -2767,7 +2678,7 @@ fn write_dataset_with_no_other_edits_takes_inplace_fast_path() {
 /// same commit.
 #[test]
 fn add_empty_dataset_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_empty.h5");
+    let path = temp_path("hdf5_pure_edit_add_empty.h5");
     write_starter(&path);
 
     {
@@ -2801,7 +2712,6 @@ fn add_empty_dataset_via_edit_session() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// An empty dataset whose supplied data does not match its (zero-element)
@@ -2810,7 +2720,7 @@ fn add_empty_dataset_via_edit_session() {
 /// the shape contains a `0` dimension, not just for non-empty shapes.
 #[test]
 fn add_empty_dataset_with_mismatched_data_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_empty_mismatched.h5");
+    let path = temp_path("hdf5_pure_edit_add_empty_mismatched.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -2827,7 +2737,6 @@ fn add_empty_dataset_with_mismatched_data_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A provenance-tagged dataset (issue #105) can be added in place; the
@@ -2839,7 +2748,7 @@ fn add_empty_dataset_with_mismatched_data_is_rejected_without_writing() {
 fn add_provenance_dataset_via_edit_session() {
     use hdf5_pure::VerifyResult;
 
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance.h5");
+    let path = temp_path("hdf5_pure_edit_add_provenance.h5");
     write_starter(&path);
 
     {
@@ -2874,7 +2783,6 @@ fn add_provenance_dataset_via_edit_session() {
         attrs.get("_provenance_source"),
         Some(&AttrValue::String("bench".into()))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A provenance-tagged dataset can also be chunked/compressed in the same
@@ -2886,7 +2794,7 @@ fn add_provenance_dataset_via_edit_session() {
 fn add_provenance_chunked_dataset_via_edit_session() {
     use hdf5_pure::VerifyResult;
 
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_add_provenance_chunked.h5");
     write_starter(&path);
 
     {
@@ -2917,7 +2825,6 @@ fn add_provenance_chunked_dataset_via_edit_session() {
         !attrs.contains_key("_provenance_source"),
         "no source was given, so no source attribute should be written"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// Provenance attributes (up to 4) are appended to `attrs` before the
@@ -2928,7 +2835,7 @@ fn add_provenance_chunked_dataset_via_edit_session() {
 #[cfg(feature = "provenance")]
 #[test]
 fn add_provenance_dataset_at_attr_budget_boundary_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_at_budget.h5");
+    let path = temp_path("hdf5_pure_edit_add_provenance_at_budget.h5");
     write_starter(&path);
 
     {
@@ -2962,7 +2869,6 @@ fn add_provenance_dataset_at_attr_budget_boundary_via_edit_session() {
         attrs.get("_provenance_creator"),
         Some(&AttrValue::String("test-suite".into()))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// One attribute past the boundary above (9 total, once provenance is
@@ -2970,7 +2876,7 @@ fn add_provenance_dataset_at_attr_budget_boundary_via_edit_session() {
 #[cfg(feature = "provenance")]
 #[test]
 fn add_provenance_dataset_over_attr_budget_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_provenance_over_budget.h5");
+    let path = temp_path("hdf5_pure_edit_add_provenance_over_budget.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -2992,7 +2898,6 @@ fn add_provenance_dataset_over_attr_budget_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A dataset with a variable-length attribute (issue #105) can be added in
@@ -3000,7 +2905,7 @@ fn add_provenance_dataset_over_attr_budget_is_rejected_without_writing() {
 /// patched during commit, alongside the dataset's own fixed-size attributes.
 #[test]
 fn add_dataset_with_variable_length_attribute_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_dataset_vlen_attr.h5");
+    let path = temp_path("hdf5_pure_edit_add_dataset_vlen_attr.h5");
     write_starter(&path);
 
     {
@@ -3037,7 +2942,6 @@ fn add_dataset_with_variable_length_attribute_via_edit_session() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A variable-length attribute is patched before the chunked/non-chunked
@@ -3046,7 +2950,7 @@ fn add_dataset_with_variable_length_attribute_via_edit_session() {
 /// refused when chunked, not VL attributes).
 #[test]
 fn add_chunked_dataset_with_variable_length_attribute_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked_vlen_attr.h5");
+    let path = temp_path("hdf5_pure_edit_add_chunked_vlen_attr.h5");
     write_starter(&path);
 
     let data: Vec<f64> = (0..100).map(|i| i as f64 * 0.5).collect();
@@ -3074,7 +2978,6 @@ fn add_chunked_dataset_with_variable_length_attribute_via_edit_session() {
             "two".into()
         ]))
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A dataset attribute whose serialized message overflows the object header's
@@ -3084,7 +2987,7 @@ fn add_chunked_dataset_with_variable_length_attribute_via_edit_session() {
 /// enough of them push the message past `u16::MAX` bytes).
 #[test]
 fn add_dataset_with_oversized_variable_length_attribute_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_oversized_vlen_attr.h5");
+    let path = temp_path("hdf5_pure_edit_add_oversized_vlen_attr.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3106,7 +3009,6 @@ fn add_dataset_with_oversized_variable_length_attribute_is_rejected_without_writ
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Regression test for issue #105's silent-corruption bug: a variable-length
@@ -3117,7 +3019,7 @@ fn add_dataset_with_oversized_variable_length_attribute_is_rejected_without_writ
 /// added dataset.
 #[test]
 fn add_vlen_string_dataset_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_vlen_string_dataset.h5");
+    let path = temp_path("hdf5_pure_edit_add_vlen_string_dataset.h5");
     write_starter(&path);
 
     {
@@ -3142,12 +3044,11 @@ fn add_vlen_string_dataset_via_edit_session() {
         file.dataset("original").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_chunked_vlen_string_dataset_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked_vlen_string.h5");
+    let path = temp_path("hdf5_pure_edit_add_chunked_vlen_string.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3167,7 +3068,6 @@ fn add_chunked_vlen_string_dataset_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An object-reference dataset (issue #105) can be added in place, targeting
@@ -3176,7 +3076,7 @@ fn add_chunked_vlen_string_dataset_is_rejected_without_writing() {
 /// untouched by this commit.
 #[test]
 fn add_reference_dataset_targeting_preexisting_object_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_preexisting.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_preexisting.h5");
     write_starter(&path);
 
     {
@@ -3197,7 +3097,6 @@ fn add_reference_dataset_targeting_preexisting_object_via_edit_session() {
         Object::Dataset(ds) => assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]),
         other => panic!("expected a dataset reference, got {other:?}"),
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// A reference dataset may target a sibling dataset added in the **same**
@@ -3206,7 +3105,7 @@ fn add_reference_dataset_targeting_preexisting_object_via_edit_session() {
 /// reference dataset in that group (issue #105).
 #[test]
 fn add_reference_dataset_targeting_sibling_added_in_same_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_sibling.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_sibling.h5");
     write_starter(&path);
 
     {
@@ -3235,7 +3134,6 @@ fn add_reference_dataset_targeting_sibling_added_in_same_commit() {
         Object::Dataset(ds) => assert_eq!(ds.read_i32().unwrap(), vec![7, 8, 9]),
         other => panic!("expected a dataset reference, got {other:?}"),
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// A path with no object anywhere — neither pre-existing nor added in this
@@ -3244,7 +3142,7 @@ fn add_reference_dataset_targeting_sibling_added_in_same_commit() {
 /// (issue #105).
 #[test]
 fn add_reference_dataset_targeting_nonexistent_path_becomes_undefined() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_nonexistent.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_nonexistent.h5");
     write_starter(&path);
 
     {
@@ -3266,7 +3164,6 @@ fn add_reference_dataset_targeting_nonexistent_path_becomes_undefined() {
     // (`u64::MAX`) from address 0 or any other unresolvable garbage address —
     // check the stored 8-byte element directly.
     assert_eq!(ds.read_raw().unwrap(), u64::MAX.to_le_bytes());
-    std::fs::remove_file(&path).ok();
 }
 
 /// A reference targeting an **ancestor group of its own dataset** is refused:
@@ -3275,7 +3172,7 @@ fn add_reference_dataset_targeting_nonexistent_path_becomes_undefined() {
 /// require a stale or made-up address (issue #105).
 #[test]
 fn add_reference_dataset_targeting_unprocessed_ancestor_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_ancestor.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_ancestor.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3292,7 +3189,6 @@ fn add_reference_dataset_targeting_unprocessed_ancestor_is_rejected_without_writ
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A reference targeting a same-depth sibling **group** that the deepest-first
@@ -3302,7 +3198,7 @@ fn add_reference_dataset_targeting_unprocessed_ancestor_is_rejected_without_writ
 /// (issue #105).
 #[test]
 fn add_reference_dataset_targeting_unprocessed_sibling_group_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_sibling_group.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_sibling_group.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3321,12 +3217,11 @@ fn add_reference_dataset_targeting_unprocessed_sibling_group_is_rejected_without
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn add_chunked_reference_dataset_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_chunked_ref.h5");
+    let path = temp_path("hdf5_pure_edit_add_chunked_ref.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3343,7 +3238,6 @@ fn add_chunked_reference_dataset_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Every element of a multi-element `with_path_references` array is resolved
@@ -3352,7 +3246,7 @@ fn add_chunked_reference_dataset_is_rejected_without_writing() {
 /// test cannot.
 #[test]
 fn add_reference_dataset_with_multiple_elements_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_multi_element.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_multi_element.h5");
     write_starter(&path);
 
     {
@@ -3387,7 +3281,6 @@ fn add_reference_dataset_with_multiple_elements_via_edit_session() {
         Object::Dataset(ds) => assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0]),
         other => panic!("expected a dataset reference, got {other:?}"),
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// A reference can resolve to a **group**, not just a dataset — the existing
@@ -3395,7 +3288,7 @@ fn add_reference_dataset_with_multiple_elements_via_edit_session() {
 /// arm of `dereference()`'s result was previously unexercised.
 #[test]
 fn add_reference_dataset_targeting_a_group_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_group.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_group.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("original")
         .with_f64_data(&[1.0, 2.0, 3.0, 4.0]);
@@ -3426,7 +3319,6 @@ fn add_reference_dataset_targeting_a_group_via_edit_session() {
         }
         other => panic!("expected a group reference, got {other:?}"),
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// `with_path_references(&[])` is a valid degenerate case, consistent with
@@ -3436,7 +3328,7 @@ fn add_reference_dataset_targeting_a_group_via_edit_session() {
 /// empty dataset.
 #[test]
 fn add_zero_element_reference_dataset_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_zero_element.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_zero_element.h5");
     write_starter(&path);
 
     {
@@ -3454,7 +3346,6 @@ fn add_zero_element_reference_dataset_via_edit_session() {
     let ds = file.dataset("refs").unwrap();
     assert_eq!(ds.shape().unwrap(), vec![0]);
     assert_eq!(ds.dereference().unwrap().len(), 0);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Regression test: a reference targeting an object **deleted in the same
@@ -3466,7 +3357,7 @@ fn add_zero_element_reference_dataset_via_edit_session() {
 /// still leave the file untouched.
 #[test]
 fn add_reference_dataset_targeting_same_commit_delete_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_deleted_target.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_deleted_target.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3494,7 +3385,6 @@ fn add_reference_dataset_targeting_same_commit_delete_is_rejected_without_writin
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A deletion takes the whole subtree with it, so a reference to a *child* of
@@ -3512,7 +3402,7 @@ fn add_reference_dataset_targeting_same_commit_delete_is_rejected_without_writin
 /// bug shipped; a grandchild catches a fix that only descends one level.
 #[test]
 fn add_reference_dataset_targeting_a_child_of_a_same_commit_delete_is_rejected() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_deleted_child.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_deleted_child.h5");
     let mut b = FileBuilder::new();
     let mut doomed = b.create_group("doomed");
     doomed.create_dataset("inner").with_i32_data(&[7, 7, 7]);
@@ -3548,7 +3438,6 @@ fn add_reference_dataset_targeting_a_child_of_a_same_commit_delete_is_rejected()
 
         assert_eq!(std::fs::read(&path).unwrap(), before, "{target}");
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// The floor under the guard above: a delete in the commit must not stop an
@@ -3558,7 +3447,7 @@ fn add_reference_dataset_targeting_a_child_of_a_same_commit_delete_is_rejected()
 /// supposed to succeed.
 #[test]
 fn a_delete_elsewhere_does_not_block_an_unrelated_reference() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_delete_elsewhere.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_delete_elsewhere.h5");
     let mut b = FileBuilder::new();
     let mut doomed = b.create_group("doomed");
     doomed.create_dataset("inner").with_i32_data(&[7]);
@@ -3588,7 +3477,6 @@ fn a_delete_elsewhere_does_not_block_an_unrelated_reference() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The interaction with issue #305: when the commit puts the deleted path
@@ -3604,7 +3492,7 @@ fn a_delete_elsewhere_does_not_block_an_unrelated_reference() {
 /// other test here does. It is not evidence that the guard is correct.
 #[test]
 fn a_reference_to_a_replaced_paths_new_child_resolves_to_the_replacement() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_replaced_child.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_replaced_child.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("g");
     g.create_dataset("inner").with_i32_data(&[7, 7, 7]);
@@ -3639,7 +3527,6 @@ fn a_reference_to_a_replaced_paths_new_child_resolves_to_the_replacement() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The delete guard runs *after* the three "still writing" ones, so a
@@ -3662,7 +3549,7 @@ fn a_reference_to_a_replaced_paths_new_child_resolves_to_the_replacement() {
 /// harder to fix rather than easier.
 #[test]
 fn a_reference_to_an_unplaced_replacement_reports_the_ordering_not_the_delete() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_unplaced_replacement.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_unplaced_replacement.h5");
     let mut b = FileBuilder::new();
     let mut a = b.create_group("a");
     a.create_dataset("seed").with_i32_data(&[0]);
@@ -3690,7 +3577,6 @@ fn a_reference_to_an_unplaced_replacement_reports_the_ordering_not_the_delete() 
     let err = session.commit().unwrap_err();
     assert!(err.to_string().contains("still writing"), "got: {err}");
     drop(session);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Regression test: a reference targeting a **copy destination** in the same
@@ -3699,7 +3585,7 @@ fn a_reference_to_an_unplaced_replacement_reports_the_ordering_not_the_delete() 
 /// nested addition must not leak into the file when the refusal fires later.
 #[test]
 fn add_reference_dataset_targeting_copy_destination_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_copy_dest.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_copy_dest.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3724,7 +3610,6 @@ fn add_reference_dataset_targeting_copy_destination_is_rejected_without_writing(
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Regression test: a reference targeting a `write_dataset` (value-overwrite)
@@ -3733,7 +3618,7 @@ fn add_reference_dataset_targeting_copy_destination_is_rejected_without_writing(
 /// again, an earlier-processed nested addition must not leak.
 #[test]
 fn add_reference_dataset_targeting_write_overwrite_target_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_ref_write_target.h5");
+    let path = temp_path("hdf5_pure_edit_add_ref_write_target.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3764,7 +3649,6 @@ fn add_reference_dataset_targeting_write_overwrite_target_is_rejected_without_wr
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The fixture the address-side reference tests below share (issue #317): a
@@ -3800,7 +3684,7 @@ fn write_reference_fixture(path: &std::path::Path) -> u64 {
 /// just reported as reusable.
 #[test]
 fn an_added_reference_address_into_deleted_space_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_add.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_add.h5");
     let inner = write_reference_fixture(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3824,7 +3708,6 @@ fn an_added_reference_address_into_deleted_space_is_refused() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The same address through the *overwrite* door, which reaches neither
@@ -3833,7 +3716,7 @@ fn an_added_reference_address_into_deleted_space_is_refused() {
 /// is screened on its own (issue #317).
 #[test]
 fn an_overwritten_reference_address_into_deleted_space_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_write.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_write.h5");
     let inner = write_reference_fixture(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3856,7 +3739,6 @@ fn an_overwritten_reference_address_into_deleted_space_is_refused() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An address naming an object the delete does not touch still commits, and
@@ -3868,7 +3750,7 @@ fn an_overwritten_reference_address_into_deleted_space_is_refused() {
 /// decides the verdict.
 #[test]
 fn a_reference_address_to_a_surviving_object_is_accepted_beside_a_delete() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_survivor.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_survivor.h5");
     let mut b = FileBuilder::new();
     let mut doomed = b.create_group("doomed");
     doomed.create_dataset("inner").with_i32_data(&[7]);
@@ -3906,7 +3788,6 @@ fn a_reference_address_to_a_surviving_object_is_accepted_beside_a_delete() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An in-file copy re-emits its source's element bytes verbatim, which for an
@@ -3916,7 +3797,7 @@ fn a_reference_address_to_a_surviving_object_is_accepted_beside_a_delete() {
 /// commit is refused (issue #317).
 #[test]
 fn a_copy_of_a_reference_dataset_beside_a_delete_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_delete.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_delete.h5");
     write_reference_fixture(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -3933,7 +3814,6 @@ fn a_copy_of_a_reference_dataset_beside_a_delete_is_refused() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The other half of that rule: with nothing deleted there is no reclaimed
@@ -3945,7 +3825,7 @@ fn a_copy_of_a_reference_dataset_beside_a_delete_is_refused() {
 /// removal in the same commit takes that away.
 #[test]
 fn a_copy_of_a_reference_dataset_without_a_delete_still_works() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_plain.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_plain.h5");
     write_reference_fixture(&path);
 
     {
@@ -3966,7 +3846,6 @@ fn a_copy_of_a_reference_dataset_without_a_delete_still_works() {
         }
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A copy of a reference dataset commits *beside* a delete when the reference
@@ -3981,7 +3860,7 @@ fn a_copy_of_a_reference_dataset_without_a_delete_still_works() {
 /// anything at all.
 #[test]
 fn a_copy_of_a_reference_dataset_is_allowed_beside_an_unrelated_delete() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_unrelated.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_unrelated.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("g");
     g.create_dataset("inner").with_i32_data(&[1, 2, 3]);
@@ -4005,7 +3884,6 @@ fn a_copy_of_a_reference_dataset_is_allowed_beside_an_unrelated_delete() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An address naming an object the same commit *rewrites elsewhere* is refused
@@ -4020,7 +3898,7 @@ fn a_copy_of_a_reference_dataset_is_allowed_beside_an_unrelated_delete() {
 /// relocated-dataset test below pins the case where it does not.
 #[test]
 fn a_reference_address_to_a_group_this_commit_rewrites_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_moved_group.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_moved_group.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("g");
     g.create_dataset("inner").with_i32_data(&[1, 2, 3]);
@@ -4083,7 +3961,6 @@ fn a_reference_address_to_a_group_this_commit_rewrites_is_refused() {
         other => panic!("expected a group reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The same rule for a *dataset* target, relocated by an attribute edit rather
@@ -4094,7 +3971,7 @@ fn a_reference_address_to_a_group_this_commit_rewrites_is_refused() {
 /// naming freed bytes.
 #[test]
 fn a_reference_address_to_a_relocated_dataset_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_moved_dataset.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_moved_dataset.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_i32_data(&[11, 22, 33]);
     b.create_dataset("refs").with_path_references(&["d"]);
@@ -4145,7 +4022,6 @@ fn a_reference_address_to_a_relocated_dataset_is_refused() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A datatype mixing an object reference this crate can locate with one it
@@ -4188,7 +4064,7 @@ fn a_datatype_mixing_locatable_and_unlocatable_references_is_refused() {
     ];
 
     for (tag, second) in unlocatable {
-        let path = std::env::temp_dir().join("hdf5_pure_edit_ref_mixed.h5");
+        let path = temp_path("hdf5_pure_edit_ref_mixed.h5");
         let inner = write_reference_fixture(&path);
         let before = std::fs::read(&path).unwrap();
 
@@ -4219,7 +4095,6 @@ fn a_datatype_mixing_locatable_and_unlocatable_references_is_refused() {
         }
 
         assert_eq!(std::fs::read(&path).unwrap(), before, "{tag}");
-        std::fs::remove_file(&path).ok();
     }
 }
 
@@ -4234,7 +4109,7 @@ fn a_datatype_mixing_locatable_and_unlocatable_references_is_refused() {
 /// C-written file are the doors.
 #[test]
 fn a_dataset_region_reference_is_refused_beside_a_delete() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_region.h5");
+    let path = temp_path("hdf5_pure_edit_ref_region.h5");
     let inner = write_reference_fixture(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -4265,7 +4140,6 @@ fn a_dataset_region_reference_is_refused_beside_a_delete() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The relocating-write half of `moved`, through the two doors an attribute
@@ -4311,7 +4185,7 @@ fn a_reference_address_to_a_dataset_a_write_relocates_is_refused() {
             }) as fn(&File),
         ),
     ] {
-        let path = std::env::temp_dir().join(format!("hdf5_pure_edit_ref_moved_{tag}.h5"));
+        let path = temp_path(&format!("hdf5_pure_edit_ref_moved_{tag}.h5"));
         let mut b = FileBuilder::new();
         // Zeros so every chunk compresses to almost nothing, leaving slots the
         // replacement below cannot fit back into.
@@ -4348,7 +4222,6 @@ fn a_reference_address_to_a_dataset_a_write_relocates_is_refused() {
         }
 
         assert_eq!(std::fs::read(&path).unwrap(), before, "{tag}");
-        std::fs::remove_file(&path).ok();
     }
 }
 
@@ -4362,7 +4235,7 @@ fn a_reference_address_to_a_dataset_a_write_relocates_is_refused() {
 /// anything" would refuse every supplied address there is.
 #[test]
 fn a_reference_address_to_an_object_this_commit_leaves_alone_is_accepted() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_untouched.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_untouched.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_i32_data(&[11, 22, 33]);
     b.create_dataset("refs").with_path_references(&["d"]);
@@ -4391,14 +4264,13 @@ fn a_reference_address_to_an_object_this_commit_leaves_alone_is_accepted() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The screen reads every element, not just the first: here element 0 names a
 /// survivor and element 1 names the deleted object (issue #317).
 #[test]
 fn a_hazardous_reference_past_the_first_element_is_found() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_addr_second_element.h5");
+    let path = temp_path("hdf5_pure_edit_ref_addr_second_element.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("g");
     g.create_dataset("inner").with_i32_data(&[1, 2, 3]);
@@ -4438,14 +4310,13 @@ fn a_hazardous_reference_past_the_first_element_is_found() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A copied *group* is screened through its whole subtree, not just at its root:
 /// the reference dataset here is a child of the group being copied (issue #317).
 #[test]
 fn a_copied_groups_subtree_is_screened() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_subtree.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_subtree.h5");
     let mut b = FileBuilder::new();
     let mut g = b.create_group("g");
     g.create_dataset("inner").with_i32_data(&[1, 2, 3]);
@@ -4471,7 +4342,6 @@ fn a_copied_groups_subtree_is_screened() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Build a file with a *chunked* object-reference dataset `crefs` holding two
@@ -4514,7 +4384,7 @@ fn write_chunked_reference_file(path: &std::path::Path, stored: u64) -> u64 {
 /// object-reference dataset outright.
 #[test]
 fn a_chunked_reference_copy_beside_a_delete_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_chunked.h5");
     let survivor = write_chunked_reference_file(&path, 0);
     assert_eq!(
         write_chunked_reference_file(&path, survivor),
@@ -4535,7 +4405,6 @@ fn a_chunked_reference_copy_beside_a_delete_is_refused() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The chunked refusal above is gated on the commit reclaiming something: with
@@ -4546,7 +4415,7 @@ fn a_chunked_reference_copy_beside_a_delete_is_refused() {
 /// rather than from the ones where an address could have gone stale.
 #[test]
 fn a_chunked_reference_copy_without_a_delete_still_works() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_chunked_ok.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_chunked_ok.h5");
     let survivor = write_chunked_reference_file(&path, 0);
     assert_eq!(write_chunked_reference_file(&path, survivor), survivor);
 
@@ -4566,7 +4435,6 @@ fn a_chunked_reference_copy_without_a_delete_still_works() {
         }
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Build a file whose `crefs` dataset holds one object reference to `g/inner`
@@ -4607,7 +4475,7 @@ fn write_committed_reference_file(path: &std::path::Path, stored: u64) -> u64 {
 /// this copy would go through unscreened.
 #[test]
 fn a_copy_of_a_committed_reference_datatype_is_screened() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_committed.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_committed.h5");
     let inner = write_committed_reference_file(&path, 0);
     assert_eq!(
         write_committed_reference_file(&path, inner),
@@ -4629,7 +4497,6 @@ fn a_copy_of_a_committed_reference_datatype_is_screened() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The other side of that resolution: a committed datatype that is *not* a
@@ -4645,7 +4512,7 @@ fn a_copy_of_a_committed_reference_datatype_is_screened() {
 /// Attribute message. Both have to be followed for this copy to go through.
 #[test]
 fn a_copy_of_a_committed_ordinary_datatype_still_commits_beside_a_delete() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_copy_committed_ok.h5");
+    let path = temp_path("hdf5_pure_edit_ref_copy_committed_ok.h5");
     let mut b = FileBuilder::new();
     b.commit_datatype("mytype", hdf5_pure::make_f64_type());
     b.commit_datatype("counttype", hdf5_pure::make_i32_type());
@@ -4676,7 +4543,6 @@ fn a_copy_of_a_committed_ordinary_datatype_still_commits_beside_a_delete() {
     );
     assert!(file.group("g").is_err(), "g was deleted");
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The chunked/extensible variable-length-string refusal is an `||` of two
@@ -4685,7 +4551,7 @@ fn a_copy_of_a_committed_ordinary_datatype_still_commits_beside_a_delete() {
 /// which the test above does not (it only sets `with_chunks`).
 #[test]
 fn add_extensible_vlen_string_dataset_is_rejected_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_extensible_vlen_string.h5");
+    let path = temp_path("hdf5_pure_edit_add_extensible_vlen_string.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -4706,7 +4572,6 @@ fn add_extensible_vlen_string_dataset_is_rejected_without_writing() {
     }
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A zero-element variable-length-string dataset (an empty `with_vlen_strings`
@@ -4715,7 +4580,7 @@ fn add_extensible_vlen_string_dataset_is_rejected_without_writing() {
 /// sentinel as any other empty dataset.
 #[test]
 fn add_zero_element_vlen_string_dataset_via_edit_session() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_add_zero_vlen_string.h5");
+    let path = temp_path("hdf5_pure_edit_add_zero_vlen_string.h5");
     write_starter(&path);
 
     {
@@ -4733,7 +4598,6 @@ fn add_zero_element_vlen_string_dataset_via_edit_session() {
     let ds = file.dataset("labels").unwrap();
     assert_eq!(ds.shape().unwrap(), vec![0]);
     assert_eq!(ds.read_string().unwrap(), Vec::<String>::new());
-    std::fs::remove_file(&path).ok();
 }
 
 /// Regression test: `write_dataset(...).with_vlen_strings(...)` must not
@@ -4743,7 +4607,7 @@ fn add_zero_element_vlen_string_dataset_via_edit_session() {
 /// refused up front, and the refusal must not write anything.
 #[test]
 fn write_dataset_rejects_vlen_strings_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_write_vlen_string_rejected.h5");
+    let path = temp_path("hdf5_pure_edit_write_vlen_string_rejected.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("labels").with_vlen_strings(&["a", "b"]);
     b.write(&path).unwrap();
@@ -4776,7 +4640,6 @@ fn write_dataset_rejects_vlen_strings_without_writing() {
         file.dataset("labels").unwrap().read_string().unwrap(),
         vec!["a".to_string(), "b".to_string()]
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// The object-reference counterpart of
@@ -4792,8 +4655,7 @@ fn write_dataset_rejects_vlen_strings_without_writing() {
 /// every write, and they are here for a version of this code where it does not.
 #[test]
 fn write_dataset_rejects_object_references_without_writing() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_write_object_ref_rejected.h5");
-    std::fs::remove_file(&path).ok();
+    let path = temp_path("hdf5_pure_edit_write_object_ref_rejected.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("a").with_i32_data(&[1]);
     b.create_dataset("bb").with_i32_data(&[2]);
@@ -4835,7 +4697,6 @@ fn write_dataset_rejects_object_references_without_writing() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The boundary of the refusal above: what it rejects is an *unresolved* target,
@@ -4853,8 +4714,7 @@ fn write_dataset_rejects_object_references_without_writing() {
 /// which this refusal neither creates nor closes).
 #[test]
 fn write_dataset_accepts_resolved_reference_addresses() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_write_resolved_refs.h5");
-    std::fs::remove_file(&path).ok();
+    let path = temp_path("hdf5_pure_edit_write_resolved_refs.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("a").with_i32_data(&[1]);
     b.create_dataset("bb").with_i32_data(&[2]);
@@ -4890,7 +4750,6 @@ fn write_dataset_accepts_resolved_reference_addresses() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A staged dataset whose datatype occupies zero bytes per element is refused at
@@ -4900,7 +4759,7 @@ fn write_dataset_accepts_resolved_reference_addresses() {
 /// parse-side refusal (issue #268).
 #[test]
 fn a_zero_width_element_type_is_refused_by_a_staged_write() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_zero_width.h5");
+    let path = temp_path("hdf5_pure_edit_zero_width.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -4941,7 +4800,6 @@ fn a_zero_width_element_type_is_refused_by_a_staged_write() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// An empty (zero-element) chunked, unlimited dataset added in place: the shape
@@ -4954,7 +4812,7 @@ fn a_zero_width_element_type_is_refused_by_a_staged_write() {
 /// the index over zero chunks is a real Extensible Array and not a placeholder.
 #[test]
 fn add_empty_extensible_chunked_dataset_and_grow_it() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_empty_chunked.h5");
+    let path = temp_path("hdf5_pure_edit_empty_chunked.h5");
     write_starter(&path);
 
     {
@@ -5019,7 +4877,6 @@ fn add_empty_extensible_chunked_dataset_and_grow_it() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// The other empty-chunked shapes the same lifted refusal now admits: a
@@ -5028,7 +4885,7 @@ fn add_empty_extensible_chunked_dataset_and_grow_it() {
 /// nothing — a fixed array, and the filtered pipeline that never runs.
 #[test]
 fn add_empty_chunked_datasets_of_every_flavor() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_empty_chunked_flavors.h5");
+    let path = temp_path("hdf5_pure_edit_empty_chunked_flavors.h5");
     write_starter(&path);
 
     {
@@ -5130,7 +4987,6 @@ fn add_empty_chunked_datasets_of_every_flavor() {
         (0..40).collect::<Vec<i32>>()
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -5159,7 +5015,7 @@ fn write_rotation_starter(path: &std::path::Path) {
 
 #[test]
 fn a_dataset_is_replaced_at_its_own_path_in_one_commit() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_dataset.h5");
+    let path = temp_path("hdf5_pure_edit_replace_dataset.h5");
     write_rotation_starter(&path);
 
     {
@@ -5200,12 +5056,11 @@ fn a_dataset_is_replaced_at_its_own_path_in_one_commit() {
         vec![7, 8]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn replacing_a_group_replaces_its_whole_subtree() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_group.h5");
+    let path = temp_path("hdf5_pure_edit_replace_group.h5");
     write_rotation_starter(&path);
 
     {
@@ -5247,12 +5102,11 @@ fn replacing_a_group_replaces_its_whole_subtree() {
         1
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn a_dataset_is_replaced_below_the_root_too() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_nested.h5");
+    let path = temp_path("hdf5_pure_edit_replace_nested.h5");
     write_rotation_starter(&path);
 
     {
@@ -5273,12 +5127,11 @@ fn a_dataset_is_replaced_below_the_root_too() {
         vec![5, 5, 5]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn rotating_one_path_in_a_session_stops_growing_the_file() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_rotation_bounded.h5");
+    let path = temp_path("hdf5_pure_edit_rotation_bounded.h5");
     write_rotation_starter(&path);
 
     let mut sizes = Vec::new();
@@ -5314,14 +5167,13 @@ fn rotating_one_path_in_a_session_stops_growing_the_file() {
         vec![11i32; 256]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn an_addition_below_a_path_needs_that_path_replaced_too() {
     // Replacing `g` makes an addition below it unambiguous: `g/added` is placed
     // in the group this commit builds, not in the one it removes.
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_descendant_ok.h5");
+    let path = temp_path("hdf5_pure_edit_replace_descendant_ok.h5");
     write_rotation_starter(&path);
     {
         let session = File::open_rw(&path).unwrap();
@@ -5345,11 +5197,10 @@ fn an_addition_below_a_path_needs_that_path_replaced_too() {
         "the addition landed in the group being removed rather than its replacement"
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 
     // Without that replacement it is the ambiguity the refusal exists for: the
     // addition names a group whose own link this commit removes.
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_descendant.h5");
+    let path = temp_path("hdf5_pure_edit_replace_descendant.h5");
     write_rotation_starter(&path);
     let before = std::fs::read(&path).unwrap();
     let session = File::open_rw(&path).unwrap();
@@ -5368,12 +5219,11 @@ fn an_addition_below_a_path_needs_that_path_replaced_too() {
     // The refusal is a preflight, so not a byte of the file changed.
     drop(session);
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn a_group_and_a_dataset_replace_each_other() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_kind_swap.h5");
+    let path = temp_path("hdf5_pure_edit_replace_kind_swap.h5");
     write_rotation_starter(&path);
 
     // A dataset over a group: the whole subtree goes with the link.
@@ -5426,12 +5276,11 @@ fn a_group_and_a_dataset_replace_each_other() {
     );
     assert_eq!(file.dataset("g/back").unwrap().read_i32().unwrap(), vec![7]);
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn a_staged_edit_to_a_replaced_object_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_edited.h5");
+    let path = temp_path("hdf5_pure_edit_replace_edited.h5");
     write_rotation_starter(&path);
 
     // `g` is replaced by a *dataset*, so the group-attribute edit at the same
@@ -5463,12 +5312,11 @@ fn a_staged_edit_to_a_replaced_object_is_refused() {
         vec![7, 8]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
 
     // The same rule one level down: `g` is replaced by a group this time, but
     // `g/sub` names the *original's* subgroup, which the replacement does not
     // create. Refused for the same reason and by the same guard.
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_edited_child.h5");
+    let path = temp_path("hdf5_pure_edit_replace_edited_child.h5");
     write_rotation_starter(&path);
     let before = std::fs::read(&path).unwrap();
     let session = File::open_rw(&path).unwrap();
@@ -5486,12 +5334,11 @@ fn a_staged_edit_to_a_replaced_object_is_refused() {
     );
     drop(session);
     assert_eq!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn a_copy_replaces_an_object_at_its_own_path() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_by_copy.h5");
+    let path = temp_path("hdf5_pure_edit_replace_by_copy.h5");
     write_rotation_starter(&path);
 
     // A copy is linked into its parent by the same apply-loop step as a created
@@ -5516,12 +5363,11 @@ fn a_copy_replaces_an_object_at_its_own_path() {
     );
     assert_eq!(file.dataset("slot").unwrap().shape().unwrap(), vec![2]);
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn a_copy_reading_from_a_replaced_path_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_replace_copy_source.h5");
+    let path = temp_path("hdf5_pure_edit_replace_copy_source.h5");
     write_rotation_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -5585,7 +5431,6 @@ fn a_copy_reading_from_a_replaced_path_is_refused() {
     );
     assert!(file.dataset("slot").is_err());
     drop(file);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A commit refused partway through its preflight must leave the staged set
@@ -5598,7 +5443,7 @@ fn a_copy_reading_from_a_replaced_path_is_refused() {
 /// valid edits and left `has_staged_edits()` answering `false`.
 #[test]
 fn a_refused_commit_leaves_its_other_staged_edits_alone() {
-    let path = std::env::temp_dir().join("hdf5_pure_refused_keeps_staged.h5");
+    let path = temp_path("hdf5_pure_refused_keeps_staged.h5");
     {
         let mut b = FileBuilder::new();
         let mut g = b.create_group("g");
@@ -5650,7 +5495,6 @@ fn a_refused_commit_leaves_its_other_staged_edits_alone() {
         before,
         "a refused commit wrote to the file"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// A commit refused in its *first* preflight loop must not leave the rest of
@@ -5663,7 +5507,7 @@ fn a_refused_commit_leaves_its_other_staged_edits_alone() {
 /// the batch it had been told was rejected.
 #[test]
 fn a_refused_commit_does_not_apply_its_survivors_later() {
-    let path = std::env::temp_dir().join("hdf5_pure_refused_no_partial_apply.h5");
+    let path = temp_path("hdf5_pure_refused_no_partial_apply.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
@@ -5710,7 +5554,6 @@ fn a_refused_commit_does_not_apply_its_survivors_later() {
         file.dataset("added_a").is_err(),
         "an edit from a refused batch reached the file"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 /// The restore a refused commit performs covers *every* kind of staged edit,
@@ -5777,7 +5620,7 @@ fn a_refused_commit_restores_every_kind_of_staged_edit() {
         }),
     ];
 
-    let donor_path = std::env::temp_dir().join("hdf5_pure_restore_kinds_donor.h5");
+    let donor_path = temp_path("hdf5_pure_restore_kinds_donor.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("donor").with_i32_data(&[7]);
@@ -5785,8 +5628,7 @@ fn a_refused_commit_restores_every_kind_of_staged_edit() {
     }
 
     for (what, stage) in cases {
-        let path =
-            std::env::temp_dir().join(format!("hdf5_pure_restore_{}.h5", what.replace(' ', "_")));
+        let path = temp_path(&format!("hdf5_pure_restore_{}.h5", what.replace(' ', "_")));
         {
             let mut b = FileBuilder::new();
             b.create_dataset("original").with_i32_data(&[0]);
@@ -5831,9 +5673,7 @@ fn a_refused_commit_restores_every_kind_of_staged_edit() {
             before,
             "[{what}] a refused commit wrote to the file"
         );
-        std::fs::remove_file(&path).ok();
     }
-    std::fs::remove_file(&donor_path).ok();
 }
 
 /// A staging call that refuses stages nothing, even when it carries a batch.
@@ -5844,7 +5684,7 @@ fn a_refused_commit_restores_every_kind_of_staged_edit() {
 /// (issue #316), leaving the session as the call found it.
 #[test]
 fn a_refused_staging_call_stages_none_of_its_batch() {
-    let path = std::env::temp_dir().join("hdf5_pure_refused_staging_batch.h5");
+    let path = temp_path("hdf5_pure_refused_staging_batch.h5");
     write_starter(&path);
     let before = std::fs::read(&path).unwrap();
 
@@ -5890,7 +5730,6 @@ fn a_refused_staging_call_stages_none_of_its_batch() {
     );
     drop(file);
     assert_ne!(std::fs::read(&path).unwrap(), before);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A group's added datasets are placed in staging order, which is the order
@@ -5904,7 +5743,7 @@ fn a_refused_staging_call_stages_none_of_its_batch() {
 /// "still writing" having already written part of itself.
 #[test]
 fn a_reference_datasets_placement_order_is_the_order_the_preflight_proved() {
-    let path = std::env::temp_dir().join("hdf5_pure_edit_ref_placement_order.h5");
+    let path = temp_path("hdf5_pure_edit_ref_placement_order.h5");
     write_starter(&path);
 
     {
@@ -5940,7 +5779,6 @@ fn a_reference_datasets_placement_order_is_the_order_the_preflight_proved() {
         }
         other => panic!("expected a dataset reference, got {other:?}"),
     }
-    std::fs::remove_file(&path).ok();
 }
 
 /// A group gains its new links in the order the commit places them: copied
@@ -5954,8 +5792,8 @@ fn a_reference_datasets_placement_order_is_the_order_the_preflight_proved() {
 /// nothing else observes where in the sequence they land.
 #[test]
 fn a_group_gains_its_new_links_in_placement_order() {
-    let donor_path = std::env::temp_dir().join("hdf5_pure_link_order_donor.h5");
-    let path = std::env::temp_dir().join("hdf5_pure_link_order.h5");
+    let donor_path = temp_path("hdf5_pure_link_order_donor.h5");
+    let path = temp_path("hdf5_pure_link_order.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("donated").with_i32_data(&[3]);
@@ -5994,6 +5832,4 @@ fn a_group_gains_its_new_links_in_placement_order() {
         ]
     );
     drop(file);
-    std::fs::remove_file(&path).ok();
-    std::fs::remove_file(&donor_path).ok();
 }

--- a/tests/edit_userblock.rs
+++ b/tests/edit_userblock.rs
@@ -18,7 +18,12 @@
 
 use hdf5_pure::{AttrValue, File, FileBuilder, Object};
 
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
+
 const UB: usize = 512;
+
 const MARKER: &[u8] = b"USERBLOCK-MARKER-0104";
 
 /// Build a userblock file with two root datasets and a nested group+dataset,
@@ -47,7 +52,7 @@ fn build_userblock_file(path: &std::path::Path) -> Vec<u8> {
 
 #[test]
 fn synthetic_userblock_file_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_roundtrip.h5");
+    let path = temp_path("hdf5_pure_ub_roundtrip.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -122,8 +127,6 @@ fn synthetic_userblock_file_roundtrip() {
     );
     assert_eq!(&after[..MARKER.len()], MARKER);
     assert_eq!(after[UB - 1], 0xAB);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -131,7 +134,7 @@ fn userblock_inplace_overwrite_only_takes_fast_path() {
     // A lone same-length overwrite takes the in-place fast path (no header
     // rewrite, no superblock flip); it must work on a userblock file and leave
     // the userblock untouched.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_inplace_only.h5");
+    let path = temp_path("hdf5_pure_ub_inplace_only.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -155,8 +158,6 @@ fn userblock_inplace_overwrite_only_takes_fast_path() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// Cross-file copy *from* a userblock source is still refused (the source-file
@@ -166,8 +167,8 @@ fn userblock_inplace_overwrite_only_takes_fast_path() {
 /// exercised in `edit_userblock_followups.rs` / `edit_userblock_crosscheck.rs`.
 #[test]
 fn userblock_cross_file_copy_from_userblock_source_is_refused() {
-    let src_path = std::env::temp_dir().join("hdf5_pure_ub_xcopy_src_refuse.h5");
-    let dst_path = std::env::temp_dir().join("hdf5_pure_ub_xcopy_dst_refuse.h5");
+    let src_path = temp_path("hdf5_pure_ub_xcopy_src_refuse.h5");
+    let dst_path = temp_path("hdf5_pure_ub_xcopy_dst_refuse.h5");
     build_userblock_file(&src_path);
     build_userblock_file(&dst_path);
     let dst_before = std::fs::read(&dst_path).unwrap();
@@ -187,9 +188,6 @@ fn userblock_cross_file_copy_from_userblock_source_is_refused() {
         dst_before,
         "a refused cross-file copy must not modify the destination"
     );
-
-    std::fs::remove_file(&src_path).ok();
-    std::fs::remove_file(&dst_path).ok();
 }
 
 /// An empty (zero-element) dataset added on a userblock file must round-trip
@@ -200,7 +198,7 @@ fn userblock_cross_file_copy_from_userblock_source_is_refused() {
 /// identical, so only a non-zero base can catch a mistake here.
 #[test]
 fn userblock_add_empty_dataset_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_empty.h5");
+    let path = temp_path("hdf5_pure_ub_add_empty.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -223,8 +221,6 @@ fn userblock_add_empty_dataset_roundtrip() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// The chunked counterpart of the test above: an empty chunked dataset added on
@@ -239,7 +235,7 @@ fn userblock_add_empty_dataset_roundtrip() {
 /// where it landed.
 #[test]
 fn userblock_add_empty_chunked_dataset_and_grow_it() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_empty_chunked.h5");
+    let path = temp_path("hdf5_pure_ub_add_empty_chunked.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -299,8 +295,6 @@ fn userblock_add_empty_chunked_dataset_and_grow_it() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// A provenance-tagged dataset added on a userblock file must round-trip
@@ -312,7 +306,7 @@ fn userblock_add_empty_chunked_dataset_and_grow_it() {
 fn userblock_add_provenance_dataset_roundtrip() {
     use hdf5_pure::VerifyResult;
 
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_provenance.h5");
+    let path = temp_path("hdf5_pure_ub_add_provenance.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -338,8 +332,6 @@ fn userblock_add_provenance_dataset_roundtrip() {
         Some(&AttrValue::String("test-suite".into()))
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// A dataset with a variable-length attribute, added on a userblock file,
@@ -348,7 +340,7 @@ fn userblock_add_provenance_dataset_roundtrip() {
 /// a no-op at `base == 0`) once `base` is non-zero.
 #[test]
 fn userblock_add_dataset_with_vlen_attribute_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_vlen_attr.h5");
+    let path = temp_path("hdf5_pure_ub_add_vlen_attr.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -375,8 +367,6 @@ fn userblock_add_dataset_with_vlen_attribute_roundtrip() {
         ]))
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// A variable-length-string dataset added on a userblock file must round-trip
@@ -385,7 +375,7 @@ fn userblock_add_dataset_with_vlen_attribute_roundtrip() {
 /// an attribute.
 #[test]
 fn userblock_add_vlen_string_dataset_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_vlen_string_ds.h5");
+    let path = temp_path("hdf5_pure_ub_add_vlen_string_ds.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -405,8 +395,6 @@ fn userblock_add_vlen_string_dataset_roundtrip() {
         vec!["alpha".to_string(), String::new(), "gamma".to_string()]
     );
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 /// An object-reference dataset added on a userblock file must round-trip
@@ -414,7 +402,7 @@ fn userblock_add_vlen_string_dataset_roundtrip() {
 /// address is otherwise only ever exercised as a no-op at `base == 0`.
 #[test]
 fn userblock_add_reference_dataset_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_add_ref.h5");
+    let path = temp_path("hdf5_pure_ub_add_ref.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -439,15 +427,13 @@ fn userblock_add_reference_dataset_roundtrip() {
         other => panic!("expected a dataset reference, got {other:?}"),
     }
     assert_eq!(&std::fs::read(&path).unwrap()[..UB], &userblock[..]);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn real_mat_add_dataset_preserves_userblock_and_data() {
     // Copy the fixture so the test never mutates the checked-in file.
     let src = std::path::Path::new("tests/fixtures/mat_real/test_string_v73.mat");
-    let path = std::env::temp_dir().join("hdf5_pure_ub_real_mat.mat");
+    let path = temp_path("hdf5_pure_ub_real_mat.mat");
     std::fs::copy(src, &path).unwrap();
 
     let original_userblock = std::fs::read(&path).unwrap()[..UB].to_vec();
@@ -509,6 +495,4 @@ fn real_mat_add_dataset_preserves_userblock_and_data() {
         after_userblock, original_userblock,
         "MATLAB userblock changed across the edit"
     );
-
-    std::fs::remove_file(&path).ok();
 }

--- a/tests/edit_userblock_chunked.rs
+++ b/tests/edit_userblock_chunked.rs
@@ -15,7 +15,12 @@
 
 use hdf5_pure::{File, FileBuilder};
 
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
+
 const UB: usize = 512;
+
 const MARKER: &[u8] = b"USERBLOCK-CHUNK-0104";
 
 /// Stamp a recognizable marker across the userblock region of `bytes` and return
@@ -39,7 +44,7 @@ fn assert_userblock_unchanged(path: &std::path::Path, original: &[u8]) {
 fn userblock_chunked_add_roundtrip() {
     // Add a deflate-compressed multi-chunk dataset to a userblock file alongside
     // an untouched contiguous dataset, then read both back.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_add.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_add.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("contig")
@@ -70,8 +75,6 @@ fn userblock_chunked_add_roundtrip() {
     );
     assert_userblock_unchanged(&path, &userblock);
     assert_eq!(&std::fs::read(&path).unwrap()[..MARKER.len()], MARKER);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -79,7 +82,7 @@ fn userblock_chunked_unfiltered_inplace_overwrite() {
     // An unfiltered chunked dataset: each chunk's slot is exactly its raw size, so
     // a same-shape overwrite re-fills every slot in place — no relocation, so the
     // file does not grow.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_inplace.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_inplace.h5");
     let original: Vec<f64> = (0..200).map(|i| i as f64).collect();
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
@@ -119,8 +122,6 @@ fn userblock_chunked_unfiltered_inplace_overwrite() {
         updated
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -130,7 +131,7 @@ fn userblock_chunked_shrinking_inplace_overwrite() {
     // the index is rebuilt in place to record the new (smaller) sizes — no
     // relocation, so the file does not grow. This exercises the base-aware
     // in-place index rebuild on a userblock file.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_shrink.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_shrink.h5");
     // Poorly compressible original (high-entropy) vs. highly compressible
     // replacement (all equal): each new chunk re-encodes far smaller than its slot.
     let original: Vec<f64> = (0..400).map(|i| (i as f64).sin() * 1e6).collect();
@@ -173,8 +174,6 @@ fn userblock_chunked_shrinking_inplace_overwrite() {
         updated
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -183,7 +182,7 @@ fn real_mat_add_chunked_dataset_preserves_userblock() {
     // index and chunk data addresses are written relative to the 512-byte MATLAB
     // userblock, and the added value plus an untouched original both read back.
     let src = std::path::Path::new("tests/fixtures/mat_real/test_string_v73.mat");
-    let path = std::env::temp_dir().join("hdf5_pure_ub_real_mat_chunk.mat");
+    let path = temp_path("hdf5_pure_ub_real_mat_chunk.mat");
     std::fs::copy(src, &path).unwrap();
     let original_userblock = std::fs::read(&path).unwrap()[..UB].to_vec();
     assert_eq!(&original_userblock[..10], b"MATLAB 7.3");
@@ -225,8 +224,6 @@ fn real_mat_add_chunked_dataset_preserves_userblock() {
         &std::fs::read(&path).unwrap()[..UB],
         &original_userblock[..]
     );
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -236,7 +233,7 @@ fn userblock_extensible_array_add_and_overwrite_roundtrip() {
     // secondary/data blocks) — all built off the planner base. This exercises that
     // index type's base arithmetic on a userblock file, for both add and a
     // relocating overwrite.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_ea.h5");
+    let path = temp_path("hdf5_pure_ub_ea.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("keep").with_i32_data(&[7, 8, 9]);
@@ -289,8 +286,6 @@ fn userblock_extensible_array_add_and_overwrite_roundtrip() {
         vec![7, 8, 9]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -298,7 +293,7 @@ fn userblock_single_chunk_index_add_and_overwrite() {
     // A dataset whose shape equals its chunk shape stores a single chunk (v4 type 1
     // single-chunk index), whose address lives in the data-layout message rather
     // than a separate index structure. Exercise add + overwrite on a userblock file.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_single_chunk.h5");
+    let path = temp_path("hdf5_pure_ub_single_chunk.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     let mut bytes = b.finish().unwrap();
@@ -342,8 +337,6 @@ fn userblock_single_chunk_index_add_and_overwrite() {
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("sc").unwrap().read_f64().unwrap(), updated);
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -351,7 +344,7 @@ fn userblock_chunked_relocating_overwrite_roundtrip() {
     // A deflate dataset whose new contents compress to different per-chunk sizes
     // cannot re-fill its slots, so the overwrite rebuilds and relocates the chunk
     // storage and reclaims the old blob. The new value must read back.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_reloc.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_reloc.h5");
     // Highly compressible original (all equal) vs. a varied replacement: their
     // compressed sizes differ, forcing the relocating path.
     let original = vec![7.0f64; 500];
@@ -386,8 +379,6 @@ fn userblock_chunked_relocating_overwrite_roundtrip() {
         vec![11, 22, 33]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -399,7 +390,7 @@ fn userblock_chunked_add_reuses_a_freed_chunk_hole() {
     // the file stays exactly as small, and only reading the data back through the
     // index catches it. So delete a chunked dataset, write another into the hole
     // it left, and read every chunk of it.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_hole.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_hole.h5");
     let victim: Vec<f64> = (0..2048).map(|i| (i % 11) as f64).collect();
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
@@ -447,8 +438,6 @@ fn userblock_chunked_add_reuses_a_freed_chunk_hole() {
     );
     assert!(file.dataset("victim").is_err());
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -462,7 +451,7 @@ fn userblock_chunked_overwrite_reuses_reclaimed_space() {
     // `userblock_chunked_add_reuses_a_freed_chunk_hole` covers the same ground for
     // a chunk blob placed into the hole, where the base arithmetic runs on the
     // addresses the blob itself embeds.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_chunk_reclaim.h5");
+    let path = temp_path("hdf5_pure_ub_chunk_reclaim.h5");
     // A moderately-compressible original lays down a sizeable contiguous chunk blob
     // (the hole that will be reclaimed). The high-entropy replacement re-encodes to
     // chunks that no longer fit those slots, forcing the relocating path.
@@ -521,6 +510,4 @@ fn userblock_chunked_overwrite_reuses_reclaimed_space() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }

--- a/tests/edit_userblock_followups.rs
+++ b/tests/edit_userblock_followups.rs
@@ -13,7 +13,12 @@
 
 use hdf5_pure::{AttrValue, File, FileBuilder};
 
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
+
 const UB: usize = 512;
+
 const MARKER: &[u8] = b"USERBLOCK-FOLLOWUP-104";
 
 /// Stamp a recognizable marker across the userblock region of `bytes` and return
@@ -53,7 +58,7 @@ fn build_userblock_file(path: &std::path::Path) -> Vec<u8> {
 
 #[test]
 fn userblock_delete_dataset_roundtrip() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_ds.h5");
+    let path = temp_path("hdf5_pure_ub_fu_delete_ds.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -77,8 +82,6 @@ fn userblock_delete_dataset_roundtrip() {
     datasets.sort();
     assert_eq!(datasets, vec!["beta".to_string()]);
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -86,7 +89,7 @@ fn userblock_delete_group_subtree_roundtrip() {
     // Deleting a group reclaims its whole subtree (its header plus the nested
     // dataset's header and data). On a userblock file every child link and data
     // address is base-relative, so the subtree walk must re-absolutize them.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_grp.h5");
+    let path = temp_path("hdf5_pure_ub_fu_delete_grp.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -104,15 +107,13 @@ fn userblock_delete_group_subtree_roundtrip() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn userblock_delete_chunked_dataset_roundtrip() {
     // Deleting a chunked/filtered dataset reclaims its chunk index and chunk data
     // blocks via the base-aware `chunked_storage_spans`.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_chunk.h5");
+    let path = temp_path("hdf5_pure_ub_fu_delete_chunk.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
@@ -139,8 +140,6 @@ fn userblock_delete_chunked_dataset_roundtrip() {
         vec![1, 2, 3]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -150,7 +149,7 @@ fn userblock_delete_then_reuse_freed_space() {
     // than only appending. The reused write lands at the freed *absolute* offset,
     // so a base mistake in `collect_free_spans` would either leak (no reuse) or, far
     // worse, free a still-live region the reuse then corrupts.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_reuse.h5");
+    let path = temp_path("hdf5_pure_ub_fu_delete_reuse.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     let big: Vec<f64> = (0..256).map(|i| i as f64).collect();
@@ -188,15 +187,13 @@ fn userblock_delete_then_reuse_freed_space() {
         vec![7, 8, 9]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn userblock_delete_one_of_several_then_read_attr() {
     // A delete rewrites the parent group's header (relinking survivors) and frees
     // the removed object. A sibling group's compact attribute must remain readable.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_delete_attr.h5");
+    let path = temp_path("hdf5_pure_ub_fu_delete_attr.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("doomed").with_f64_data(&[1.0, 2.0]);
@@ -226,8 +223,6 @@ fn userblock_delete_one_of_several_then_read_attr() {
         Some(&AttrValue::AsciiString("kept".into()))
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 // ---- copy (in-file) ----
@@ -237,7 +232,7 @@ fn userblock_copy_dataset_roundtrip() {
     // Copying a contiguous dataset writes a fresh data block and header; on a
     // userblock file the new data address and the parent link to the copy must both
     // be stored base-relative.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_ds.h5");
+    let path = temp_path("hdf5_pure_ub_fu_copy_ds.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -262,15 +257,13 @@ fn userblock_copy_dataset_roundtrip() {
         vec![7.5, 8.5]
     );
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn userblock_copy_group_subtree_roundtrip() {
     // Copying a whole group deep-copies its nested dataset too; every child link
     // and data address in the copy is written base-relative.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_grp.h5");
+    let path = temp_path("hdf5_pure_ub_fu_copy_grp.h5");
     let userblock = build_userblock_file(&path);
 
     {
@@ -293,15 +286,13 @@ fn userblock_copy_group_subtree_roundtrip() {
     groups.sort();
     assert_eq!(groups, vec!["grp".to_string(), "grp_copy".to_string()]);
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn userblock_copy_chunked_dataset_roundtrip() {
     // Copying a chunked/filtered dataset enumerates the source chunks (on a
     // base-relative view of the file) and rebuilds the index at the new location.
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_copy_chunk.h5");
+    let path = temp_path("hdf5_pure_ub_fu_copy_chunk.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     let data: Vec<f64> = (0..600).map(|i| (i % 9) as f64 * 0.25).collect();
@@ -324,8 +315,6 @@ fn userblock_copy_chunked_dataset_roundtrip() {
     assert_eq!(file.dataset("c").unwrap().read_f64().unwrap(), data);
     assert_eq!(file.dataset("c_copy").unwrap().read_f64().unwrap(), data);
     assert_userblock_unchanged(&path, &userblock);
-
-    std::fs::remove_file(&path).ok();
 }
 
 // ---- copy (cross-file, into a userblock destination) ----
@@ -334,8 +323,8 @@ fn userblock_copy_chunked_dataset_roundtrip() {
 fn userblock_cross_file_copy_into_userblock_dest() {
     // A base-0 source file is copied into a userblock destination. The destination
     // writes the copy base-relative even though the source was read base-0.
-    let dst_path = std::env::temp_dir().join("hdf5_pure_ub_fu_xcopy_dst.h5");
-    let src_path = std::env::temp_dir().join("hdf5_pure_ub_fu_xcopy_src.h5");
+    let dst_path = temp_path("hdf5_pure_ub_fu_xcopy_dst.h5");
+    let src_path = temp_path("hdf5_pure_ub_fu_xcopy_src.h5");
     let userblock = build_userblock_file(&dst_path);
 
     // A plain (no-userblock) source file.
@@ -374,9 +363,6 @@ fn userblock_cross_file_copy_into_userblock_dest() {
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_userblock_unchanged(&dst_path, &userblock);
-
-    std::fs::remove_file(&dst_path).ok();
-    std::fs::remove_file(&src_path).ok();
 }
 
 // ---- reference screening (issue #317) ----
@@ -393,7 +379,7 @@ fn userblock_cross_file_copy_into_userblock_dest() {
 /// `resolve_reference_target` entirely (issue #317).
 #[test]
 fn userblock_reference_into_deleted_space_is_refused() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_ref_delete.h5");
+    let path = temp_path("hdf5_pure_ub_fu_ref_delete.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("alpha").with_f64_data(&[1.0, 2.0]);
@@ -437,7 +423,6 @@ fn userblock_reference_into_deleted_space_is_refused() {
 
     assert_eq!(std::fs::read(&path).unwrap(), before);
     assert_userblock_unchanged(&path, &userblock);
-    std::fs::remove_file(&path).ok();
 }
 
 /// A path reference to an object the *same commit* places, on a userblock file.
@@ -449,7 +434,7 @@ fn userblock_reference_into_deleted_space_is_refused() {
 /// this edit — legal, and fine on a base-0 file — panicked in a debug build.
 #[test]
 fn userblock_reference_to_an_object_the_same_commit_places() {
-    let path = std::env::temp_dir().join("hdf5_pure_ub_fu_ref_same_commit.h5");
+    let path = temp_path("hdf5_pure_ub_fu_ref_same_commit.h5");
     let mut b = FileBuilder::new();
     b.with_userblock(UB as u64);
     b.create_dataset("alpha").with_f64_data(&[1.0, 2.0]);
@@ -493,5 +478,4 @@ fn userblock_reference_to_an_object_the_same_commit_places() {
     }
     drop(file);
     assert_userblock_unchanged(&path, &userblock);
-    std::fs::remove_file(&path).ok();
 }

--- a/tests/file_inspect.rs
+++ b/tests/file_inspect.rs
@@ -4,6 +4,10 @@
 
 use hdf5_pure::{File, FileBuilder, LibVer, is_hdf5, is_hdf5_bytes};
 
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
+
 fn sample_file() -> Vec<u8> {
     let mut builder = FileBuilder::new();
     builder
@@ -22,7 +26,10 @@ fn is_hdf5_bytes_detects_signature() {
 
 #[test]
 fn is_hdf5_path_roundtrip() {
-    let dir = std::env::temp_dir();
+    // One directory, three names: this test wants a missing path alongside the
+    // two it writes, so it holds the directory rather than a single fixture.
+    let held = tempfile::tempdir().unwrap();
+    let dir = held.path();
     let h5 = dir.join("hdf5_pure_is_hdf5_yes.h5");
     let other = dir.join("hdf5_pure_is_hdf5_no.bin");
     std::fs::write(&h5, sample_file()).unwrap();
@@ -33,9 +40,6 @@ fn is_hdf5_path_roundtrip() {
 
     // A missing file is an I/O error, not `Ok(false)`.
     assert!(is_hdf5(dir.join("hdf5_pure_definitely_missing.h5")).is_err());
-
-    std::fs::remove_file(&h5).ok();
-    std::fs::remove_file(&other).ok();
 }
 
 #[test]
@@ -46,12 +50,11 @@ fn file_size_matches_buffer_and_metadata() {
     let file = File::from_bytes(bytes.clone()).unwrap();
     assert_eq!(file.file_size(), len);
 
-    let path = std::env::temp_dir().join("hdf5_pure_file_size.h5");
+    let path = temp_path("hdf5_pure_file_size.h5");
     std::fs::write(&path, &bytes).unwrap();
     let on_disk = File::open(&path).unwrap();
     assert_eq!(on_disk.file_size(), len);
     assert_eq!(on_disk.file_size(), std::fs::metadata(&path).unwrap().len());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]

--- a/tests/file_space_strategy.rs
+++ b/tests/file_space_strategy.rs
@@ -5,9 +5,9 @@
 
 use hdf5_pure::{File, FileBuilder, FileSpaceStrategy};
 
-fn tmp(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(name)
-}
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
 
 #[test]
 fn each_strategy_roundtrips() {
@@ -20,7 +20,7 @@ fn each_strategy_roundtrips() {
     .into_iter()
     .enumerate()
     {
-        let path = tmp(&format!("hdf5_pure_fss_{i}.h5"));
+        let path = temp_path(&format!("hdf5_pure_fss_{i}.h5"));
         let mut b = FileBuilder::new();
         b.create_dataset("d").with_i32_data(&[1, 2, 3, 4]);
         b.with_file_space_strategy(strategy, false, 7)
@@ -44,14 +44,12 @@ fn each_strategy_roundtrips() {
             f.dataset("d").unwrap().read_i32().unwrap(),
             vec![1, 2, 3, 4]
         );
-
-        std::fs::remove_file(&path).ok();
     }
 }
 
 #[test]
 fn no_config_writes_no_extension() {
-    let path = tmp("hdf5_pure_fss_default.h5");
+    let path = temp_path("hdf5_pure_fss_default.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_f64_data(&[1.5, 2.5]);
     b.write(&path).unwrap();
@@ -65,12 +63,11 @@ fn no_config_writes_no_extension() {
         Some(u64::MAX),
         "no extension is written when file space is unconfigured"
     );
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn page_size_only_defaults_strategy() {
-    let path = tmp("hdf5_pure_fss_pageonly.h5");
+    let path = temp_path("hdf5_pure_fss_pageonly.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_i32_data(&[9]);
     b.with_file_space_page_size(2048);
@@ -83,14 +80,13 @@ fn page_size_only_defaults_strategy() {
     assert_eq!(info.strategy, FileSpaceStrategy::FsmAggr);
     assert_eq!(info.page_size, 2048);
     assert_eq!(info.threshold, 1); // default
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
 fn strategy_survives_userblock_and_empty_file() {
     // A userblock shifts base_address, so the extension's base-relative address
     // must still resolve; and a file with no datasets must still carry it.
-    let path = tmp("hdf5_pure_fss_userblock.h5");
+    let path = temp_path("hdf5_pure_fss_userblock.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_i32_data(&[5, 6]);
     b.with_userblock(512)
@@ -99,15 +95,13 @@ fn strategy_survives_userblock_and_empty_file() {
     let f = File::open(&path).unwrap();
     assert_eq!(f.file_space_strategy(), Some(FileSpaceStrategy::None));
     assert_eq!(f.dataset("d").unwrap().read_i32().unwrap(), vec![5, 6]);
-    std::fs::remove_file(&path).ok();
 
-    let path = tmp("hdf5_pure_fss_empty.h5");
+    let path = temp_path("hdf5_pure_fss_empty.h5");
     let mut b = FileBuilder::new();
     b.with_file_space_strategy(FileSpaceStrategy::Aggr, false, 1);
     b.write(&path).unwrap();
     let f = File::open(&path).unwrap();
     assert_eq!(f.file_space_strategy(), Some(FileSpaceStrategy::Aggr));
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -118,7 +112,7 @@ fn survives_in_place_edit() {
     // cut by truncation). Uses a non-paged strategy: a paged file cannot be edited
     // through the whole-file editor (issue #173 Phase 2), which is covered in
     // `tests/paged_mutation.rs`.
-    let path = tmp("hdf5_pure_fss_edit.h5");
+    let path = temp_path("hdf5_pure_fss_edit.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, false, 1);
@@ -143,7 +137,6 @@ fn survives_in_place_edit() {
         vec![1, 2, 3]
     );
     assert!(f.dataset("added").is_err());
-    std::fs::remove_file(&path).ok();
 }
 
 #[test]
@@ -151,7 +144,7 @@ fn persist_true_records_intent_on_a_fresh_file() {
     // A brand-new file has no free space, so persist = true records the persist
     // flag with no on-disk managers (matching the C library's brand-new persisted
     // file). A later File::open_rw that frees space fills the managers in.
-    let path = tmp("hdf5_pure_fss_persist.h5");
+    let path = temp_path("hdf5_pure_fss_persist.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("d").with_i32_data(&[1, 2, 3]);
     b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 1);
@@ -165,5 +158,4 @@ fn persist_true_records_intent_on_a_fresh_file() {
     assert!(info.manager_addrs.iter().all(|&a| a == u64::MAX));
     assert!(f.persisted_free_space().is_empty());
     assert_eq!(f.dataset("d").unwrap().read_i32().unwrap(), vec![1, 2, 3]);
-    std::fs::remove_file(&path).ok();
 }

--- a/tests/lzf_roundtrip.rs
+++ b/tests/lzf_roundtrip.rs
@@ -6,9 +6,9 @@
 
 use hdf5_pure::{Error, File, FileBuilder, FormatError, RepackOptions, repack};
 
-fn tmp(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(name)
-}
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
 
 #[test]
 fn lzf_i32_roundtrip() {
@@ -129,7 +129,7 @@ fn lzf_plus_deflate_refused() {
 /// requires `pipeline_reencodable` to accept the filter) and reads back exact.
 #[test]
 fn add_lzf_dataset_in_place() {
-    let path = tmp("hdf5_pure_edit_add_lzf.h5");
+    let path = temp_path("hdf5_pure_edit_add_lzf.h5");
     {
         let mut b = FileBuilder::new();
         b.create_dataset("original").with_f64_data(&[1.0, 2.0]);
@@ -150,14 +150,13 @@ fn add_lzf_dataset_in_place() {
 
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("lzf").unwrap().read_i32().unwrap(), data);
-    std::fs::remove_file(&path).ok();
 }
 
 /// Overwriting an LZF dataset in place re-encodes its chunks through the LZF
 /// compressor, the path `pipeline_reencodable` used to refuse.
 #[test]
 fn overwrite_lzf_dataset_in_place() {
-    let path = tmp("hdf5_pure_edit_overwrite_lzf.h5");
+    let path = temp_path("hdf5_pure_edit_overwrite_lzf.h5");
     let before: Vec<i32> = (0..256).collect();
     let after: Vec<i32> = (0..256).map(|i| i * 3).collect();
     {
@@ -177,7 +176,6 @@ fn overwrite_lzf_dataset_in_place() {
 
     let file = File::open(&path).unwrap();
     assert_eq!(file.dataset("v").unwrap().read_i32().unwrap(), after);
-    std::fs::remove_file(&path).ok();
 }
 
 fn fixture(name: &str) -> std::path::PathBuf {
@@ -325,8 +323,8 @@ fn reads_h5py_lzf_multichunk() {
 /// re-encode paths.
 #[test]
 fn repack_roundtrips_lzf() {
-    let src = tmp("hdf5_pure_repack_lzf_src.h5");
-    let dst = tmp("hdf5_pure_repack_lzf_dst.h5");
+    let src = temp_path("hdf5_pure_repack_lzf_src.h5");
+    let dst = temp_path("hdf5_pure_repack_lzf_dst.h5");
     let data: Vec<f64> = (0..1024).map(|i| (i as f64).cos()).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("vals")
@@ -342,7 +340,4 @@ fn repack_roundtrips_lzf() {
     let ds = file.dataset("vals").unwrap();
     assert_eq!(ds.filters(), vec![2, 32000]);
     assert_eq!(ds.read_f64().unwrap(), data);
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }

--- a/tests/mat_builder.rs
+++ b/tests/mat_builder.rs
@@ -3,12 +3,15 @@
 use hdf5_pure::mat::{Compression, MatBuilder, MatClass, MatError, Options, StringClass};
 use hdf5_pure::{AttrValue, File, LibVer};
 
-fn temp_path(name: &str) -> std::path::PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("hdf5pure-mat-builder-{name}-{nanos}.mat"))
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+
+/// A `.mat` fixture, in a directory that goes away with the returned value.
+///
+/// Replaces a nanosecond-stamped name in the shared temporary directory, which
+/// no two runs collided on but no run ever cleaned up (issue #334).
+fn temp_path(name: &str) -> temp_fixture::TempPath {
+    temp_fixture::temp_path(&format!("{name}.mat"))
 }
 
 fn read_class(file: &File, ds_path: &str) -> String {

--- a/tests/paged_mutation.rs
+++ b/tests/paged_mutation.rs
@@ -19,12 +19,16 @@ fn open_bounded(path: &std::path::Path) -> Result<File, hdf5_pure::Error> {
 
 const PAGE: u64 = 4096;
 
-fn tmp(name: &str) -> std::path::PathBuf {
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+
+/// A fixture under the repository's gitignored `tmp/`, in a directory of its own
+/// so two concurrent runs of this binary cannot collide on the name (issue #334).
+fn tmp(name: &str) -> temp_fixture::TempPath {
     let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tmp");
-    let _ = std::fs::create_dir_all(&p);
-    p.push(name);
-    p
+    std::fs::create_dir_all(&p).expect("create the repository's tmp directory");
+    temp_fixture::temp_path_in(&p, name)
 }
 
 /// Build a persisting paged file with an unlimited rank-1 chunked i32 dataset `d`

--- a/tests/paged_staged_commit.rs
+++ b/tests/paged_staged_commit.rs
@@ -11,12 +11,16 @@ use hdf5_pure::{
 
 const PAGE: u64 = 4096;
 
-fn tmp(name: &str) -> std::path::PathBuf {
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+
+/// A fixture under the repository's gitignored `tmp/`, in a directory of its own
+/// so two concurrent runs of this binary cannot collide on the name (issue #334).
+fn tmp(name: &str) -> temp_fixture::TempPath {
     let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tmp");
-    let _ = std::fs::create_dir_all(&p);
-    p.push(name);
-    p
+    std::fs::create_dir_all(&p).expect("create the repository's tmp directory");
+    temp_fixture::temp_path_in(&p, name)
 }
 
 /// Build a paged file with one contiguous i32 dataset `d` seeded with `0..n`.

--- a/tests/paged_write.rs
+++ b/tests/paged_write.rs
@@ -7,12 +7,16 @@ use hdf5_pure::{AttrValue, File, FileBuilder, FileSpaceStrategy};
 
 const PAGE: u64 = 16384;
 
-fn tmp(name: &str) -> std::path::PathBuf {
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+
+/// A fixture under the repository's gitignored `tmp/`, in a directory of its own
+/// so two concurrent runs of this binary cannot collide on the name (issue #334).
+fn tmp(name: &str) -> temp_fixture::TempPath {
     let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tmp");
-    let _ = std::fs::create_dir_all(&p);
-    p.push(name);
-    p
+    std::fs::create_dir_all(&p).expect("create the repository's tmp directory");
+    temp_fixture::temp_path_in(&p, name)
 }
 
 /// A persisting paged file with small and large datasets round-trips through

--- a/tests/repack.rs
+++ b/tests/repack.rs
@@ -6,9 +6,9 @@ use hdf5_pure::{
     ScaleOffset, repack,
 };
 
-fn tmp(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(name)
-}
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+use temp_fixture::temp_path;
 
 /// A variable-length attribute survives a repack still variable-length.
 ///
@@ -20,8 +20,8 @@ fn tmp(name: &str) -> std::path::PathBuf {
 /// asserting the variant asserts the encoding, not just the values.
 #[test]
 fn carries_a_variable_length_attribute_without_re_encoding_it() {
-    let src = tmp("hdf5_pure_repack_vlen_attr_src.h5");
-    let dst = tmp("hdf5_pure_repack_vlen_attr_dst.h5");
+    let src = temp_path("hdf5_pure_repack_vlen_attr_src.h5");
+    let dst = temp_path("hdf5_pure_repack_vlen_attr_dst.h5");
     let fields: Vec<String> = vec!["x".into(), "y".into(), "velocity".into()];
     let mut b = FileBuilder::new();
     b.create_dataset("x").with_f64_data(&[1.0]);
@@ -45,14 +45,12 @@ fn carries_a_variable_length_attribute_without_re_encoding_it() {
         Some(&AttrValue::VarLenAsciiArray(fields)),
         "group attribute must stay variable-length"
     );
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn drops_object_and_shrinks_file() {
-    let src = tmp("hdf5_pure_repack_drop_src.h5");
-    let dst = tmp("hdf5_pure_repack_drop_dst.h5");
+    let src = temp_path("hdf5_pure_repack_drop_src.h5");
+    let dst = temp_path("hdf5_pure_repack_drop_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.create_dataset("bulk").with_f64_data(&vec![9.0; 4096]);
@@ -74,14 +72,12 @@ fn drops_object_and_shrinks_file() {
         vec![1, 2, 3]
     );
     assert!(f.dataset("bulk").is_err());
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn pure_compaction_preserves_everything() {
-    let src = tmp("hdf5_pure_repack_compact_src.h5");
-    let dst = tmp("hdf5_pure_repack_compact_dst.h5");
+    let src = temp_path("hdf5_pure_repack_compact_src.h5");
+    let dst = temp_path("hdf5_pure_repack_compact_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("ints").with_i64_data(&[10, 20, 30, 40]);
     b.create_dataset("floats").with_f64_data(&[1.5, 2.5, 3.5]);
@@ -121,8 +117,6 @@ fn pure_compaction_preserves_everything() {
         grp_attrs.get("units"),
         Some(&AttrValue::AsciiString("m/s".to_string()))
     );
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -131,7 +125,7 @@ fn repacks_v1_symbol_table_source_with_attributes() {
     // groups) carrying compact attributes. Repack now opens the source via the
     // streaming backend, so this drives v1 group traversal and compact attribute
     // reads end to end through the repack entry point (issues #82 / #27).
-    let dst = tmp("hdf5_pure_repack_v1_attrs_dst.h5");
+    let dst = temp_path("hdf5_pure_repack_v1_attrs_dst.h5");
     let src = "tests/fixtures/attrs.h5";
 
     let source = hdf5_pure::File::open(src).unwrap();
@@ -146,8 +140,6 @@ fn repacks_v1_symbol_table_source_with_attributes() {
     assert_eq!(f.dataset("data").unwrap().read_f64().unwrap(), src_data);
     assert_eq!(f.dataset("data").unwrap().attrs().unwrap(), src_data_attrs);
     assert_eq!(f.root().attrs().unwrap(), src_root_attrs);
-
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -155,7 +147,7 @@ fn repacks_v1_nested_symbol_table_groups() {
     // `two_groups.h5` has v1 symbol-table groups nested under the root. Repacking
     // it exercises the streaming v1 B-tree/local-heap/SNOD traversal across
     // multiple groups and preserves the full subtree.
-    let dst = tmp("hdf5_pure_repack_v1_groups_dst.h5");
+    let dst = temp_path("hdf5_pure_repack_v1_groups_dst.h5");
     let src = "tests/fixtures/two_groups.h5";
 
     repack(src, &dst, &RepackOptions::new()).unwrap();
@@ -172,14 +164,12 @@ fn repacks_v1_nested_symbol_table_groups() {
         f.group("group2").unwrap().datasets().unwrap(),
         vec!["temps".to_string()]
     );
-
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn carries_dataset_attributes() {
-    let src = tmp("hdf5_pure_repack_dsattr_src.h5");
-    let dst = tmp("hdf5_pure_repack_dsattr_dst.h5");
+    let src = temp_path("hdf5_pure_repack_dsattr_src.h5");
+    let dst = temp_path("hdf5_pure_repack_dsattr_dst.h5");
     let mut b = FileBuilder::new();
     let ds = b.create_dataset("signal");
     ds.with_f64_data(&[1.0, 2.0, 3.0]);
@@ -200,14 +190,12 @@ fn carries_dataset_attributes() {
         f.dataset("signal").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0]
     );
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn drops_whole_group_subtree() {
-    let src = tmp("hdf5_pure_repack_dropgrp_src.h5");
-    let dst = tmp("hdf5_pure_repack_dropgrp_dst.h5");
+    let src = temp_path("hdf5_pure_repack_dropgrp_src.h5");
+    let dst = temp_path("hdf5_pure_repack_dropgrp_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("root_ds").with_i32_data(&[1]);
     let mut g = b.create_group("doomed");
@@ -222,14 +210,12 @@ fn drops_whole_group_subtree() {
     assert_eq!(f.root().datasets().unwrap(), vec!["root_ds".to_string()]);
     assert!(f.group("doomed").is_err());
     assert!(f.dataset("doomed/a").is_err());
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn preserves_chunked_and_compressed_dataset() {
-    let src = tmp("hdf5_pure_repack_chunk_src.h5");
-    let dst = tmp("hdf5_pure_repack_chunk_dst.h5");
+    let src = temp_path("hdf5_pure_repack_chunk_src.h5");
+    let dst = temp_path("hdf5_pure_repack_chunk_dst.h5");
     let data: Vec<f64> = (0..2048).map(|i| i as f64 * 0.5).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[7]);
@@ -247,14 +233,12 @@ fn preserves_chunked_and_compressed_dataset() {
     let f = hdf5_pure::File::open(&dst).unwrap();
     assert_eq!(f.dataset("comp").unwrap().read_f64().unwrap(), data);
     assert_eq!(f.dataset("keep").unwrap().read_i32().unwrap(), vec![7]);
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn preserves_multidim_and_maxshape() {
-    let src = tmp("hdf5_pure_repack_md_src.h5");
-    let dst = tmp("hdf5_pure_repack_md_dst.h5");
+    let src = temp_path("hdf5_pure_repack_md_src.h5");
+    let dst = temp_path("hdf5_pure_repack_md_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("grid")
         .with_f64_data(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
@@ -269,8 +253,6 @@ fn preserves_multidim_and_maxshape() {
     let ds = f.dataset("grid").unwrap();
     assert_eq!(ds.shape().unwrap(), vec![2, 3]);
     assert_eq!(ds.read_f64().unwrap(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -280,10 +262,10 @@ fn roundtrips_integer_scale_offset() {
     // value range) makes the filter's survival observable from the file size.
     let data: Vec<i32> = (0..4096).map(|i| i % 8).collect();
 
-    let so_src = tmp("hdf5_pure_repack_so_src.h5");
-    let so_dst = tmp("hdf5_pure_repack_so_dst.h5");
-    let plain_src = tmp("hdf5_pure_repack_soplain_src.h5");
-    let plain_dst = tmp("hdf5_pure_repack_soplain_dst.h5");
+    let so_src = temp_path("hdf5_pure_repack_so_src.h5");
+    let so_dst = temp_path("hdf5_pure_repack_so_dst.h5");
+    let plain_src = temp_path("hdf5_pure_repack_soplain_src.h5");
+    let plain_dst = temp_path("hdf5_pure_repack_soplain_dst.h5");
 
     let mut b = FileBuilder::new();
     b.create_dataset("vals")
@@ -314,10 +296,6 @@ fn roundtrips_integer_scale_offset() {
         so_size < plain_size,
         "repacked scale-offset file ({so_size}) should be smaller than the unfiltered repack ({plain_size}), proving the filter was re-applied"
     );
-
-    for p in [so_src, so_dst, plain_src, plain_dst] {
-        std::fs::remove_file(p).ok();
-    }
 }
 
 #[test]
@@ -327,8 +305,8 @@ fn roundtrips_lossy_float_scale_offset_verbatim() {
     // byte-exact instead of refusing. The values read back from the repacked file
     // must equal the values read back from the source (the lossy rounding is
     // baked into the stored bytes and carried through unchanged).
-    let src = tmp("hdf5_pure_repack_fso_src.h5");
-    let dst = tmp("hdf5_pure_repack_fso_dst.h5");
+    let src = temp_path("hdf5_pure_repack_fso_src.h5");
+    let dst = temp_path("hdf5_pure_repack_fso_dst.h5");
     let data: Vec<f64> = (0..1024).map(|i| (i as f64) * 0.01).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("vals")
@@ -363,17 +341,14 @@ fn roundtrips_lossy_float_scale_offset_verbatim() {
         std::fs::metadata(&dst).unwrap().len() < 1024 * 8,
         "scale-offset filter should keep the repacked file below the raw data size"
     );
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn roundtrips_opaque_and_bitfield_datatypes() {
     // Opaque and bit-field datatypes now serialize losslessly, so repack carries
     // them through byte-for-byte instead of refusing.
-    let src = tmp("hdf5_pure_repack_dt_src.h5");
-    let dst = tmp("hdf5_pure_repack_dt_dst.h5");
+    let src = temp_path("hdf5_pure_repack_dt_src.h5");
+    let dst = temp_path("hdf5_pure_repack_dt_dst.h5");
 
     let opaque_dt = Datatype::Opaque {
         size: 4,
@@ -404,15 +379,12 @@ fn roundtrips_opaque_and_bitfield_datatypes() {
     let flags = f.dataset("flags").unwrap();
     assert_eq!(flags.datatype().unwrap(), bitfield_dt);
     assert_eq!(flags.read_raw().unwrap(), bitfield_raw);
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn preserves_file_space_strategy() {
-    let src = tmp("hdf5_pure_repack_fss_src.h5");
-    let dst = tmp("hdf5_pure_repack_fss_dst.h5");
+    let src = temp_path("hdf5_pure_repack_fss_src.h5");
+    let dst = temp_path("hdf5_pure_repack_fss_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("keep").with_i32_data(&[1, 2, 3]);
     b.create_dataset("drop_me").with_f64_data(&vec![0.0; 1000]);
@@ -435,14 +407,12 @@ fn preserves_file_space_strategy() {
         vec![1, 2, 3]
     );
     assert!(f.dataset("drop_me").is_err());
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn rejects_nonexistent_drop_path() {
-    let src = tmp("hdf5_pure_repack_baddrop_src.h5");
-    let dst = tmp("hdf5_pure_repack_baddrop_dst.h5");
+    let src = temp_path("hdf5_pure_repack_baddrop_src.h5");
+    let dst = temp_path("hdf5_pure_repack_baddrop_dst.h5");
     let mut b = FileBuilder::new();
     b.create_dataset("present").with_i32_data(&[1]);
     b.write(&src).unwrap();
@@ -457,8 +427,6 @@ fn rejects_nonexistent_drop_path() {
         !dst.exists(),
         "dst must not be created when the repack fails"
     );
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -466,8 +434,8 @@ fn verbatim_chunk_copy_preserves_compressed_bytes() {
     // A chunked + deflate dataset: repack copies its compressed chunks verbatim,
     // so the values read back are byte-identical and the dataset stays chunked +
     // compressed (the file remains far smaller than the raw element bytes).
-    let src = tmp("hdf5_pure_repack_verbatim_src.h5");
-    let dst = tmp("hdf5_pure_repack_verbatim_dst.h5");
+    let src = temp_path("hdf5_pure_repack_verbatim_src.h5");
+    let dst = temp_path("hdf5_pure_repack_verbatim_dst.h5");
     // Highly compressible data so the filter's survival is observable by size.
     let data: Vec<i32> = (0..4096).map(|i| i % 4).collect();
     let mut b = FileBuilder::new();
@@ -495,9 +463,6 @@ fn verbatim_chunk_copy_preserves_compressed_bytes() {
         std::fs::metadata(&dst).unwrap().len() < 4096 * 4,
         "deflate filter must survive (file smaller than raw element bytes)"
     );
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -505,8 +470,8 @@ fn repacks_multichunk_2d_fixed_array() {
     // A 2D dataset chunked into a 2x2 grid uses a v4 Fixed Array index. Repack's
     // verbatim path must lay the four chunks back in dense grid order so the
     // values round-trip exactly.
-    let src = tmp("hdf5_pure_repack_fa_src.h5");
-    let dst = tmp("hdf5_pure_repack_fa_dst.h5");
+    let src = temp_path("hdf5_pure_repack_fa_src.h5");
+    let dst = temp_path("hdf5_pure_repack_fa_dst.h5");
     // 4x4 grid, chunk 2x2 -> a 2x2 chunk grid (four chunks).
     let data: Vec<f64> = (0..16).map(|i| i as f64 * 1.5).collect();
     let mut b = FileBuilder::new();
@@ -524,17 +489,14 @@ fn repacks_multichunk_2d_fixed_array() {
     assert_eq!(ds.shape().unwrap(), vec![4, 4]);
     assert_eq!(ds.read_f64().unwrap(), data);
     assert!(ds.chunk_cache_stats().index_loaded());
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
 fn repacks_resizable_extensible_array() {
     // An unlimited-maxshape dataset uses a v4 Extensible Array index. Repack must
     // carry the maxshape through and reproduce the values exactly.
-    let src = tmp("hdf5_pure_repack_ea_src.h5");
-    let dst = tmp("hdf5_pure_repack_ea_dst.h5");
+    let src = temp_path("hdf5_pure_repack_ea_src.h5");
+    let dst = temp_path("hdf5_pure_repack_ea_dst.h5");
     let data: Vec<i64> = (0..1000).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("series")
@@ -553,9 +515,6 @@ fn repacks_resizable_extensible_array() {
     // Maxshape (resizability) is carried through.
     assert_eq!(ds.shape().unwrap(), vec![1000]);
     assert!(ds.chunk_cache_stats().index_loaded());
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[cfg(feature = "zfp")]
@@ -565,8 +524,8 @@ fn roundtrips_zfp_verbatim() {
     // but a chunked dataset's compressed chunks are copied verbatim, so repack
     // reproduces the stored (lossy-compressed) values byte-exact. The values read
     // back from the repacked file must equal those read back from the source.
-    let src = tmp("hdf5_pure_repack_zfp_src.h5");
-    let dst = tmp("hdf5_pure_repack_zfp_dst.h5");
+    let src = temp_path("hdf5_pure_repack_zfp_src.h5");
+    let dst = temp_path("hdf5_pure_repack_zfp_dst.h5");
     let data: Vec<f64> = (0..1024).map(|i| (i as f64).sin()).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("vals")
@@ -594,9 +553,6 @@ fn roundtrips_zfp_verbatim() {
         dst_ds.chunk_cache_stats().index_loaded(),
         "repacked ZFP dataset must still be chunked"
     );
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -604,8 +560,8 @@ fn repacks_single_chunk_filtered_verbatim() {
     // A dataset whose single chunk covers the whole dataset uses the v4
     // single-chunk index. The verbatim path must carry the chunk's real filter
     // mask into that index and reproduce the values exactly.
-    let src = tmp("hdf5_pure_repack_single_src.h5");
-    let dst = tmp("hdf5_pure_repack_single_dst.h5");
+    let src = temp_path("hdf5_pure_repack_single_src.h5");
+    let dst = temp_path("hdf5_pure_repack_single_dst.h5");
     let data: Vec<i32> = (0..256).map(|i| i % 5).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("vals")
@@ -620,9 +576,6 @@ fn repacks_single_chunk_filtered_verbatim() {
     let ds = f.dataset("vals").unwrap();
     assert_eq!(ds.read_i32().unwrap(), data);
     assert!(ds.chunk_cache_stats().index_loaded());
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 #[test]
@@ -631,8 +584,8 @@ fn repacks_chunked_dataset_from_a_userblock_file() {
     // and chunk data are stored base-relative. Repack reads each chunk verbatim
     // from the source; it must apply the base address, or it reads the wrong bytes
     // and produces a corrupt copy.
-    let src = tmp("hdf5_pure_repack_ub_src.h5");
-    let dst = tmp("hdf5_pure_repack_ub_dst.h5");
+    let src = temp_path("hdf5_pure_repack_ub_src.h5");
+    let dst = temp_path("hdf5_pure_repack_ub_dst.h5");
     let data: Vec<f64> = (0..1000).map(|i| i as f64 * 0.25).collect();
     let mut b = FileBuilder::new();
     b.with_userblock(512);
@@ -651,9 +604,6 @@ fn repacks_chunked_dataset_from_a_userblock_file() {
         f.dataset("plain").unwrap().read_f64().unwrap(),
         vec![1.0, 2.0, 3.0]
     );
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 /// A repack carries the source's on-disk format forward.
@@ -665,8 +615,8 @@ fn repacks_chunked_dataset_from_a_userblock_file() {
 /// read that would pass either way.
 #[test]
 fn preserves_the_source_on_disk_format() {
-    let src = tmp("hdf5_pure_repack_libver_src.h5");
-    let dst = tmp("hdf5_pure_repack_libver_dst.h5");
+    let src = temp_path("hdf5_pure_repack_libver_src.h5");
+    let dst = temp_path("hdf5_pure_repack_libver_dst.h5");
     let mut b = FileBuilder::new();
     b.with_libver_bounds(LibVer::Earliest, LibVer::V18);
     b.create_dataset("values").with_f64_data(&[1.0, 2.0, 3.0]);
@@ -685,9 +635,6 @@ fn preserves_the_source_on_disk_format() {
             .unwrap(),
         vec![1.0, 2.0, 3.0]
     );
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 /// The carried-forward format yields where the content leaves no choice.
@@ -705,7 +652,7 @@ fn preserves_the_source_on_disk_format() {
 /// strict rule from the right one.
 #[test]
 fn upgrades_only_where_the_source_format_cannot_hold_the_content() {
-    let dst = tmp("hdf5_pure_repack_libver_forced_dst.h5");
+    let dst = temp_path("hdf5_pure_repack_libver_forced_dst.h5");
 
     // Contiguous content under a version 0 superblock: floored at the oldest
     // format this crate writes, and no further.
@@ -745,8 +692,6 @@ fn upgrades_only_where_the_source_format_cannot_hold_the_content() {
             .unwrap(),
         expected
     );
-
-    std::fs::remove_file(&dst).ok();
 }
 
 /// An explicit bound is a guarantee, not a preference: content it cannot express
@@ -754,8 +699,8 @@ fn upgrades_only_where_the_source_format_cannot_hold_the_content() {
 /// and the carried-forward default above.
 #[test]
 fn an_explicit_bound_refuses_content_it_cannot_express() {
-    let src = tmp("hdf5_pure_repack_libver_chunked_src.h5");
-    let dst = tmp("hdf5_pure_repack_libver_chunked_dst.h5");
+    let src = temp_path("hdf5_pure_repack_libver_chunked_src.h5");
+    let dst = temp_path("hdf5_pure_repack_libver_chunked_dst.h5");
     let data: Vec<f64> = (0..1000).map(|i| i as f64).collect();
     let mut b = FileBuilder::new();
     b.create_dataset("chk")
@@ -781,9 +726,6 @@ fn an_explicit_bound_refuses_content_it_cannot_express() {
     let to_v110 = RepackOptions::new().with_libver_bounds(LibVer::Earliest, LibVer::V110);
     repack(&src, &dst, &to_v110).unwrap();
     assert_eq!(superblock_version(&dst), 3);
-
-    std::fs::remove_file(&src).ok();
-    std::fs::remove_file(&dst).ok();
 }
 
 /// The superblock version byte of the file at `path`, found by scanning for the

--- a/tests/serde_with_options.rs
+++ b/tests/serde_with_options.rs
@@ -8,12 +8,15 @@ use hdf5_pure::mat::{
 use hdf5_pure::{AttrValue, File, LibVer};
 use serde::{Deserialize, Serialize};
 
-fn temp_path(name: &str) -> std::path::PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("hdf5pure-mat-opts-{name}-{nanos}.mat"))
+#[path = "common/temp_fixture.rs"]
+mod temp_fixture;
+
+/// A `.mat` fixture, in a directory that goes away with the returned value.
+///
+/// Replaces a nanosecond-stamped name in the shared temporary directory, which
+/// no two runs collided on but no run ever cleaned up (issue #334).
+fn temp_path(name: &str) -> temp_fixture::TempPath {
+    temp_fixture::temp_path(&format!("{name}.mat"))
 }
 
 fn read_class(file: &File, ds_path: &str) -> String {


### PR DESCRIPTION
Closes #334.

## The issue's scope, and what was actually there

`tests/edit_free_space.rs` named each of its 27 fixtures directly in the shared system temporary directory, so two runs of the suite at once wrote over each other. The issue names two tests as the ones that collided; measured on this branch before the change, **two concurrent runs of that binary failed 16 and 19 of their 26 tests**, every one of which passes alone. The three defensive `remove_file` pre-cleans already in the file are the trace of an earlier encounter with this, covering only the sequential case.

The issue also says every other test file already uses `tempfile::tempdir()`. That is not so, and it is why fixing the one file it names would have left the property it asks for unavailable:

| | files | sites |
| --- | --- | --- |
| fixed name in the system temp directory | 11 (`edit_in_place.rs` has 159) | ~200 |
| fixed name under the repository's gitignored `tmp/` | 3 paged tests | 17 |
| nanosecond-stamped name, never swept | 3 | 15 per run |

The paged tests are the ones the issue's `temp_dir` grep cannot reach. All of them are converted here.

## The fix

`tests/common/temp_fixture.rs` holds one implementation, included with `#[path]` rather than through `common/mod.rs` for the reason `common/allocation.rs` already gives: a binary that names that module links a static libhdf5 it has no use for.

`temp_path(name)` returns a guard that derefs to `Path` and implements `AsRef<Path>`, so all ~262 call sites keep their names and their `&path` with no conversion. `temp_path_in(parent, name)` serves the three paged tests, preserving their deliberate repo-local placement while making it collision-free.

The guard's `Drop` removes the directory whether the test passed, failed, or panicked, so 270 manual `remove_file` calls come out with it. Each removed call was the last statement of its block, so none could be load-bearing. That also sweeps the fixtures nothing ever cleaned: 15 nanosecond-stamped `.mat` files per run (which never collided but took a new name every time, so they accumulated without bound), two `rustyhdf5_chunked_*.h5` the h5py tests write and abandon, and 17 `pure_paged_*.h5` in the repository's own `tmp/`. Both directories are empty after a run now.

## Verification

The property the issue asks for, rather than a new test: **three concurrent `cargo nextest run --all-features`, 2,323 tests each, all green.** The same experiment failed 6 tests before the paged files were converted, and 16/19 before any were.

Also clean: the solo suite (2,323), 46 doctests, `clippy --all-features --all-targets -D warnings`, `cargo fmt --check`, and the lib unit tests compiled for `i686-unknown-linux-gnu` and `s390x-unknown-linux-gnu` under the cross jobs' feature set (`tempfile` was already used in `src/` unit tests, so nothing new links there).

No changelog entry: this is test infrastructure with no user-facing surface.