### PR TITLE
Reproduce a source's filter order and optional flags through repack (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `repack` reproduces a dataset's filter pipeline in the order the source stored it, and keeps each filter's optional flag, instead of rebuilding it in this crate's own order with every filter but LZF marked mandatory. A source that ordered `fletcher32` before deflate checksummed the uncompressed bytes and arrived checksumming the compressed ones; the verbatim chunk-copy path was never affected ([#333](https://github.com/stephenberry/hdf5-pure/issues/333)).
 - `File::copy` and `File::copy_from` reproduce a dataset whose storage was never allocated, instead of refusing it as out of bounds. The copy declares the same empty storage rather than materializing the fill value it reads as, matching `repack` ([#336](https://github.com/stephenberry/hdf5-pure/issues/336)).
 - `File::copy` and `File::copy_from` refuse a dataset whose data lives in external files (`H5Pset_external`) by name, instead of by an out-of-bounds error a valid never-written dataset also got. Deleting such a dataset now leaves its object header as dead space rather than reclaiming it ([#336](https://github.com/stephenberry/hdf5-pure/issues/336)).
 - **Breaking:** `FileBuilder` refuses a dataset that stages element data under a zero-element shape, instead of writing a file the reference library refuses to open as corrupt (or, chunked, silently dropping the data). Staging no data for such a shape is unchanged ([#332](https://github.com/stephenberry/hdf5-pure/issues/332)).

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -22,7 +22,7 @@ use crate::fill_value::FillPattern;
 use crate::filter_pipeline::FILTER_ZFP;
 use crate::filter_pipeline::{
     FILTER_DEFLATE, FILTER_FLETCHER32, FILTER_LZF, FILTER_SCALEOFFSET, FILTER_SHUFFLE,
-    FilterDescription, FilterPipeline,
+    FilterDescription, FilterPipeline, H5Z_FLAG_OPTIONAL,
 };
 use crate::filters::{ChunkContext, compress_chunk_with};
 use crate::scaleoffset::{FillAvailability, ScaleOffset, build_cd_values};
@@ -50,53 +50,210 @@ pub(crate) const FIXED_ARRAY_PAGE_BITS: u8 = 10;
 const INDEX_OFFSET_SIZE: u8 = 8;
 const INDEX_LENGTH_SIZE: u8 = 8;
 
+/// Which filter, and the parameters that are the caller's to choose.
+///
+/// Not the whole `cd_values` word list. What a filter records about the
+/// *dataset* — element size, chunk geometry, the fill-value bytes — is derived
+/// at [`ChunkOptions::build_pipeline`] time from the dataset actually being
+/// written, so a filter carried from one dataset onto another (what
+/// [`repack`](crate::repack) does) describes the destination rather than
+/// restating the source's numbers. What a filter records about the *request* —
+/// a deflate level, a scale-offset mode and whether it records a fill value at
+/// all — is here, and is carried across unchanged.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FilterKind {
+    /// ZFP fixed-rate compression, in bits per value. A primary transform:
+    /// it consumes the raw elements and displaces the byte filters.
+    #[cfg(feature = "zfp")]
+    Zfp(f64),
+    /// Scale-offset, with whether the filter records the dataset's fill value.
+    /// Also a primary transform: it displaces shuffle, but a byte compressor
+    /// may follow it.
+    ScaleOffset(ScaleOffset, FillAvailability),
+    /// Byte shuffle.
+    Shuffle,
+    /// The h5py LZF filter (id 32000).
+    Lzf,
+    /// Deflate, at the given level (0-9).
+    Deflate(u32),
+    /// Fletcher32 checksum.
+    Fletcher32,
+}
+
+impl FilterKind {
+    /// The registered HDF5 filter id this kind is written as.
+    ///
+    /// Identity for every purpose that asks "is this filter in the pipeline":
+    /// two `Deflate`s at different levels are one filter appearing twice, not
+    /// two filters, which is what makes [`ChunkOptions::set_filter`] replace
+    /// rather than accumulate.
+    fn filter_id(self) -> u16 {
+        match self {
+            #[cfg(feature = "zfp")]
+            Self::Zfp(_) => FILTER_ZFP,
+            Self::ScaleOffset(..) => FILTER_SCALEOFFSET,
+            Self::Shuffle => FILTER_SHUFFLE,
+            Self::Lzf => FILTER_LZF,
+            Self::Deflate(_) => FILTER_DEFLATE,
+            Self::Fletcher32 => FILTER_FLETCHER32,
+        }
+    }
+
+    /// Where this filter sits in the pipeline this crate's own writer builds:
+    /// a primary transform first, then shuffle, then a byte compressor, then
+    /// the checksum last. Lower runs earlier, so it is applied to less
+    /// processed bytes.
+    fn canonical_rank(self) -> u8 {
+        match self {
+            #[cfg(feature = "zfp")]
+            Self::Zfp(_) => 0,
+            Self::ScaleOffset(..) => 1,
+            Self::Shuffle => 2,
+            Self::Lzf => 3,
+            Self::Deflate(_) => 4,
+            Self::Fletcher32 => 5,
+        }
+    }
+
+    /// Whether a filter added through [`ChunkOptions::set_filter`] is recorded
+    /// optional.
+    ///
+    /// Only LZF is. Unlike every other filter here it *can* decline a chunk:
+    /// liblzf returns 0 for one it cannot shrink, and h5py's filter relies on
+    /// the optional flag to store that chunk raw with its filter-mask bit set.
+    /// A mandatory LZF makes that a hard error, so h5py could not write
+    /// incompressible data back into a file we wrote. (Our own writer applies
+    /// LZF unconditionally — a grown stream is a valid stream — so it never
+    /// sets a mask bit; the flag is for the writers that come after us.)
+    ///
+    /// For a filter that cannot fail the flag is unobservable here, and leaving
+    /// those mandatory keeps our bytes stable against existing fixtures. h5py
+    /// marks every filter optional; we match it only where it means something.
+    fn default_optional(self) -> bool {
+        matches!(self, Self::Lzf)
+    }
+}
+
+/// A filter together with whether a reader may skip it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FilterSpec {
+    /// Which filter, and its parameters.
+    pub kind: FilterKind,
+    /// `H5Z_FLAG_OPTIONAL` (flags bit 0): a reader that cannot apply this
+    /// filter may skip it. A mandatory filter must be applied for the data to
+    /// decode, so a reader missing it has to fail.
+    pub optional: bool,
+}
+
 /// Options for chunked dataset creation.
 #[derive(Debug, Clone, Default)]
 pub struct ChunkOptions {
     /// Chunk dimensions (one per dataset dimension).
     pub chunk_dims: Option<Vec<u64>>,
-    /// Deflate compression level (0-9), None = no deflate.
-    pub deflate_level: Option<u32>,
-    /// Whether to apply shuffle filter before compression.
-    pub shuffle: bool,
-    /// Whether to apply the h5py LZF filter (id 32000). Mutually exclusive
-    /// with deflate; ignored when ZFP is active (ZFP replaces byte
-    /// compressors).
-    pub lzf: bool,
-    /// Whether to apply fletcher32 checksum.
-    pub fletcher32: bool,
-    /// ZFP fixed-rate compression (bits per value), None = no ZFP.
-    /// When set, takes priority over shuffle + deflate.
-    #[cfg(feature = "zfp")]
-    pub zfp_rate: Option<f64>,
-    /// Scale-offset compression mode, None = no scale-offset. When set it is
-    /// the primary transform (mutually exclusive with ZFP, replaces shuffle)
-    /// and may be followed by deflate.
-    pub scale_offset: Option<ScaleOffset>,
-    /// Whether the scale-offset filter records the dataset's fill value.
+    /// The dataset's filter pipeline, in the order it is written: each filter's
+    /// output is the next one's input, and a reader reverses the list.
     ///
-    /// The default records it, which is what the reference library does for
-    /// every dataset whose fill value is not explicitly undefined. See
-    /// [`FillAvailability`] for why the other setting exists and who sets it.
-    pub scale_offset_fill: FillAvailability,
+    /// An ordered list rather than one switch per filter, because the order is
+    /// observable and is not always this crate's canonical one. `fletcher32`
+    /// before deflate checksums the uncompressed bytes; after it, the
+    /// compressed ones — a different checksum over different data, and a
+    /// different thing to verify on read. A file written elsewhere may declare
+    /// any order, and `repack` reproduces what it read (issue #333), which a
+    /// set of independent switches cannot express at all.
+    ///
+    /// Add to it through [`set_filter`](Self::set_filter), which places a
+    /// filter where this crate's own writer puts it, or
+    /// [`push_filter`](Self::push_filter), which appends one exactly where the
+    /// caller wants it.
+    pub filters: Vec<FilterSpec>,
 }
 
 impl ChunkOptions {
     /// Whether any chunking option is enabled.
     pub fn is_chunked(&self) -> bool {
-        self.chunk_dims.is_some()
-            || self.deflate_level.is_some()
-            || self.shuffle
-            || self.lzf
-            || self.fletcher32
-            || self.zfp_enabled()
-            || self.scale_offset.is_some()
+        self.chunk_dims.is_some() || !self.filters.is_empty()
+    }
+
+    /// Add `kind` at the position this crate's own writer gives it, replacing
+    /// any filter with the same id already present.
+    ///
+    /// This is what the `DatasetBuilder` switches (`with_shuffle`,
+    /// `with_deflate`, ...) call. Placing by
+    /// [`canonical_rank`](FilterKind::canonical_rank) rather than by call order
+    /// is what keeps `with_deflate(6).with_shuffle()` and
+    /// `with_shuffle().with_deflate(6)` writing the same bytes: those setters
+    /// name a filter to apply, not a position to apply it at.
+    pub fn set_filter(&mut self, kind: FilterKind) {
+        let spec = FilterSpec {
+            optional: kind.default_optional(),
+            kind,
+        };
+        // Naming a filter twice sets its parameter rather than applying it
+        // twice, which is what the `Option<u32>`-per-filter fields this replaced
+        // did. The whole entry is overwritten, optional flag included: this
+        // setter states what the crate's own writer wants, so a flag carried in
+        // by `push_filter` does not survive it. Overwritten where it sits rather
+        // than removed and re-inserted, so a pushed pipeline at least keeps its
+        // order. No caller mixes the two today; both halves are stated because
+        // the field is `pub` and nothing enforces that.
+        if let Some(slot) = self
+            .filters
+            .iter_mut()
+            .find(|f| f.kind.filter_id() == kind.filter_id())
+        {
+            *slot = spec;
+            return;
+        }
+        let at = self
+            .filters
+            .iter()
+            .position(|f| f.kind.canonical_rank() > kind.canonical_rank())
+            .unwrap_or(self.filters.len());
+        self.filters.insert(at, spec);
+    }
+
+    /// Append `spec` after every filter already added, keeping its optional
+    /// flag as given.
+    ///
+    /// For reproducing a pipeline that already exists: `repack` reads a
+    /// source's filters and re-applies them in the order and with the flags it
+    /// found, which need not be the canonical order
+    /// [`set_filter`](Self::set_filter) produces.
+    pub fn push_filter(&mut self, spec: FilterSpec) {
+        self.filters.push(spec);
+    }
+
+    /// Whether the pipeline includes the filter with this id.
+    fn has(&self, id: u16) -> bool {
+        self.filters.iter().any(|f| f.kind.filter_id() == id)
+    }
+
+    /// Refuse a filter the pipeline asks for that this build cannot apply.
+    /// Returns a static reason on the first problem; callers map it to their
+    /// own error type, as they do for
+    /// [`validate_geometry`](Self::validate_geometry).
+    ///
+    /// Deflate is behind a crate feature, but
+    /// [`build_pipeline`](Self::build_pipeline) emits its descriptor either
+    /// way, so nothing downstream refuses the request — the first chunk to be
+    /// compressed fails instead, with `UnsupportedFilter`.
+    ///
+    /// Called from the in-place edit path, which has file bytes to protect: a
+    /// commit that got that far would have written some. The whole-file writer
+    /// does not call it and still fails at the first chunk, which costs only a
+    /// discarded buffer.
+    pub fn refuse_unavailable_filters(&self) -> Result<(), &'static str> {
+        #[cfg(not(feature = "deflate"))]
+        if self.has(FILTER_DEFLATE) {
+            return Err("deflate compression requires the `deflate` crate feature");
+        }
+        Ok(())
     }
 
     #[cfg(feature = "zfp")]
     #[inline]
     fn zfp_enabled(&self) -> bool {
-        self.zfp_rate.is_some()
+        self.has(FILTER_ZFP)
     }
 
     #[cfg(not(feature = "zfp"))]
@@ -134,31 +291,36 @@ impl ChunkOptions {
         };
 
         if self.zfp_enabled() {
-            if self.scale_offset.is_some() {
+            if self.has(FILTER_SCALEOFFSET) {
                 return clash("scale-offset", "ZFP");
             }
-            if self.shuffle {
+            if self.has(FILTER_SHUFFLE) {
                 return clash("shuffle", "ZFP");
             }
-            if self.lzf {
+            if self.has(FILTER_LZF) {
                 return clash("lzf", "ZFP");
             }
-            if self.deflate_level.is_some() {
+            if self.has(FILTER_DEFLATE) {
                 return clash("deflate", "ZFP");
             }
         }
-        if self.scale_offset.is_some() && self.shuffle {
+        if self.has(FILTER_SCALEOFFSET) && self.has(FILTER_SHUFFLE) {
             return clash("shuffle", "scale-offset");
         }
         // Not a primary transform, but the same shape: LZF and deflate fill one
         // byte-compressor slot, and stacking two of them is never useful.
-        if self.lzf && self.deflate_level.is_some() {
+        if self.has(FILTER_LZF) && self.has(FILTER_DEFLATE) {
             return clash("lzf", "deflate");
         }
         Ok(())
     }
 
     /// Build a FilterPipeline from the options.
+    ///
+    /// The filters come out in [`filters`](Self::filters) order, carrying their
+    /// optional flags: that is the order they are applied in and the order the
+    /// message stores, and it is not always this crate's canonical one — see
+    /// the field for why.
     ///
     /// The context's chunk dimensions and element type are only consulted when
     /// the ZFP filter is active — they're embedded into the ZFP cd_values so the
@@ -192,108 +354,98 @@ impl ChunkOptions {
         let chunk_dims = ctx.chunk_dims;
         let scale_offset_type = ctx.scale_offset_type;
 
-        let mut filters = Vec::new();
         let _ = ctx.element_type; // used only under the `zfp` feature below
 
-        // ZFP is a standalone compressor: `refuse_conflicting_filters` has
-        // already established that nothing it would displace was asked for.
-        #[cfg(feature = "zfp")]
-        if let Some(rate) = self.zfp_rate {
-            let elem_ty = ctx.element_type.ok_or_else(|| {
-                FormatError::UnsupportedZfp(
-                    "ZFP compression requires the dataset's datatype to be one \
-                     of f32, f64, i32, or i64"
-                        .into(),
-                )
-            })?;
-            filters.push(FilterDescription {
-                filter_id: FILTER_ZFP,
-                name: Some("zfp".into()),
-                flags: 0,
-                client_data: crate::zfp::zfp_cd_values_rate(rate, elem_ty, chunk_dims)?,
+        // In the order they are stored, which is the order they are applied:
+        // `compress_chunk_with` walks the same list, and the reader reverses it.
+        // `refuse_conflicting_filters` above has already established that no
+        // filter here displaces another.
+        let mut filters = Vec::with_capacity(self.filters.len());
+        for spec in &self.filters {
+            // No flag bit other than H5Z_FLAG_OPTIONAL is written.
+            let flags = if spec.optional { H5Z_FLAG_OPTIONAL } else { 0 };
+            filters.push(match spec.kind {
+                #[cfg(feature = "zfp")]
+                FilterKind::Zfp(rate) => {
+                    let elem_ty = ctx.element_type.ok_or_else(|| {
+                        FormatError::UnsupportedZfp(
+                            "ZFP compression requires the dataset's datatype to be one \
+                             of f32, f64, i32, or i64"
+                                .into(),
+                        )
+                    })?;
+                    FilterDescription {
+                        filter_id: FILTER_ZFP,
+                        name: Some("zfp".into()),
+                        flags,
+                        client_data: crate::zfp::zfp_cd_values_rate(rate, elem_ty, chunk_dims)?,
+                    }
+                }
+                FilterKind::ScaleOffset(mode, fill_avail) => {
+                    let ty = scale_offset_type.ok_or_else(|| {
+                        FormatError::FilterError(
+                            "scale-offset requires an integer or floating-point scalar \
+                             datatype with a definite (little/big endian) byte order"
+                                .into(),
+                        )
+                    })?;
+                    let nelmts =
+                        u32::try_from(chunk_dims.iter().product::<u64>()).map_err(|_| {
+                            FormatError::FilterError(
+                                "scale-offset: chunk has too many elements".into(),
+                            )
+                        })?;
+                    FilterDescription {
+                        filter_id: FILTER_SCALEOFFSET,
+                        name: None,
+                        flags,
+                        client_data: build_cd_values(
+                            mode,
+                            ty,
+                            element_size,
+                            nelmts,
+                            fill_avail.with_value(fill)?,
+                        )?,
+                    }
+                }
+                FilterKind::Shuffle => FilterDescription {
+                    filter_id: FILTER_SHUFFLE,
+                    name: None,
+                    flags,
+                    client_data: vec![element_size],
+                },
+                FilterKind::Lzf => FilterDescription {
+                    filter_id: FILTER_LZF,
+                    // Ids >= 256 serialize a name; "lzf" is h5py's registered
+                    // name. Derived rather than carried from a source pipeline,
+                    // since it is a property of the filter, not of the file.
+                    name: Some("lzf".into()),
+                    // `h5py_cd_values` records the chunk's *raw* byte size as
+                    // the decompressed size h5py should expect. That is exact
+                    // only where LZF reads the raw elements; behind another
+                    // filter it can understate them — behind fletcher32 by the
+                    // 4 checksum bytes, behind scale-offset by whatever it
+                    // packed to. Neither reader is misled: ours never consults
+                    // the value (`inner_output_cap` folds over the real prefix)
+                    // and h5py's filter grows its buffer on `E2BIG`. Not new
+                    // here — canonical rank already put LZF after scale-offset.
+                    flags,
+                    client_data: crate::lzf::h5py_cd_values(element_size, chunk_dims).to_vec(),
+                },
+                FilterKind::Deflate(level) => FilterDescription {
+                    filter_id: FILTER_DEFLATE,
+                    name: None,
+                    flags,
+                    client_data: vec![level],
+                },
+                FilterKind::Fletcher32 => FilterDescription {
+                    filter_id: FILTER_FLETCHER32,
+                    name: None,
+                    flags,
+                    client_data: vec![],
+                },
             });
         }
-
-        // Scale-offset is also a primary transform: it displaces shuffle, but
-        // may be followed by a byte compressor (pushed first so the pipeline
-        // order is [scaleoffset, lzf|deflate]).
-        if let Some(mode) = self.scale_offset {
-            let ty = scale_offset_type.ok_or_else(|| {
-                FormatError::FilterError(
-                    "scale-offset requires an integer or floating-point scalar \
-                     datatype with a definite (little/big endian) byte order"
-                        .into(),
-                )
-            })?;
-            let nelmts = u32::try_from(chunk_dims.iter().product::<u64>()).map_err(|_| {
-                FormatError::FilterError("scale-offset: chunk has too many elements".into())
-            })?;
-            filters.push(FilterDescription {
-                filter_id: FILTER_SCALEOFFSET,
-                name: None,
-                flags: 0,
-                client_data: build_cd_values(
-                    mode,
-                    ty,
-                    element_size,
-                    nelmts,
-                    self.scale_offset_fill.with_value(fill)?,
-                )?,
-            });
-        }
-
-        if self.shuffle {
-            filters.push(FilterDescription {
-                filter_id: FILTER_SHUFFLE,
-                name: None,
-                flags: 0,
-                client_data: vec![element_size],
-            });
-        }
-
-        // LZF fills the same byte-compressor slot as deflate; h5py's convention
-        // is shuffle then lzf.
-        if self.lzf {
-            filters.push(FilterDescription {
-                filter_id: FILTER_LZF,
-                // Ids >= 256 serialize a name; "lzf" is h5py's registered name.
-                name: Some("lzf".into()),
-                // Optional (bit 0), which is what h5py records. Unlike every
-                // other filter here, LZF *can* fail: liblzf returns 0 for a
-                // chunk it cannot shrink, and h5py's filter relies on the
-                // optional flag to store that chunk raw with its filter-mask
-                // bit set. A mandatory LZF makes that a hard error, so h5py
-                // cannot write incompressible data back into a file we wrote.
-                // Our own writer still applies LZF unconditionally (a grown
-                // stream is a valid stream), so it never sets a mask bit; the
-                // flag exists for the writers that come after us.
-                flags: 1,
-                client_data: crate::lzf::h5py_cd_values(element_size, chunk_dims).to_vec(),
-            });
-        }
-
-        if let Some(level) = self.deflate_level {
-            filters.push(FilterDescription {
-                filter_id: FILTER_DEFLATE,
-                name: None,
-                flags: 0,
-                client_data: vec![level],
-            });
-        }
-
-        if self.fletcher32 {
-            filters.push(FilterDescription {
-                filter_id: FILTER_FLETCHER32,
-                name: None,
-                flags: 0,
-                client_data: vec![],
-            });
-        }
-
-        // Note: h5py marks every filter optional (flags=0x0001); we match it
-        // only on LZF, the one filter here whose compressor can decline a
-        // chunk. For a filter that cannot fail the flag is unobservable, and
-        // leaving those at 0 keeps our bytes stable against existing fixtures.
 
         if filters.is_empty() {
             Ok(None)
@@ -3577,6 +3729,26 @@ mod tests {
         assert!(explicit.validate_geometry(&[0], None).is_ok());
     }
 
+    /// Options carrying `filters`, placed the way the `DatasetBuilder`
+    /// switches place them — so a test that means "shuffle then deflate", the
+    /// combination a caller asks for, does not have to restate the canonical
+    /// order it comes out in. A test about a *stored* order pushes instead.
+    fn filtered(filters: &[FilterKind]) -> ChunkOptions {
+        let mut options = ChunkOptions::default();
+        for &f in filters {
+            options.set_filter(f);
+        }
+        options
+    }
+
+    /// [`filtered`] with chunk dimensions.
+    fn chunked(chunk_dims: &[u64], filters: &[FilterKind]) -> ChunkOptions {
+        ChunkOptions {
+            chunk_dims: Some(chunk_dims.to_vec()),
+            ..filtered(filters)
+        }
+    }
+
     fn f64_to_bytes(data: &[f64]) -> Vec<u8> {
         let mut b = Vec::with_capacity(data.len() * 8);
         for &v in data {
@@ -3770,11 +3942,7 @@ mod tests {
     #[test]
     fn roundtrip_1d_single_chunk_deflate() {
         let values: Vec<f64> = (0..100).map(|i| i as f64).collect();
-        let options = ChunkOptions {
-            chunk_dims: Some(vec![100]),
-            deflate_level: Some(6),
-            ..Default::default()
-        };
+        let options = chunked(&[100], &[FilterKind::Deflate(6)]);
         let result = roundtrip_chunked(&values, &[100], &[100], &options);
         assert_eq!(result, values);
     }
@@ -3794,11 +3962,7 @@ mod tests {
     #[test]
     fn roundtrip_1d_multi_chunk_deflate() {
         let values: Vec<f64> = (0..100).map(|i| i as f64).collect();
-        let options = ChunkOptions {
-            chunk_dims: Some(vec![20]),
-            deflate_level: Some(6),
-            ..Default::default()
-        };
+        let options = chunked(&[20], &[FilterKind::Deflate(6)]);
         let result = roundtrip_chunked(&values, &[100], &[20], &options);
         assert_eq!(result, values);
     }
@@ -3807,12 +3971,7 @@ mod tests {
     #[test]
     fn roundtrip_1d_shuffle_deflate() {
         let values: Vec<f64> = (0..100).map(|i| i as f64).collect();
-        let options = ChunkOptions {
-            chunk_dims: Some(vec![50]),
-            deflate_level: Some(6),
-            shuffle: true,
-            ..Default::default()
-        };
+        let options = chunked(&[50], &[FilterKind::Shuffle, FilterKind::Deflate(6)]);
         let result = roundtrip_chunked(&values, &[100], &[50], &options);
         assert_eq!(result, values);
     }
@@ -3979,11 +4138,7 @@ mod tests {
 
     #[test]
     fn chunk_options_auto_dims() {
-        let options = ChunkOptions {
-            chunk_dims: None,
-            deflate_level: Some(6),
-            ..Default::default()
-        };
+        let options = filtered(&[FilterKind::Deflate(6)]);
         let dims = options.resolve_chunk_dims(&[100, 50]);
         assert_eq!(dims, vec![100, 50]);
     }
@@ -4001,11 +4156,10 @@ mod tests {
         let elem = NonZeroUsize::new(8).expect("8 is non-zero");
         let fill = 2.5f64.to_le_bytes();
         let parms = |fill_availability, fill: FillPattern<'_>| {
-            let options = ChunkOptions {
-                scale_offset: Some(ScaleOffset::FloatDScale(2)),
-                scale_offset_fill: fill_availability,
-                ..Default::default()
-            };
+            let options = filtered(&[FilterKind::ScaleOffset(
+                ScaleOffset::FloatDScale(2),
+                fill_availability,
+            )]);
             let pl = options.build_pipeline(&ctx, fill).unwrap().unwrap();
             let f = pl
                 .filters
@@ -4040,10 +4194,10 @@ mod tests {
         );
         // And a fill value that could not be read refuses the pipeline rather
         // than recording a zero the encoder would treat every real zero as.
-        let options = ChunkOptions {
-            scale_offset: Some(ScaleOffset::FloatDScale(2)),
-            ..Default::default()
-        };
+        let options = filtered(&[FilterKind::ScaleOffset(
+            ScaleOffset::FloatDScale(2),
+            FillAvailability::Defined,
+        )]);
         assert!(matches!(
             options.build_pipeline(&ctx, FillPattern::UNKNOWN),
             Err(FormatError::UnreadableFillValue)
@@ -4051,37 +4205,40 @@ mod tests {
         // But only the setting that would record it refuses: a filter that
         // records no fill value has nowhere to put one, so a value it could not
         // read is not an obstacle to saying there is none.
-        let undefined = ChunkOptions {
-            scale_offset: Some(ScaleOffset::FloatDScale(2)),
-            scale_offset_fill: FillAvailability::Undefined,
-            ..Default::default()
-        };
+        let undefined = filtered(&[FilterKind::ScaleOffset(
+            ScaleOffset::FloatDScale(2),
+            FillAvailability::Undefined,
+        )]);
         assert!(undefined.build_pipeline(&ctx, FillPattern::UNKNOWN).is_ok());
 
         // The default is the reference library's: every scale-offset dataset it
         // writes records a fill value, including one whose fill value was never
-        // set. Asserted here as well as in the crosschecks because those are
-        // gated to little-endian 64-bit targets, where the `cross` jobs run
-        // nothing that would notice this flipping back.
+        // set. Asserted through the builder switch, which is the one place that
+        // chooses an availability on the caller's behalf — and asserted here as
+        // well as in the crosschecks because those are gated to little-endian
+        // 64-bit targets, where the `cross` jobs run nothing that would notice
+        // this flipping back.
+        let mut db = crate::type_builders::DatasetBuilder::new("d");
+        db.with_scale_offset(ScaleOffset::FloatDScale(2));
         assert_eq!(
-            ChunkOptions::default().scale_offset_fill,
-            FillAvailability::Defined
+            db.chunk_options.filters,
+            vec![FilterSpec {
+                kind: FilterKind::ScaleOffset(
+                    ScaleOffset::FloatDScale(2),
+                    FillAvailability::Defined
+                ),
+                optional: false,
+            }]
         );
         // Every other pipeline is buildable from the same pattern: only the
         // filter that records the fill value needs to read it.
-        let plain = ChunkOptions {
-            deflate_level: Some(6),
-            ..Default::default()
-        };
+        let plain = filtered(&[FilterKind::Deflate(6)]);
         assert!(plain.build_pipeline(&ctx, FillPattern::UNKNOWN).is_ok());
     }
 
     #[test]
     fn chunk_options_pipeline_deflate() {
-        let options = ChunkOptions {
-            deflate_level: Some(6),
-            ..Default::default()
-        };
+        let options = filtered(&[FilterKind::Deflate(6)]);
         let pl = options
             .build_pipeline(&ChunkContext::basic(&[], 8), FillPattern::ZERO)
             .unwrap()
@@ -4092,12 +4249,11 @@ mod tests {
 
     #[test]
     fn chunk_options_pipeline_shuffle_deflate_fletcher32() {
-        let options = ChunkOptions {
-            deflate_level: Some(6),
-            shuffle: true,
-            fletcher32: true,
-            ..Default::default()
-        };
+        let options = filtered(&[
+            FilterKind::Shuffle,
+            FilterKind::Deflate(6),
+            FilterKind::Fletcher32,
+        ]);
         let pl = options
             .build_pipeline(&ChunkContext::basic(&[], 8), FillPattern::ZERO)
             .unwrap()
@@ -4106,6 +4262,82 @@ mod tests {
         assert_eq!(pl.filters[0].filter_id, FILTER_SHUFFLE);
         assert_eq!(pl.filters[1].filter_id, FILTER_DEFLATE);
         assert_eq!(pl.filters[2].filter_id, FILTER_FLETCHER32);
+    }
+
+    /// `set_filter` places a filter at this crate's canonical rank whatever
+    /// order the caller names them in, and replaces rather than repeats.
+    ///
+    /// This is what the `DatasetBuilder` switches promise: they name a filter to
+    /// apply, not a position to apply it at, so `with_deflate(6).with_shuffle()`
+    /// has to write the same bytes as `with_shuffle().with_deflate(6)`. The
+    /// pipeline being an ordered list now (issue #333) is exactly what would let
+    /// that drift.
+    #[test]
+    fn setting_filters_places_them_in_canonical_order_whatever_order_they_arrive_in() {
+        let ids = |o: &ChunkOptions| -> Vec<u16> {
+            o.filters.iter().map(|f| f.kind.filter_id()).collect()
+        };
+        let canonical = [FILTER_SHUFFLE, FILTER_DEFLATE, FILTER_FLETCHER32];
+
+        assert_eq!(
+            ids(&filtered(&[
+                FilterKind::Shuffle,
+                FilterKind::Deflate(6),
+                FilterKind::Fletcher32,
+            ])),
+            canonical
+        );
+        assert_eq!(
+            ids(&filtered(&[
+                FilterKind::Fletcher32,
+                FilterKind::Deflate(6),
+                FilterKind::Shuffle,
+            ])),
+            canonical
+        );
+
+        // Naming one twice sets its parameter, rather than applying it twice.
+        let twice = filtered(&[
+            FilterKind::Deflate(1),
+            FilterKind::Shuffle,
+            FilterKind::Deflate(9),
+        ]);
+        assert_eq!(ids(&twice), [FILTER_SHUFFLE, FILTER_DEFLATE]);
+        assert_eq!(twice.filters[1].kind, FilterKind::Deflate(9));
+    }
+
+    /// A pushed pipeline reaches the file in the order and with the optional
+    /// flags it was pushed with, not this crate's canonical order (issue #333).
+    ///
+    /// `fletcher32` between shuffle and deflate is the case that matters: it
+    /// checksums the shuffled bytes, where the canonical placement at the end
+    /// would checksum the deflated ones. That is a different checksum over
+    /// different data, so a `repack` that quietly re-ordered it produced a
+    /// destination verifying something the source never did.
+    #[test]
+    fn a_pushed_pipeline_keeps_its_order_and_its_optional_flags() {
+        let mut options = ChunkOptions::default();
+        for (kind, optional) in [
+            (FilterKind::Shuffle, true),
+            (FilterKind::Fletcher32, false),
+            (FilterKind::Deflate(4), true),
+        ] {
+            options.push_filter(FilterSpec { kind, optional });
+        }
+
+        let pl = options
+            .build_pipeline(&ChunkContext::basic(&[], 8), FillPattern::ZERO)
+            .unwrap()
+            .unwrap();
+        let stored: Vec<(u16, u16)> = pl.filters.iter().map(|f| (f.filter_id, f.flags)).collect();
+        assert_eq!(
+            stored,
+            [
+                (FILTER_SHUFFLE, 1),
+                (FILTER_FLETCHER32, 0),
+                (FILTER_DEFLATE, 1),
+            ]
+        );
     }
 
     /// Every request naming two filters where one would displace the other is
@@ -4120,64 +4352,41 @@ mod tests {
     #[test]
     fn conflicting_filter_requests_are_refused() {
         let so = ScaleOffset::FloatDScale(2);
+        let fill = FillAvailability::Defined;
         let cases: &[(&str, &str, ChunkOptions)] = &[
             (
                 "lzf",
                 "deflate",
-                ChunkOptions {
-                    lzf: true,
-                    deflate_level: Some(6),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Lzf, FilterKind::Deflate(6)]),
             ),
             (
                 "shuffle",
                 "scale-offset",
-                ChunkOptions {
-                    shuffle: true,
-                    scale_offset: Some(so),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Shuffle, FilterKind::ScaleOffset(so, fill)]),
             ),
             #[cfg(feature = "zfp")]
             (
                 "scale-offset",
                 "ZFP",
-                ChunkOptions {
-                    scale_offset: Some(so),
-                    zfp_rate: Some(16.0),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::ScaleOffset(so, fill), FilterKind::Zfp(16.0)]),
             ),
             #[cfg(feature = "zfp")]
             (
                 "shuffle",
                 "ZFP",
-                ChunkOptions {
-                    shuffle: true,
-                    zfp_rate: Some(16.0),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Shuffle, FilterKind::Zfp(16.0)]),
             ),
             #[cfg(feature = "zfp")]
             (
                 "lzf",
                 "ZFP",
-                ChunkOptions {
-                    lzf: true,
-                    zfp_rate: Some(16.0),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Lzf, FilterKind::Zfp(16.0)]),
             ),
             #[cfg(feature = "zfp")]
             (
                 "deflate",
                 "ZFP",
-                ChunkOptions {
-                    deflate_level: Some(6),
-                    zfp_rate: Some(16.0),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Deflate(6), FilterKind::Zfp(16.0)]),
             ),
         ];
 
@@ -4228,39 +4437,22 @@ mod tests {
     /// blanket ban on combining filters.
     #[test]
     fn compatible_filter_requests_still_build() {
-        let so = Some(ScaleOffset::FloatDScale(2));
+        let so = FilterKind::ScaleOffset(ScaleOffset::FloatDScale(2), FillAvailability::Defined);
         let cases: &[(ChunkOptions, &[u16])] = &[
             (
-                ChunkOptions {
-                    shuffle: true,
-                    deflate_level: Some(6),
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Shuffle, FilterKind::Deflate(6)]),
                 &[FILTER_SHUFFLE, FILTER_DEFLATE],
             ),
             (
-                ChunkOptions {
-                    shuffle: true,
-                    lzf: true,
-                    ..Default::default()
-                },
+                filtered(&[FilterKind::Shuffle, FilterKind::Lzf]),
                 &[FILTER_SHUFFLE, FILTER_LZF],
             ),
             (
-                ChunkOptions {
-                    scale_offset: so,
-                    deflate_level: Some(6),
-                    ..Default::default()
-                },
+                filtered(&[so, FilterKind::Deflate(6)]),
                 &[FILTER_SCALEOFFSET, FILTER_DEFLATE],
             ),
             (
-                ChunkOptions {
-                    scale_offset: so,
-                    lzf: true,
-                    fletcher32: true,
-                    ..Default::default()
-                },
+                filtered(&[so, FilterKind::Lzf, FilterKind::Fletcher32]),
                 &[FILTER_SCALEOFFSET, FILTER_LZF, FILTER_FLETCHER32],
             ),
         ];
@@ -4580,11 +4772,10 @@ mod tests {
                 for &unlimited in &[false, true] {
                     let values: Vec<f64> = (0..elements).map(|i| i as f64).collect();
                     let raw = f64_to_bytes(&values);
-                    let options = ChunkOptions {
-                        chunk_dims: Some(vec![chunk]),
-                        deflate_level: deflate.then_some(6),
-                        ..Default::default()
-                    };
+                    let mut options = chunked(&[chunk], &[]);
+                    if deflate {
+                        options.set_filter(FilterKind::Deflate(6));
+                    }
                     let dims = [chunk];
                     let maxshape = unlimited.then_some([u64::MAX]);
                     let set = compress_chunks(

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -8605,20 +8605,17 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
         db.chunk_options
             .validate_geometry(&shape, db.maxshape.as_deref())
             .map_err(Error::EditUnsupported)?;
-        // Deflate is compiled out unless the `deflate` feature is on, but
-        // `build_pipeline` emits its descriptor regardless; catch a
-        // disabled-feature request here so it is refused up front rather than
+        // A filter this build cannot apply is refused up front rather than
         // failing mid-apply when a chunk is compressed.
-        #[cfg(not(feature = "deflate"))]
-        if db.chunk_options.deflate_level.is_some() {
-            return Err(Error::EditUnsupported(
-                "deflate compression requires the `deflate` crate feature",
-            ));
-        }
+        db.chunk_options
+            .refuse_unavailable_filters()
+            .map_err(Error::EditUnsupported)?;
         // Validate the requested filter pipeline now — before any file bytes are
         // written — so an unsupported filter, an incompatible datatype, or a
-        // disabled compression feature is refused up front; the chunk data
-        // itself is laid out in the commit's apply phase. Chunked/filtered
+        // fill value the filter cannot record is refused up front; the chunk
+        // data itself is laid out in the commit's apply phase. A filter the
+        // build compiled out is not among them: `build_pipeline` emits its
+        // descriptor regardless, which is why the check above exists. Chunked/filtered
         // storage flows through the very builder the normal writer uses
         // ([`compress_chunks`] + [`assemble_chunked_at`] + [`build_chunked_dataset_oh`]),
         // so the
@@ -8641,9 +8638,8 @@ fn flatten_dataset(db: DatasetBuilder) -> Result<FlatDataset, Error> {
             .map_err(|_| {
                 Error::EditUnsupported(
                     "this dataset's filter pipeline cannot be added in place \
-                     (an unsupported filter, an incompatible datatype, a fill \
-                     value the filter cannot record, or a compression feature \
-                     that is not enabled)",
+                     (an unsupported filter, an incompatible datatype, or a \
+                     fill value the filter cannot record)",
                 )
             })?;
     }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -20,6 +20,11 @@ pub const FILTER_LZF: u16 = 32000;
 #[cfg(feature = "zfp")]
 pub const FILTER_ZFP: u16 = 32013;
 
+/// `H5Z_FLAG_OPTIONAL`, bit 0 of a filter's flags word: a reader that cannot
+/// apply the filter may skip it. Named so the paths that read the bit and the
+/// path that writes it cannot read different values.
+pub const H5Z_FLAG_OPTIONAL: u16 = 1;
+
 /// Description of a single filter in a pipeline.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FilterDescription {
@@ -31,6 +36,15 @@ pub struct FilterDescription {
     pub flags: u16,
     /// Client data values passed to the filter.
     pub client_data: Vec<u32>,
+}
+
+impl FilterDescription {
+    /// Whether a reader that cannot apply this filter may skip it
+    /// ([`H5Z_FLAG_OPTIONAL`]). A mandatory filter must be applied for the data
+    /// to decode, so a reader missing it has to fail.
+    pub fn is_optional(&self) -> bool {
+        self.flags & H5Z_FLAG_OPTIONAL != 0
+    }
 }
 
 /// A filter pipeline consisting of one or more filters.

--- a/src/lzf_crosscheck.rs
+++ b/src/lzf_crosscheck.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
-use crate::chunked_write::ChunkOptions;
+use crate::chunked_write::{ChunkOptions, FilterKind};
 use crate::filter_pipeline::{FILTER_LZF, FILTER_SHUFFLE};
 use crate::lzf;
 
@@ -112,12 +112,14 @@ fn writer_pipeline_matches_h5py() {
             fix.name
         );
 
-        let options = ChunkOptions {
+        let mut options = ChunkOptions {
             chunk_dims: Some(fix.chunk_shape.clone()),
-            lzf: true,
-            shuffle: fix.filters.contains(&FILTER_SHUFFLE),
             ..ChunkOptions::default()
         };
+        if fix.filters.contains(&FILTER_SHUFFLE) {
+            options.set_filter(FilterKind::Shuffle);
+        }
+        options.set_filter(FilterKind::Lzf);
         let pipeline = options
             .build_pipeline(
                 &crate::filters::ChunkContext::basic(&fix.chunk_shape, fix.element_size()),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3794,8 +3794,8 @@ the same commit to replace it",
                     .into_iter()
                     .map(|f| Filter {
                         id: f.filter_id,
+                        is_optional: f.is_optional(),
                         name: f.name,
-                        is_optional: f.flags & 0x1 != 0,
                         client_data: f.client_data,
                     })
                     .collect()

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -115,7 +115,7 @@ use std::sync::Arc;
 
 use crate::attribute::AttributeMessage;
 use crate::chunked_read::ChunkInfo;
-use crate::chunked_write::{ChunkMeta, ChunkProvider};
+use crate::chunked_write::{ChunkMeta, ChunkProvider, FilterKind, FilterSpec};
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
 use crate::datatype::{Datatype, ReferenceType, embedded_reference_slots};
@@ -587,7 +587,7 @@ fn emit_dataset(
     // re-apply is refused here exactly as it is on the re-encode path below —
     // the filters are reproduced through the same `carry_shape_and_pipeline`.
     if storage_is_unallocated(&layout, &source_chunks) {
-        check_pipeline(pipeline.as_ref(), path)?;
+        let filters = check_pipeline(pipeline.as_ref(), path)?;
         db.fill = fill;
         db.with_unallocated_storage(datatype, &dims);
         carry_shape_and_pipeline(
@@ -595,7 +595,7 @@ fn emit_dataset(
             &dims,
             dataspace.max_dimensions.as_deref(),
             &layout,
-            &pipeline,
+            &filters,
         );
         copy_dataset_attrs(db, ds, path, drop, addr_map)?;
         return Ok(());
@@ -731,7 +731,7 @@ fn emit_dataset(
     // Contiguous/compact, or a sparse chunked dataset: read the decompressed
     // bytes and re-encode. This path can only reproduce lossless filters, so
     // refuse a lossy pipeline before reading.
-    check_pipeline(pipeline.as_ref(), path)?;
+    let filters = check_pipeline(pipeline.as_ref(), path)?;
 
     if n_elements == 0 {
         // An empty dataset owns no element bytes: carry just the datatype and
@@ -748,7 +748,7 @@ fn emit_dataset(
         &dims,
         dataspace.max_dimensions.as_deref(),
         &layout,
-        &pipeline,
+        &filters,
     );
 
     // Carry the dataset's attributes, refusing if any cannot be represented.
@@ -785,14 +785,15 @@ fn copy_dataset_attrs(
 /// variable-length re-staging paths, which both rebuild their elements from
 /// scratch and so must reapply the layout themselves.
 ///
-/// `check_pipeline` has already rejected any filter not handled here, so the
-/// match over filter ids is exhaustive.
+/// `filters` are the ones [`check_pipeline`] decoded, which is what makes them
+/// safe to re-apply: there is no way to reach this with a pipeline that was not
+/// proved reproducible first.
 fn carry_shape_and_pipeline(
     db: &mut DatasetBuilder,
     dims: &[u64],
     max_dimensions: Option<&[u64]>,
     layout: &DataLayout,
-    pipeline: &Option<FilterPipeline>,
+    filters: &[FilterSpec],
 ) {
     // A max-shape that differs from the current shape means a resizable dataset.
     if let Some(maxshape) = max_dimensions
@@ -816,45 +817,21 @@ fn carry_shape_and_pipeline(
         db.with_chunks(&logical);
     }
 
-    // Re-apply supported filters in their stored order.
-    if let Some(p) = pipeline {
-        for f in &p.filters {
-            match f.filter_id {
-                FILTER_SHUFFLE => {
-                    db.with_shuffle();
-                }
-                FILTER_FLETCHER32 => {
-                    db.with_fletcher32();
-                }
-                FILTER_DEFLATE => {
-                    // Client-data[0] is the deflate level; default to 6 if absent.
-                    db.with_deflate(f.client_data.first().copied().unwrap_or(6));
-                }
-                FILTER_LZF => {
-                    db.with_lzf();
-                }
-                FILTER_SCALEOFFSET => {
-                    // `check_pipeline` guarantees integer (lossless) mode here.
-                    // Re-apply with the source's minbits parameter; integer
-                    // scale-offset reconstructs the exact element bytes.
-                    //
-                    // Its fill availability is re-applied too. The value it
-                    // records comes from the dataset's own fill value, carried
-                    // separately, so only the availability needs saying — and
-                    // saying it keeps a source that records none from gaining
-                    // one, which would re-encode every chunk a code point wider.
-                    if let Some((mode @ ScaleOffset::Integer(_), fill)) =
-                        scaleoffset::scale_offset_mode(&f.client_data)
-                    {
-                        db.with_scale_offset(mode);
-                        db.chunk_options.scale_offset_fill = fill;
-                    } else {
-                        unreachable!("check_pipeline rejected non-integer scale-offset");
-                    }
-                }
-                _ => unreachable!("check_pipeline rejected unsupported filters"),
-            }
-        }
+    // Re-apply the source's filters in the source's own order, each carrying
+    // the optional flag it was stored with (issue #333).
+    //
+    // Both are observable, and neither is necessarily what this crate's own
+    // writer would choose. `fletcher32` between shuffle and deflate checksums
+    // the shuffled bytes; moved to the end it checksums the deflated ones — a
+    // different checksum over different data, and a different thing for a
+    // reader to verify. A filter that loses its optional flag becomes one a
+    // reader must be able to apply, where before it could skip it.
+    //
+    // Pushed rather than set through the `with_*` switches, which name a filter
+    // to apply and place it at this crate's canonical rank: that is right for a
+    // caller composing a pipeline and wrong for reproducing one that exists.
+    for &spec in filters {
+        db.chunk_options.push_filter(spec);
     }
 }
 
@@ -878,7 +855,7 @@ fn emit_vlen_string_dataset(
 ) -> Result<(), Error> {
     // A lossy pipeline cannot be reproduced, so refuse it before reading — the
     // same guard the fixed-size re-encode path applies.
-    check_pipeline(pipeline.as_ref(), path)?;
+    let filters = check_pipeline(pipeline.as_ref(), path)?;
 
     // Read each element's exact heap bytes, preserving the null-vs-empty
     // distinction. Reading bytes (not the lossily UTF-8-decoded `String`) keeps
@@ -903,7 +880,7 @@ fn emit_vlen_string_dataset(
         dims,
         ds.dataspace()?.max_dimensions.as_deref(),
         layout,
-        pipeline,
+        &filters,
     );
     Ok(())
 }
@@ -925,7 +902,7 @@ fn emit_vlen_sequence_dataset(
     layout: &DataLayout,
     pipeline: &Option<FilterPipeline>,
 ) -> Result<(), Error> {
-    check_pipeline(pipeline.as_ref(), path)?;
+    let filters = check_pipeline(pipeline.as_ref(), path)?;
 
     // Read each element's exact heap bytes (preserving the null-vs-empty
     // distinction and any embedded NULs), then re-stage with the source datatype.
@@ -946,7 +923,7 @@ fn emit_vlen_sequence_dataset(
         dims,
         ds.dataspace()?.max_dimensions.as_deref(),
         layout,
-        pipeline,
+        &filters,
     );
     Ok(())
 }
@@ -985,7 +962,7 @@ fn emit_embedded_address_dataset(
 ) -> Result<(), Error> {
     // This path re-encodes, so a lossy filter cannot be reproduced — the same
     // guard the other re-staging paths apply.
-    check_pipeline(pipeline.as_ref(), path)?;
+    let filters = check_pipeline(pipeline.as_ref(), path)?;
 
     // An embedded object address is resolved as the elements are re-staged, which
     // a compressed chunk would need rewritten in place, so the layout guards that
@@ -1046,7 +1023,7 @@ fn emit_embedded_address_dataset(
         dims,
         ds.dataspace()?.max_dimensions.as_deref(),
         layout,
-        pipeline,
+        &filters,
     );
     Ok(())
 }
@@ -1698,38 +1675,58 @@ fn check_layout(layout: &DataLayout, path: &str) -> Result<(), Error> {
 ///
 /// The dense chunked path (the common case) copies compressed chunks verbatim
 /// and never calls this — there every filter is safe because nothing is decoded.
-fn check_pipeline(pipeline: Option<&FilterPipeline>, path: &str) -> Result<(), Error> {
+fn check_pipeline(pipeline: Option<&FilterPipeline>, path: &str) -> Result<Vec<FilterSpec>, Error> {
     let Some(p) = pipeline else {
-        return Ok(());
+        return Ok(Vec::new());
     };
-    // Re-encoding replays filters through the builder, which emits its own
-    // fixed order and refuses lzf + deflate on one dataset, so a foreign
-    // pipeline carrying both cannot be reproduced faithfully.
+    // Re-encoding replays the filters through the builder, which refuses lzf and
+    // deflate on one dataset — they fill the same byte-compressor slot — so a
+    // foreign pipeline carrying both cannot be reproduced. Refused here, by
+    // name, rather than left to surface as the builder's combination error.
     let has = |id| p.filters.iter().any(|f| f.filter_id == id);
     if has(FILTER_LZF) && has(FILTER_DEFLATE) {
         return Err(Error::RepackUnsupported(format!(
             "dataset {path}: an lzf + deflate pipeline cannot be re-encoded faithfully"
         )));
     }
-    for f in &p.filters {
-        match f.filter_id {
-            FILTER_DEFLATE | FILTER_SHUFFLE | FILTER_FLETCHER32 | FILTER_LZF => {}
-            FILTER_SCALEOFFSET => match scaleoffset::scale_offset_mode(&f.client_data) {
-                Some((ScaleOffset::Integer(_), _)) => {}
-                _ => {
+    p.filters
+        .iter()
+        .map(|f| {
+            let kind = match f.filter_id {
+                FILTER_SHUFFLE => FilterKind::Shuffle,
+                FILTER_FLETCHER32 => FilterKind::Fletcher32,
+                // Client-data[0] is the deflate level; default to 6 if absent.
+                FILTER_DEFLATE => FilterKind::Deflate(f.client_data.first().copied().unwrap_or(6)),
+                FILTER_LZF => FilterKind::Lzf,
+                // Only the lossless integer mode qualifies, re-applied with the
+                // source's minbits parameter. Its fill availability comes along
+                // too: the value the filter records is the dataset's own fill
+                // value, carried separately, so only the availability needs
+                // saying — and saying it keeps a source that recorded none from
+                // gaining one, which would re-encode every chunk a code point
+                // wider.
+                FILTER_SCALEOFFSET => match scaleoffset::scale_offset_mode(&f.client_data) {
+                    Some((mode @ ScaleOffset::Integer(_), fill)) => {
+                        FilterKind::ScaleOffset(mode, fill)
+                    }
+                    _ => {
+                        return Err(Error::RepackUnsupported(format!(
+                            "dataset {path}: only lossless integer scale-offset can be repacked faithfully"
+                        )));
+                    }
+                },
+                other => {
                     return Err(Error::RepackUnsupported(format!(
-                        "dataset {path}: only lossless integer scale-offset can be repacked faithfully"
+                        "dataset {path}: filter id {other} cannot be repacked yet"
                     )));
                 }
-            },
-            other => {
-                return Err(Error::RepackUnsupported(format!(
-                    "dataset {path}: filter id {other} cannot be repacked yet"
-                )));
-            }
-        }
-    }
-    Ok(())
+            };
+            Ok(FilterSpec {
+                kind,
+                optional: f.is_optional(),
+            })
+        })
+        .collect()
 }
 
 /// Canonicalize a path to slash-free form: split on `/`, drop empty components,
@@ -1800,9 +1797,24 @@ mod tests {
                     single_chunk_filtered_size: None,
                     single_chunk_filter_mask: None,
                 },
-                &pipeline,
+                // Routed through `check_pipeline`, as every production caller
+                // is: it is the step that decodes the availability out of the
+                // source's parameters.
+                &check_pipeline(pipeline.as_ref(), "d").expect("integer scale-offset repacks"),
             );
-            db.chunk_options.scale_offset_fill
+            let [
+                FilterSpec {
+                    kind: FilterKind::ScaleOffset(_, fill),
+                    ..
+                },
+            ] = db.chunk_options.filters[..]
+            else {
+                panic!(
+                    "expected one scale-offset filter, got {:?}",
+                    db.chunk_options.filters
+                );
+            };
+            fill
         };
 
         assert_eq!(
@@ -1816,10 +1828,9 @@ mod tests {
     }
 
     /// A foreign pipeline carrying both lzf and deflate is refused with the
-    /// repack error, not the builder's combination error: the builder replays
-    /// filters in its own fixed order, so the stored order cannot be
-    /// reproduced. The builder cannot produce such a file, hence a synthetic
-    /// pipeline rather than a file-level test.
+    /// repack error naming the pair, not the builder's combination error raised
+    /// later from deeper down. The builder cannot produce such a file, hence a
+    /// synthetic pipeline rather than a file-level test.
     #[test]
     fn lzf_plus_deflate_pipeline_is_refused() {
         use crate::filter_pipeline::FilterDescription;

--- a/src/scaleoffset.rs
+++ b/src/scaleoffset.rs
@@ -166,11 +166,10 @@ fn order_code(order: &DatatypeByteOrder) -> Option<u32> {
 /// for one caller: [`repack`](crate::repack), reproducing a source file whose
 /// filter recorded `FILL_UNDEFINED`. The day the writer models an undefined
 /// fill value, this collapses back into the fill value itself.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FillAvailability {
     /// `FILL_DEFINED`: the filter records the dataset's fill value, and encodes
     /// elements equal to it as the reserved sentinel.
-    #[default]
     Defined,
     /// `FILL_UNDEFINED`: the filter records no fill value, and every element is
     /// encoded as an ordinary offset.

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -10,7 +10,7 @@ use core::fmt;
 use core::num::NonZeroUsize;
 
 use crate::attribute::AttributeMessage;
-use crate::chunked_write::{ChunkMeta, ChunkOptions, ChunkProvider, StorageAllocation};
+use crate::chunked_write::{ChunkMeta, ChunkOptions, ChunkProvider, FilterKind, StorageAllocation};
 use crate::compound::CompoundType;
 use crate::convert::TryToUsize;
 use crate::dataspace::{Dataspace, DataspaceType};
@@ -19,7 +19,7 @@ use crate::datatype::{
 };
 use crate::display::write_elided;
 use crate::error::FormatError;
-use crate::scaleoffset::ScaleOffset;
+use crate::scaleoffset::{FillAvailability, ScaleOffset};
 use crate::shared_message::DatatypeLocation;
 
 // ---- Datatype constructors ----
@@ -2392,7 +2392,7 @@ impl DatasetBuilder {
     /// filter error. May follow [`with_shuffle`](Self::with_shuffle) or
     /// [`with_scale_offset`](Self::with_scale_offset).
     pub fn with_deflate(&mut self, level: u32) -> &mut Self {
-        self.chunk_options.deflate_level = Some(level);
+        self.chunk_options.set_filter(FilterKind::Deflate(level));
         self
     }
 
@@ -2403,7 +2403,7 @@ impl DatasetBuilder {
     /// [`with_zfp`](Self::with_zfp): requesting shuffle alongside either makes
     /// the write fail with a filter error rather than dropping it.
     pub fn with_shuffle(&mut self) -> &mut Self {
-        self.chunk_options.shuffle = true;
+        self.chunk_options.set_filter(FilterKind::Shuffle);
         self
     }
 
@@ -2418,13 +2418,13 @@ impl DatasetBuilder {
     /// replaces it — requesting either combination makes the write fail with a
     /// filter error.
     pub fn with_lzf(&mut self) -> &mut Self {
-        self.chunk_options.lzf = true;
+        self.chunk_options.set_filter(FilterKind::Lzf);
         self
     }
 
     /// Enable fletcher32 checksum.
     pub fn with_fletcher32(&mut self) -> &mut Self {
-        self.chunk_options.fletcher32 = true;
+        self.chunk_options.set_filter(FilterKind::Fletcher32);
         self
     }
 
@@ -2451,7 +2451,13 @@ impl DatasetBuilder {
     /// [`with_lzf`](Self::with_lzf). Files are readable by the reference HDF5
     /// library (filter id 6) and vice versa.
     pub fn with_scale_offset(&mut self, mode: ScaleOffset) -> &mut Self {
-        self.chunk_options.scale_offset = Some(mode);
+        self.chunk_options
+            // `Defined` named rather than defaulted: it is this builder that
+            // chooses it on the caller's behalf, matching what the reference
+            // library records for every dataset whose fill value is not
+            // explicitly undefined, and `with_scale_offset` is where a reader
+            // looks for that choice.
+            .set_filter(FilterKind::ScaleOffset(mode, FillAvailability::Defined));
         self
     }
 
@@ -2478,7 +2484,7 @@ impl DatasetBuilder {
     /// will read and decompress it, and vice versa.
     #[cfg(feature = "zfp")]
     pub fn with_zfp(&mut self, rate: f64) -> &mut Self {
-        self.chunk_options.zfp_rate = Some(rate);
+        self.chunk_options.set_filter(FilterKind::Zfp(rate));
         self
     }
 

--- a/tests/repack_crosscheck.rs
+++ b/tests/repack_crosscheck.rs
@@ -1887,3 +1887,204 @@ fn repack_still_refuses_a_never_written_dataset_with_a_lossy_filter() {
     }
     assert!(!dst.exists(), "dst must not be created when repack refuses");
 }
+
+/// Filter ids, so a pipeline assertion reads as filters rather than as numbers.
+const FILTER_DEFLATE: u16 = 1;
+const FILTER_SHUFFLE: u16 = 2;
+const FILTER_FLETCHER32: u16 = 3;
+
+/// A dataset's pipeline as `(filter id, is_optional)`, in stored order — the
+/// two properties issue #333 is about, and the pair `h5dump` and `H5Pget_filter2`
+/// report.
+fn pipeline_of(path: &std::path::Path, dataset: &str) -> Vec<(u16, bool)> {
+    File::open(path)
+        .unwrap()
+        .dataset(dataset)
+        .unwrap()
+        .filter_pipeline()
+        .iter()
+        .map(|f| (f.id, f.is_optional))
+        .collect()
+}
+
+/// A source pipeline's filter *order* and per-filter *optional* flags survive a
+/// re-encoding repack (issue #333).
+///
+/// The order is not cosmetic. `shuffle -> fletcher32 -> deflate` checksums the
+/// shuffled bytes; moving fletcher32 last checksums the deflated bytes instead,
+/// so the destination verifies a different thing on read than the source did.
+/// And a filter that loses its optional flag becomes mandatory, so a reader that
+/// cannot apply it must now fail where it was previously allowed to skip.
+///
+/// Driven through the *sparse* chunked source that forces the re-encode
+/// fallback: the dense verbatim chunk-copy path copies the source's pipeline
+/// message byte-exact and never had this defect.
+#[test]
+fn c_pipeline_order_and_optional_flags_survive_re_encoding_repack() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_order.h5");
+    let dst = dir.path().join("c_order_repacked.h5");
+
+    let n = 2000usize; // chunk 512 -> 4 chunks; only the first 1000 written
+    let written = 1000usize;
+    let head: Vec<i32> = (1..=written as i32).collect();
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        let ds = file
+            .new_dataset::<i32>()
+            .shape([n])
+            .chunk([512])
+            .shuffle()
+            .fletcher32()
+            .deflate(4)
+            .create("data")
+            .unwrap();
+        ds.write_slice(head.as_slice(), 0..written).unwrap();
+        file.close().unwrap();
+    }
+
+    let source_pipeline = pipeline_of(&src, "data");
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    assert_eq!(
+        pipeline_of(&dst, "data"),
+        source_pipeline,
+        "repack must reproduce the source's filter order and optional flags"
+    );
+
+    // The data still round-trips, through both readers.
+    let f = File::open(&dst).unwrap();
+    let ds = f.dataset("data").unwrap();
+    let vals = ds.read_i32().unwrap();
+    assert_eq!(&vals[..written], head.as_slice());
+    assert!(vals[written..].iter().all(|&v| v == 0));
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let c_vals = c.dataset("data").unwrap().read_raw::<i32>().unwrap();
+    assert_eq!(&c_vals[..written], head.as_slice());
+}
+
+/// The same, through a re-encoding path that writes no chunks at all: a dataset
+/// the C library created and never wrote to (issue #293), whose storage repack
+/// reproduces as storage rather than materializing.
+///
+/// The pipeline is decoded and re-applied by the same `check_pipeline` +
+/// `carry_shape_and_pipeline` pair as every other re-encoding path, so this is
+/// not separate coverage of *that*. What it covers is the emit path afterwards:
+/// the message has to survive `with_unallocated_storage`, a writer that encodes
+/// nothing for it to describe. It is also the one test here that pins the C
+/// library's pipeline as a literal rather than comparing destination to source.
+#[test]
+fn a_never_written_dataset_keeps_its_pipeline_order_and_optional_flags() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_unwritten.h5");
+    let dst = dir.path().join("c_unwritten_repacked.h5");
+
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<i32>()
+            .shape([2000])
+            .chunk([512])
+            .shuffle()
+            .fletcher32()
+            .deflate(4)
+            .create("data")
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let source = pipeline_of(&src, "data");
+    assert_eq!(
+        source,
+        [
+            (FILTER_SHUFFLE, true),
+            (FILTER_FLETCHER32, false),
+            (FILTER_DEFLATE, true)
+        ],
+        "the C library did not write the pipeline this test is about"
+    );
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    assert_eq!(
+        pipeline_of(&dst, "data"),
+        source,
+        "repack must reproduce the source's filter order and optional flags"
+    );
+}
+
+/// And through `emit_vlen_string_dataset`, the third kind of re-encoding path.
+///
+/// A variable-length string dataset is never chunk-copied verbatim — its
+/// elements are heap references that go stale on rewrite, so every one is
+/// re-staged and re-encoded, whatever its layout. That routes it through the
+/// same `check_pipeline` + `carry_shape_and_pipeline` pair, so it lost its
+/// source's filter order and optional flags exactly as the fixed-size paths did
+/// (issue #333). The existing variable-length repack tests could not see it:
+/// they build their sources through this crate's own writer, which emits one
+/// canonically ordered, all-mandatory pipeline.
+#[test]
+fn a_vlen_string_dataset_keeps_its_pipeline_order_and_optional_flags() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("c_vlen_order.h5");
+    let dst = dir.path().join("c_vlen_order_repacked.h5");
+
+    let words: Vec<hdf5::types::VarLenUnicode> = (0..64)
+        .map(|i| format!("value-{i}").parse().unwrap())
+        .collect();
+    {
+        let file = hdf5::File::create(&src).unwrap();
+        file.new_dataset::<hdf5::types::VarLenUnicode>()
+            .shape([words.len()])
+            .chunk([8])
+            .shuffle()
+            .fletcher32()
+            .deflate(4)
+            .create("data")
+            .unwrap()
+            .write(&words)
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let source = pipeline_of(&src, "data");
+    assert_eq!(
+        source,
+        [
+            (FILTER_SHUFFLE, true),
+            (FILTER_FLETCHER32, false),
+            (FILTER_DEFLATE, true)
+        ],
+        "the C library did not write the pipeline this test is about"
+    );
+
+    repack(&src, &dst, &RepackOptions::new()).unwrap();
+
+    assert_eq!(
+        pipeline_of(&dst, "data"),
+        source,
+        "repack must reproduce the source's filter order and optional flags"
+    );
+
+    // And the strings themselves survive the re-staging, through both readers.
+    let f = File::open(&dst).unwrap();
+    let read: Vec<String> = f
+        .dataset("data")
+        .unwrap()
+        .read_vlen_strings(Default::default())
+        .unwrap();
+    let expected: Vec<String> = words.iter().map(|w| w.to_string()).collect();
+    assert_eq!(read, expected);
+
+    let c = hdf5::File::open(&dst).unwrap();
+    let c_read = c
+        .dataset("data")
+        .unwrap()
+        .read_raw::<hdf5::types::VarLenUnicode>()
+        .unwrap();
+    assert_eq!(
+        c_read.iter().map(|w| w.to_string()).collect::<Vec<_>>(),
+        expected
+    );
+}


### PR DESCRIPTION
Closes #333.

`repack`'s re-encoding paths rebuilt a dataset's filter pipeline by calling the `DatasetBuilder` switches — `with_shuffle()`, `with_fletcher32()`, `with_deflate(n)` — which emit filters in this crate's own canonical order and mark every one but LZF mandatory. A pipeline the C library wrote came back different in two ways:

| | pipeline |
| --- | --- |
| source | `[(2, true), (3, false), (1, true)]` — shuffle(optional), fletcher32(mandatory), deflate(optional) |
| destination (before) | `[(2, false), (1, false), (3, false)]` — shuffle, **deflate**, **fletcher32**, all mandatory |

Fletcher32 moving from second to last is the sharp end: it goes from checksumming the shuffled bytes to checksumming the deflated ones, so the destination verifies a different thing on read than the source did. And a filter that loses its optional flag becomes one a reader must be able to apply, where before it could skip it.

## The switches could not express it

`ChunkOptions` held one field per filter (`shuffle: bool`, `deflate_level: Option<u32>`, ...) and `build_pipeline` emitted them in a hardcoded order with `flags: 0`. A set of independent switches cannot say "fletcher32 before deflate" at all, so this was not a missing line — it was the representation.

It now holds a single ordered `filters: Vec<FilterSpec>`, where `FilterSpec` is a `FilterKind` plus its optional flag. Two ways in, for the two things callers actually want:

- **`set_filter(kind)`** places a filter at its canonical rank and replaces any entry with the same id. This is what the public switches call, and both halves are load-bearing: without rank placement `with_deflate(6).with_shuffle()` would emit a different byte order than `with_shuffle().with_deflate(6)`, and without replace-by-id `with_deflate(1).with_deflate(9)` would emit deflate twice where `Option<u32>` emitted one. Those setters name a filter to apply, not a position to apply it at.
- **`push_filter(spec)`** appends verbatim. This is how a pipeline that already exists gets reproduced.

`compress_chunk_with` and `decompress_chunk` were already driven entirely by the stored list, so the encoder needed no change — only `build_pipeline` fixed the order.

**Existing writes are byte-identical.** `canonical_rank` reproduces the old hardcoded emission order arm for arm, including the ZFP and scale-offset arms, and LZF's deliberate `flags: 1` survives as `FilterKind::default_optional`. The h5py LZF fixtures pin both.

## `check_pipeline` returns what it validated

`check_pipeline` and `carry_shape_and_pipeline` were matching over the same five filter ids and decoding scale-offset twice, with the coupling between them asserted by two `unreachable!()`s and a doc line. `check_pipeline` now returns the `Vec<FilterSpec>` it decoded and `carry_shape_and_pipeline` takes it.

That deletes the second match, both `unreachable!()`s and the duplicate decode, and turns "only a pipeline proved reproducible can be carried" into a property of the signature rather than of a comment. The duplication predates this PR; the ordered representation is what made removing it cheap.

## Five paths change, not two

The issue measured two re-encoding paths and I initially tested those two. `carry_shape_and_pipeline` has five production call sites, and the three variable-length and embedded-address re-staging paths change with them.

The existing coverage could not see it. `repack_roundtrips_filtered_and_resizable_vlen_string_datasets` builds its source through *this crate's* writer, which emits one canonically ordered, all-mandatory pipeline — structurally incapable of observing either property. `a_vlen_string_dataset_keeps_its_pipeline_order_and_optional_flags` builds its source with the C library instead.

The dense verbatim chunk-copy path is unaffected throughout: it copies the source's pipeline message byte-exact, which is why this went unnoticed.

## One thing worth knowing

`h5py_cd_values` records a chunk's raw byte size as the decompressed size h5py should expect, which is exact only where LZF reads the raw elements. A pushed pipeline can now place LZF behind fletcher32, understating it by the four checksum bytes. Neither reader is misled — ours never consults the value, and h5py's filter grows its buffer on `E2BIG` — and it was already inexact for `[scaleoffset, lzf]`, which canonical rank already produced. Documented at the arm that derives it rather than changed.

## Tests

Every new test was mutation-verified to fail under the mutation it exists for, and to fail alone:

| mutation | fails |
| --- | --- |
| `optional: f.is_optional()` → `false` | the three crosscheck tests only |
| `push_filter(spec)` → `set_filter(spec.kind)` | the three crosscheck tests only; the *existing* VL test still passes, which is the point |
| `build_pipeline` writes `flags = 0` | `a_pushed_pipeline_…` + the LZF fixture crosscheck + the three |
| `set_filter` appends instead of ranking | `setting_filters_places_them_in_canonical_order_…` only |
| `set_filter` accumulates instead of replacing | the same test only |
| `default_optional` returns `false` for LZF | the LZF fixture crosscheck only |

Two unit tests carry the rules where the crosschecks cannot reach: `tests/repack_crosscheck.rs` is gated to 64-bit little-endian, so on the i686 and s390x `cross` jobs `a_pushed_pipeline_keeps_its_order_and_its_optional_flags` is the only thing asserting that order and flags reach the message.

Gates run: `cargo nextest run --all-features` (2331), `cargo test --all-features --doc` (46), `cargo clippy --all-targets`, `RUSTDOCFLAGS="-D warnings" cargo doc`, the allocation baseline (unmoved), and five feature sets. `cargo semver-checks` reports no public API change — `chunked_write` is `pub(crate)`, so `ChunkOptions` was never exported — and no version bump is owed.
