### PR TITLE
Group the Extensible Array super-block geometry (#323)

### DIFF
--- a/src/chunk_index_inplace.rs
+++ b/src/chunk_index_inplace.rs
@@ -36,7 +36,7 @@ use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;
 use crate::datatype::Datatype;
 use crate::error::{Error, FormatError};
-use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
+use crate::extensible_array::{DataBlockGeom, EaGeometry, ExtensibleArrayHeader, SuperBlockGeom};
 use crate::fill_value::FillPattern;
 use crate::filter_pipeline::FilterPipeline;
 use crate::filters::{ChunkContext, FilterScratch, compress_chunk_with, decompress_chunk};
@@ -575,7 +575,7 @@ impl Located {
                 "chunk index geometry does not cover the appended element",
             ));
         }
-        let is_paged = region.dblk_nelmts > page_nelmts;
+        let is_paged = region.blocks(page_nelmts).is_paged();
         let slot = e - region.db_start;
 
         // Resolve the owning super block (if any) and the data-block pointer,
@@ -629,15 +629,13 @@ impl Located {
             }
             Parent::Super { dblk_local, .. } => {
                 let sblk_addr = sblk_addr.expect("super-block address resolved for a Super parent");
-                sb_dblk_slot_off(
+                Ok(sb_dblk_slot_off(
                     os,
                     sblk_addr,
                     dblk_local,
-                    region.ndblks,
-                    region.dblk_nelmts,
-                    self.page_nelmts,
+                    region.super_block(self.page_nelmts),
                     blk_off,
-                )
+                ))
             }
         }
     }
@@ -694,20 +692,16 @@ impl Located {
             ));
         }
         let dblk_nelmts = region.dblk_nelmts;
-        let is_paged = dblk_nelmts > self.page_nelmts;
+        let sb_geom = region.super_block(self.page_nelmts);
+        let is_paged = sb_geom.blocks.is_paged();
         let slot = e - region.db_start;
         let block_offset_rel = region.db_start - idx;
-        let ndblks = region.ndblks;
 
         // Ensure the owning super block exists (idempotent) for a Super parent.
         let sblk_addr = match region.parent {
-            Parent::Super { sblk_j, .. } => Some(self.ensure_super_block(
-                file,
-                sblk_j,
-                region.sb_block_offset,
-                ndblks,
-                dblk_nelmts,
-            )?),
+            Parent::Super { sblk_j, .. } => {
+                Some(self.ensure_super_block(file, sblk_j, region.sb_block_offset, sb_geom)?)
+            }
             Parent::IndexDirect { .. } => None,
         };
 
@@ -736,9 +730,7 @@ impl Located {
                 Parent::Super { .. } => self.publish_super_block(
                     file,
                     sblk_addr.unwrap(),
-                    ndblks,
-                    dblk_nelmts,
-                    self.page_nelmts,
+                    sb_geom,
                     blk_off,
                     dblk_ptr_off,
                     &new_addr.to_le_bytes()[..os],
@@ -775,16 +767,7 @@ impl Located {
                 if let Parent::Super { dblk_local, .. } = region.parent {
                     let global_page = dblk_local as u64 * npages + page;
                     let (byte, set) = sb_page_bit(file, sblk_addr, blk_off, global_page)?;
-                    self.publish_super_block(
-                        file,
-                        sblk_addr,
-                        ndblks,
-                        dblk_nelmts,
-                        self.page_nelmts,
-                        blk_off,
-                        byte,
-                        &[set],
-                    )?;
+                    self.publish_super_block(file, sblk_addr, sb_geom, blk_off, byte, &[set])?;
                 }
             }
         }
@@ -812,8 +795,7 @@ impl Located {
         file: &mut F,
         sblk_j: usize,
         sb_block_offset: u64,
-        ndblks: u64,
-        dblk_nelmts: u64,
+        sb: SuperBlockGeom,
     ) -> Result<u64, Error> {
         let existing = self.super_block_addr(file, sblk_j)?;
         if !is_undef(existing, file.offset_size()) {
@@ -823,8 +805,8 @@ impl Located {
         let ib_prefix = (4 + 1 + 1 + os) as u64;
         let ndblk_addrs = self.geom.direct_dblk_nelmts.len();
 
-        let bitmap = vec![0u8; sb_bitmap_size(ndblks, dblk_nelmts, self.page_nelmts)?];
-        let undef = vec![undef_addr(file.offset_size()); ndblks.to_usize()?];
+        let bitmap = vec![0u8; sb.bitmap_size().to_usize()?];
+        let undef = vec![undef_addr(file.offset_size()); sb.ndblks.to_usize()?];
         let aesb = crate::chunked_write::build_aesb(
             self.ea_addr,
             sb_block_offset,
@@ -976,17 +958,14 @@ impl Located {
         &self,
         file: &mut F,
         sblk_addr: u64,
-        ndblks: u64,
-        dblk_nelmts: u64,
-        page_nelmts: u64,
+        sb: SuperBlockGeom,
         blk_off: usize,
         at: u64,
         value: &[u8],
     ) -> Result<(), Error> {
         let os = file.offset_size() as usize;
         let prefix = (4 + 1 + 1 + os + blk_off) as u64;
-        let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)? as u64;
-        let cks_off = sblk_addr + prefix + bitmap + ndblks * os as u64;
+        let cks_off = sblk_addr + prefix + sb.bitmap_size() + sb.ndblks * os as u64;
         file.publish_checksummed(sblk_addr, cks_off, at, value)
     }
 
@@ -1299,32 +1278,17 @@ fn sb_page_bit<F: Store>(
     Ok((byte, v[0] | (0x80u8 >> (global_page % 8))))
 }
 
-/// Byte size of a super block's page-init bitmap (0 when its data blocks are not
-/// paged): `ndblks * ceil(npages / 8)`.
-fn sb_bitmap_size(ndblks: u64, dblk_nelmts: u64, page_nelmts: u64) -> Result<usize, Error> {
-    if dblk_nelmts > page_nelmts {
-        let npages = (dblk_nelmts / page_nelmts).to_usize()?;
-        Ok(ndblks.to_usize()? * npages.div_ceil(8))
-    } else {
-        Ok(0)
-    }
-}
-
 /// File offset of the `dblk_local`-th data-block-address slot inside a super
 /// block, accounting for the page-init bitmap when the block is paged.
-#[allow(clippy::too_many_arguments)]
 fn sb_dblk_slot_off(
     os: usize,
     sblk_addr: u64,
     dblk_local: usize,
-    ndblks: u64,
-    dblk_nelmts: u64,
-    page_nelmts: u64,
+    sb: SuperBlockGeom,
     blk_off: usize,
-) -> Result<u64, Error> {
+) -> u64 {
     let prefix = (4 + 1 + 1 + os + blk_off) as u64;
-    let bitmap = sb_bitmap_size(ndblks, dblk_nelmts, page_nelmts)? as u64;
-    Ok(sblk_addr + prefix + bitmap + (dblk_local * os) as u64)
+    sblk_addr + prefix + sb.bitmap_size() + (dblk_local * os) as u64
 }
 
 // ---------------------------------------------------------------------------
@@ -1345,6 +1309,30 @@ struct DataBlockLoc {
     ndblks: u64,
     sb_block_offset: u64,
     parent: Parent,
+}
+
+impl DataBlockLoc {
+    /// The shape of the super block this data block belongs to, in an array
+    /// whose pages hold `page_nelmts` elements.
+    ///
+    /// Meaningful for a [`Parent::Super`] block; for a [`Parent::IndexDirect`]
+    /// one the counts describe the single block itself and no `EASB` exists to
+    /// apply them to.
+    fn super_block(&self, page_nelmts: u64) -> SuperBlockGeom {
+        SuperBlockGeom {
+            ndblks: self.ndblks,
+            blocks: self.blocks(page_nelmts),
+        }
+    }
+
+    /// How this data block is paged, which holds whether or not it has a super
+    /// block above it.
+    fn blocks(&self, page_nelmts: u64) -> DataBlockGeom {
+        DataBlockGeom {
+            dblk_nelmts: self.dblk_nelmts,
+            page_nelmts,
+        }
+    }
 }
 
 /// Locate the data block containing element `e` (which is `>= idx_blk_elmts`).

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -16,7 +16,7 @@ use core::num::NonZeroUsize;
 use crate::chunk_grid::{ChunkGrid, GridOrder};
 use crate::convert::{TryToUsize, nonzero_usize_from};
 use crate::error::FormatError;
-use crate::extensible_array::{EaGeometry, ExtensibleArrayHeader};
+use crate::extensible_array::{DataBlockGeom, EaGeometry, ExtensibleArrayHeader, SuperBlockGeom};
 use crate::fill_value::FillPattern;
 #[cfg(feature = "zfp")]
 use crate::filter_pipeline::FILTER_ZFP;
@@ -1668,7 +1668,13 @@ pub(crate) fn build_eadb(
     write_ea_addr(&mut buf, ea_address, offset_size);
     buf.extend_from_slice(&block_offset_rel.to_le_bytes()[..blk_off_size]);
 
-    if dblk_nelmts <= page_nelmts {
+    // The paging boundary has one definition; the counts here are already
+    // `usize` loop bounds, so the page arithmetic below stays in that width.
+    let blocks = DataBlockGeom {
+        dblk_nelmts: dblk_nelmts as u64,
+        page_nelmts: page_nelmts as u64,
+    };
+    if !blocks.is_paged() {
         // Non-paged: elements inline, single checksum.
         for slot in 0..dblk_nelmts {
             if let Some(chunk) = slots.at(elem_start + slot) {
@@ -1783,53 +1789,30 @@ pub(crate) struct EaStats {
 /// On-disk byte size of one non-paged Extensible Array data block (`EADB`)
 /// holding `dblk_nelmts` element slots.
 pub(crate) fn eadb_size(
-    dblk_nelmts: u64,
+    blocks: DataBlockGeom,
     elem_size: usize,
-    page_nelmts: u64,
     offset_size: u8,
     blk_off_size: usize,
 ) -> u64 {
-    let prefix = 4 + 1 + 1 + offset_size as usize + blk_off_size;
-    if dblk_nelmts <= page_nelmts {
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "data block element count derived from the in-memory write request; bounded by addressable memory"
-        )]
-        let nelmts = dblk_nelmts as usize;
-        (prefix + nelmts * elem_size + 4) as u64
+    let prefix = (4 + 1 + 1 + offset_size as u64) + blk_off_size as u64;
+    if blocks.is_paged() {
+        // Paged: the header carries its own checksum, then full pages follow.
+        prefix + 4 + blocks.npages() * (blocks.page_nelmts * elem_size as u64 + 4)
     } else {
-        // Paged: header carries its own checksum, then full pages follow.
-        let npages = dblk_nelmts / page_nelmts;
-        (prefix + 4) as u64 + npages * (page_nelmts * elem_size as u64 + 4)
+        prefix + blocks.dblk_nelmts * elem_size as u64 + 4
     }
 }
 
-/// On-disk byte size of one Extensible Array super block (`EASB`) with `ndblks`
-/// data-block pointers and (when its data blocks are paged) a page-init bitmap.
-pub(crate) fn aesb_size(
-    ndblks: u64,
-    dblk_nelmts: u64,
-    page_nelmts: u64,
-    offset_size: u8,
-    blk_off_size: usize,
-) -> u64 {
-    let os = offset_size as usize;
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "data block and page counts derived from the in-memory write request; bounded by addressable memory"
-    )]
-    let bitmap = if dblk_nelmts > page_nelmts {
-        let npages = dblk_nelmts / page_nelmts;
-        ndblks as usize * npages.div_ceil(8) as usize
-    } else {
-        0
-    };
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "data block count derived from the in-memory write request; bounded by addressable memory"
-    )]
-    let ndblks_usize = ndblks as usize;
-    (4 + 1 + 1 + os + blk_off_size + bitmap + ndblks_usize * os + 4) as u64
+/// On-disk byte size of one Extensible Array super block (`EASB`): its header,
+/// the page-init bitmap when its data blocks are paged, its data-block
+/// addresses, and its checksum.
+///
+/// Computed in `u64` throughout, so the block and page counts are never narrowed
+/// to a 32-bit `usize` before being multiplied.
+pub(crate) fn aesb_size(geom: SuperBlockGeom, offset_size: u8, blk_off_size: usize) -> u64 {
+    let os = offset_size as u64;
+    let header = 4 + 1 + 1 + os + blk_off_size as u64;
+    header + geom.bitmap_size() + geom.ndblks * os + 4
 }
 
 /// Compute the six Extensible Array header statistics for an array holding
@@ -1861,24 +1844,28 @@ pub(crate) fn ea_compute_stats(
     let mut elem = idx_blk_elmts;
     for &dn in &geom.direct_dblk_nelmts {
         if occupancy.any_occupied(elem, dn) {
+            let blocks = DataBlockGeom {
+                dblk_nelmts: dn,
+                page_nelmts,
+            };
             s.ndata_blks += 1;
-            s.data_blk_size += eadb_size(dn, elem_size, page_nelmts, offset_size, blk_off_size);
+            s.data_blk_size += eadb_size(blocks, elem_size, offset_size, blk_off_size);
             s.nelmts += dn;
         }
         elem += dn;
     }
     for j in 0..geom.nsblk_addrs {
-        let (ndblks, dn) = geom.sblks[geom.first_indirect_sblk + j];
+        let sb = geom.super_block_at(j, page_nelmts);
+        let (ndblks, dn) = (sb.ndblks, sb.blocks.dblk_nelmts);
         let span = ndblks * dn;
         if occupancy.any_occupied(elem, span) {
             s.nsuper_blks += 1;
-            s.super_blk_size += aesb_size(ndblks, dn, page_nelmts, offset_size, blk_off_size);
+            s.super_blk_size += aesb_size(sb, offset_size, blk_off_size);
             let mut le = elem;
             for _ in 0..ndblks {
                 if occupancy.any_occupied(le, dn) {
                     s.ndata_blks += 1;
-                    s.data_blk_size +=
-                        eadb_size(dn, elem_size, page_nelmts, offset_size, blk_off_size);
+                    s.data_blk_size += eadb_size(sb.blocks, elem_size, offset_size, blk_off_size);
                     s.nelmts += dn;
                 }
                 le += dn;
@@ -2174,19 +2161,11 @@ pub fn build_extensible_array_at(
 
         // Past the early-out this super block holds real data, so its block
         // counts are bounded by the (usize) chunk count and narrow safely.
-        let is_paged = dblk_nelmts > page_nelmts as u64;
-        let npages = if is_paged {
-            dblk_nelmts / page_nelmts as u64
-        } else {
-            0
-        };
+        let sb = geom.super_block_at(j, page_nelmts as u64);
+        let is_paged = sb.blocks.is_paged();
+        let npages = sb.blocks.npages();
         let sb_block_offset = elem_cursor - inline as u64;
-        let bitmap_size = if is_paged {
-            (ndblks * npages.div_ceil(8)).to_usize()?
-        } else {
-            0
-        };
-        let mut page_bitmap = vec![0u8; bitmap_size];
+        let mut page_bitmap = vec![0u8; sb.bitmap_size().to_usize()?];
 
         let mut sb_dblk_addrs: Vec<u64> = Vec::with_capacity(ndblks.to_usize()?);
         let mut local_elem = elem_cursor;

--- a/src/extensible_array.rs
+++ b/src/extensible_array.rs
@@ -185,6 +185,24 @@ pub(crate) struct EaGeometry {
 }
 
 impl EaGeometry {
+    /// The shape of the super block reached by the `j`-th super-block pointer in
+    /// the index block, in an array whose pages hold `page_nelmts` elements.
+    ///
+    /// `j` indexes the *pointers*, not [`sblks`](Self::sblks): the first
+    /// `first_indirect_sblk` super blocks are stored directly in the index block
+    /// and have no pointer, which is the offset every caller was applying by
+    /// hand before this existed.
+    pub(crate) fn super_block_at(&self, j: usize, page_nelmts: u64) -> SuperBlockGeom {
+        let (ndblks, dblk_nelmts) = self.sblks[self.first_indirect_sblk + j];
+        SuperBlockGeom {
+            ndblks,
+            blocks: DataBlockGeom {
+                dblk_nelmts,
+                page_nelmts,
+            },
+        }
+    }
+
     /// Derive the geometry from a parsed header.
     pub fn from_header(h: &ExtensibleArrayHeader) -> Self {
         let min_dblk = h.min_dblk_nelmts as u64;
@@ -230,6 +248,75 @@ impl EaGeometry {
             nsblk_addrs,
             first_indirect_sblk: sup_blk_min,
         }
+    }
+}
+
+/// How one Extensible Array data block is paged: the elements it holds, against
+/// the elements that fill one page.
+///
+/// A data block holding more than one page's worth of elements is stored as a
+/// sequence of individually-checksummed pages. A block holding *exactly* one
+/// page's worth is not paged — the boundary is strictly greater, matching
+/// libhdf5's `H5EA__dblock_alloc`.
+///
+/// Separate from [`SuperBlockGeom`] because that is the whole dependency: a
+/// direct data block, whose address sits in the index block and which has no
+/// super block at all, is paged by the same rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DataBlockGeom {
+    /// Elements the data block holds.
+    pub(crate) dblk_nelmts: u64,
+    /// Elements that fill one page.
+    pub(crate) page_nelmts: u64,
+}
+
+impl DataBlockGeom {
+    /// Whether the block is stored as pages.
+    pub(crate) const fn is_paged(self) -> bool {
+        self.dblk_nelmts > self.page_nelmts
+    }
+
+    /// Pages in the block, or zero when it is not paged.
+    pub(crate) const fn npages(self) -> u64 {
+        if self.is_paged() {
+            self.dblk_nelmts / self.page_nelmts
+        } else {
+            0
+        }
+    }
+}
+
+/// The shape of one Extensible Array super block (`EASB`): the data blocks it
+/// points at, and how those blocks are paged.
+///
+/// A super block whose data blocks are paged carries a page-init bitmap between
+/// its header and its data-block addresses; one whose blocks are not carries no
+/// bitmap at all. [`DataBlockGeom::is_paged`] therefore decides the *position* of
+/// every data-block address in the block rather than merely a size, and every
+/// reader of an `EASB` has to agree with every writer about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SuperBlockGeom {
+    /// Data-block pointers the super block holds.
+    pub(crate) ndblks: u64,
+    /// How each of those data blocks is paged.
+    pub(crate) blocks: DataBlockGeom,
+}
+
+impl SuperBlockGeom {
+    /// Byte size of the page-init bitmap, zero when the data blocks are not
+    /// paged.
+    ///
+    /// One bit per page per data block. The bits are a contiguous stream indexed
+    /// by `dblk_local * npages + page`; the per-block round-up to a whole byte is
+    /// over-allocation rather than alignment, so block *k*'s bits do not in
+    /// general start at byte `k * ceil(npages / 8)`.
+    ///
+    /// Computed in `u64`, and narrowed by whichever caller needs a `usize`,
+    /// rather than narrowing the operands first. The product cannot overflow
+    /// where this is called: `bitmap_size <= ndblks * dblk_nelmts`, and every
+    /// caller has already computed that product or the enclosing block's length.
+    pub(crate) const fn bitmap_size(self) -> u64 {
+        self.ndblks * self.blocks.npages().div_ceil(8)
     }
 }
 
@@ -712,22 +799,16 @@ fn read_super_block(
     // addresses. Its size is `ndblks * ceil(npages / 8)` bytes, and it is a
     // contiguous bit stream indexed by `db_local_idx * npages + page`.
     let page_nelmts = 1usize << header.max_dblk_nelmts_bits;
-    let is_paged = nelmts_per_dblk > page_nelmts;
-    let npages = if is_paged {
-        nelmts_per_dblk / page_nelmts
-    } else {
-        0
+    let sb = SuperBlockGeom {
+        ndblks: ndblks as u64,
+        blocks: DataBlockGeom {
+            dblk_nelmts: nelmts_per_dblk as u64,
+            page_nelmts: page_nelmts as u64,
+        },
     };
-    let bitmap_size = if is_paged {
-        ndblks
-            .checked_mul(npages.div_ceil(8))
-            .ok_or(FormatError::OffsetOverflow {
-                offset: ndblks as u64,
-                length: npages.div_ceil(8) as u64,
-            })?
-    } else {
-        0
-    };
+    let is_paged = sb.blocks.is_paged();
+    let npages = sb.blocks.npages().to_usize()?;
+    let bitmap_size = sb.bitmap_size().to_usize()?;
 
     // The whole super block -- header, bitmap, every data-block pointer, and
     // the checksum over them -- is fixed by the geometry, so it is bounded
@@ -895,9 +976,11 @@ pub(crate) fn extensible_array_index_spans<S: Source + ?Sized>(
         spans.push((
             addr,
             eadb_size(
-                dblk_nelmts,
+                DataBlockGeom {
+                    dblk_nelmts,
+                    page_nelmts,
+                },
                 elem_size,
-                page_nelmts,
                 offset_size,
                 blk_off_size,
             ),
@@ -909,17 +992,12 @@ pub(crate) fn extensible_array_index_spans<S: Source + ?Sized>(
         if is_undefined_addr(addr, offset_size) {
             continue;
         }
-        let (ndblks, dblk_nelmts) = geom.sblks[geom.first_indirect_sblk + j];
-        spans.push((
-            addr,
-            aesb_size(ndblks, dblk_nelmts, page_nelmts, offset_size, blk_off_size),
-        ));
+        let sb = geom.super_block_at(j, page_nelmts);
+        spans.push((addr, aesb_size(sb, offset_size, blk_off_size)));
         easb_data_block_spans(
             source,
             addr,
-            ndblks,
-            dblk_nelmts,
-            page_nelmts,
+            sb,
             offset_size,
             blk_off_size,
             elem_size,
@@ -935,13 +1013,10 @@ pub(crate) fn extensible_array_index_spans<S: Source + ?Sized>(
 /// reading (header, optional page-init bitmap, then `ndblks` data-block
 /// addresses), emitting an extent for each defined address.
 #[cfg(feature = "std")]
-#[allow(clippy::too_many_arguments)]
 fn easb_data_block_spans<S: Source + ?Sized>(
     source: &S,
     sb_addr: u64,
-    ndblks: u64,
-    dblk_nelmts: u64,
-    page_nelmts: u64,
+    sb: SuperBlockGeom,
     offset_size: u8,
     blk_off_size: usize,
     elem_size: usize,
@@ -954,46 +1029,27 @@ fn easb_data_block_spans<S: Source + ?Sized>(
     // The whole super block in one read: its checksum covers all of it, and the
     // addresses read out of it become free space, so one that fails is refused
     // rather than reclaimed from.
-    let sb_len =
-        aesb_size(ndblks, dblk_nelmts, page_nelmts, offset_size, blk_off_size).to_usize()?;
-    let sb = source.read_metadata_at(sb_addr, sb_len)?;
-    if &sb[..4] != b"EASB" {
+    let sb_len = aesb_size(sb, offset_size, blk_off_size).to_usize()?;
+    let block = source.read_metadata_at(sb_addr, sb_len)?;
+    if &block[..4] != b"EASB" {
         return Err(FormatError::ChunkedReadError(
             "invalid Extensible Array super block signature".into(),
         ));
     }
-    crate::checksum::verify_trailing(&sb)?;
+    crate::checksum::verify_trailing(&block)?;
 
-    // When the super block's data blocks are paged, a page-init bitmap of
-    // `ndblks * ceil(npages / 8)` bytes precedes the data-block addresses.
-    let bitmap_size = if dblk_nelmts > page_nelmts {
-        let npages = (dblk_nelmts / page_nelmts).to_usize()?;
-        ndblks
-            .to_usize()?
-            .checked_mul(npages.div_ceil(8))
-            .ok_or(FormatError::OffsetOverflow {
-                offset: ndblks,
-                length: npages as u64,
-            })?
-    } else {
-        0
-    };
-    let mut pos = sb_header + bitmap_size;
-    for _ in 0..ndblks {
-        let addr = read_offset(&sb, pos, offset_size)?;
+    // A paged super block carries its page-init bitmap between the header and
+    // the data-block addresses; `bitmap_size` is zero when it does not.
+    let mut pos = sb_header + sb.bitmap_size().to_usize()?;
+    for _ in 0..sb.ndblks {
+        let addr = read_offset(&block, pos, offset_size)?;
         pos += os;
         if is_undefined_addr(addr, offset_size) {
             continue;
         }
         spans.push((
             addr,
-            eadb_size(
-                dblk_nelmts,
-                elem_size,
-                page_nelmts,
-                offset_size,
-                blk_off_size,
-            ),
+            eadb_size(sb.blocks, elem_size, offset_size, blk_off_size),
         ));
     }
     Ok(())
@@ -1310,22 +1366,16 @@ fn read_super_block_from_source<S: Source + ?Sized>(
     let sb_header_size = 4 + 1 + 1 + os + blk_off_size;
 
     let page_nelmts = 1usize << header.max_dblk_nelmts_bits;
-    let is_paged = nelmts_per_dblk > page_nelmts;
-    let npages = if is_paged {
-        nelmts_per_dblk / page_nelmts
-    } else {
-        0
+    let sb = SuperBlockGeom {
+        ndblks: ndblks as u64,
+        blocks: DataBlockGeom {
+            dblk_nelmts: nelmts_per_dblk as u64,
+            page_nelmts: page_nelmts as u64,
+        },
     };
-    let bitmap_size = if is_paged {
-        ndblks
-            .checked_mul(npages.div_ceil(8))
-            .ok_or(FormatError::OffsetOverflow {
-                offset: ndblks as u64,
-                length: npages.div_ceil(8) as u64,
-            })?
-    } else {
-        0
-    };
+    let is_paged = sb.blocks.is_paged();
+    let npages = sb.blocks.npages().to_usize()?;
+    let bitmap_size = sb.bitmap_size().to_usize()?;
 
     // Header + (optional) page-init bitmap + data-block addresses + checksum.
     let addr_bytes = ndblks.checked_mul(os).ok_or(FormatError::OffsetOverflow {
@@ -1399,6 +1449,48 @@ fn read_super_block_from_source<S: Source + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The paged/not-paged boundary, which decides whether an `EASB` carries a
+    /// page-init bitmap at all — so a reader and a writer that disagree by one
+    /// element disagree about the position of every data-block address after it.
+    ///
+    /// Strictly greater, not greater-or-equal: a data block holding exactly one
+    /// page's worth of elements is *not* paged, matching libhdf5's
+    /// `H5EA__dblock_alloc`.
+    #[test]
+    fn a_data_block_is_paged_only_past_a_full_page() {
+        let at = |dblk_nelmts| DataBlockGeom {
+            dblk_nelmts,
+            page_nelmts: 16,
+        };
+        assert!(!at(15).is_paged(), "under a page");
+        assert!(!at(16).is_paged(), "exactly a page is not paged");
+        assert!(at(17).is_paged(), "past a page");
+        assert_eq!(at(16).npages(), 0, "a block that is not paged has no pages");
+        assert_eq!(at(32).npages(), 2);
+    }
+
+    /// The bitmap is one bit per page per data block, each block's bits rounded
+    /// up to a whole byte — so eight pages fit one byte and nine need two.
+    #[test]
+    fn the_page_init_bitmap_is_a_byte_per_eight_pages_per_block() {
+        let sb = |ndblks, dblk_nelmts| SuperBlockGeom {
+            ndblks,
+            blocks: DataBlockGeom {
+                dblk_nelmts,
+                page_nelmts: 16,
+            },
+        };
+        // Not paged: no bitmap at all, which is what makes the boundary above
+        // decide a byte offset rather than merely a size.
+        assert_eq!(sb(4, 16).bitmap_size(), 0);
+        // 2 blocks x 8 pages each -> one byte per block.
+        assert_eq!(sb(2, 8 * 16).bitmap_size(), 2);
+        // 2 blocks x 9 pages each -> the round-up costs a second byte per block.
+        assert_eq!(sb(2, 9 * 16).bitmap_size(), 4);
+        // One block, two pages: a single byte, not two bits.
+        assert_eq!(sb(1, 2 * 16).bitmap_size(), 1);
+    }
 
     /// The grid of a dataset with no maximum shape: dense row-major, which is
     /// what these tests read. The numbering rule itself is tested in
@@ -1924,9 +2016,11 @@ mod tests {
                             eadb_extent(nelmts as usize, &header, offset_size, blk_off).unwrap()
                                 as u64,
                             crate::chunked_write::eadb_size(
-                                nelmts,
+                                DataBlockGeom {
+                                    dblk_nelmts: nelmts,
+                                    page_nelmts,
+                                },
                                 stride,
-                                page_nelmts,
                                 offset_size,
                                 blk_off,
                             ),


### PR DESCRIPTION
Closes #323.

An Extensible Array super block points at `ndblks` data blocks of `dblk_nelmts` elements each, against `page_nelmts` elements per page. The three are all `u64` counts and travelled as separate parameters, so they were mutually swappable — `publish_super_block` took four `u64`s in a row, which is the signature that prompted this issue.

Two types now carry them. `DataBlockGeom { dblk_nelmts, page_nelmts }` owns the paging rule; `SuperBlockGeom { ndblks, blocks }` owns the bitmap. The split matters: a *direct* data block, whose address sits in the index block and which has no super block at all, is paged by the same rule, so tying the rule to a super block would have been wrong.

### Deduplication

That grouping turned out to be worth more than the swap-proofing.

- The paging boundary (`dblk_nelmts > page_nelmts`) had **ten** hand-written copies across three modules, two of them written as the negation. It now has one definition.
- The page-init bitmap size had **six**, in four different overflow styles: three `checked_mul` in `usize`, one unchecked `as` cast then `usize` multiply, one checked narrowing then `usize` multiply, and one already in `u64`. It now has one, in `u64`.

The boundary decides whether a super block carries a page-init bitmap at all, and so the byte position of every data-block address after it — not merely a size. Ten chances for one copy to drift to `>=`.

`publish_super_block` goes from 9 parameters to 6. Two `#[expect(cast_possible_truncation)]` and two `#[allow(clippy::too_many_arguments)]` are gone.

### Behaviour

No change on a 64-bit target: the five old bitmap formulas and both `aesb_size` variants were swept over 138,240 geometries against the new methods, with no disagreement. On 32-bit it is a fix — `sb_bitmap_size` and `aesb_size` both narrowed their operands before multiplying, so a large geometry wrapped silently and produced a short bitmap with every data-block address written at the wrong offset.

Three sites dropped a `checked_mul` returning `OffsetOverflow` in favour of infallible `u64` arithmetic narrowed by the caller. All three are shadowed: each caller computes `ndblks * dblk_nelmts` (or the enclosing block length) one statement earlier, and `bitmap_size <= ndblks * dblk_nelmts`, so nothing that previously errored now succeeds.

The strict-`>` boundary is checked against libhdf5 `H5EA__dblock_alloc`, and the bitmap formula against `H5EAsblock.c`.

### Testing

Mutating the boundary to `>=` fails `pure_writes_c_reads`, `c_writes_pure_reads`, `eahd_stats_match_c`, `eadb_extent_matches_the_writer`, and the two new unit tests. Mutating the bitmap rounding fails seven.

Worth noting for whoever touches this next: unifying the predicate made the *roundtrip* tests blind to it. Before, the same mutation reddened `ea_roundtrip_paged_data_blocks` and friends; now writer and reader share the definition and are wrong together, so a roundtrip still passes. What pins it is the C crosschecks and the two unit tests, which state the rule absolutely — that is why they are there rather than relying on the existing coverage.

`cargo nextest run --all-features` 2494/2494 · clippy `--all-targets --all-features` · rustdoc `-D warnings`. Internal types only; no public API change and no version bump.