### PR TITLE
Pin that MemoryStrategy::Auto mirrors only what Bounded refuses (#389)

### DIFF
--- a/docs/guide/editing.md
+++ b/docs/guide/editing.md
@@ -11,7 +11,7 @@
 
 ## Choosing a write path
 
-`File::open_rw` is the read-write open, and it picks how to hold the file's bytes from the file itself rather than making you pick a function. A latest-format file with no userblock is edited **bounded**: no whole-file copy is ever built, so memory stays at the [configured caches](streaming.md) plus whatever an edit is building. Anything else — a pre-v2 superblock, or a userblock — falls back to a whole-file **mirror**, `O(file size)`, which is what makes such a file editable at all. Either backing mutates the file the same way: new bytes are appended and a small, fixed set of locations is patched, never a rewrite on commit; see [write paths](../about/architecture.md#write-paths) for the mechanics.
+`File::open_rw` is the read-write open, and it picks how to hold the file's bytes from the file itself rather than making you pick a function. A latest-format file with no userblock is edited **bounded**: no whole-file copy is ever built, so memory stays at the [configured caches](streaming.md) plus whatever an edit is building. Anything else — a pre-v2 superblock, or a userblock — falls back to a whole-file **mirror**, `O(file size)`, which is what makes such a file editable at all. Those two are the whole fallback set: neither the file's size nor its [file-space strategy](file-space.md) enters into it, so a persisting `FsmAggr` file of any size is edited bounded. Either backing mutates the file the same way: new bytes are appended and a small, fixed set of locations is patched, never a rewrite on commit; see [write paths](../about/architecture.md#write-paths) for the mechanics.
 
 Ask a file which backing it got with `File::edit_backing()`, and demand one with `FileAccessProperties::with_memory_strategy`:
 
@@ -288,6 +288,8 @@ file.close().unwrap();
 ```
 
 Bounded editing **does** grow a file that persists its free space — including a genuine paged file (`H5F_FSPACE_STRATEGY_PAGE`) — seeding the on-disk free-space managers on open and rewriting them at `File::close`, with paged appends kept page-homogeneous (raw and metadata in separate pages). See [File-Space Strategy](file-space.md) for the paged details. Memory budgets are set with the same `FileAccessProperties` as the streaming reader; cached metadata windows touched by an append are invalidated automatically, so reads through the same file never observe stale bytes.
+
+The metadata cache is **off** by default, which is why a bounded session's resident memory starts near zero rather than near the file's size. `FileAccessProperties::with_metadata_cache(MetadataCacheConfig::new(bytes))` turns it on to pin the metadata a long append loop keeps re-reading, against a byte budget you choose and that never scales with the file's length; `File::metadata_cache_stats` reports the hit rate and occupancy that say whether the budget was the right one.
 
 ## How it works
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1041,6 +1041,16 @@ pub enum MemoryStrategy {
     /// file it cannot edit, rather than refusing. Memory then scales with the
     /// file, which is the cost of the file opening at all. What
     /// [`File::open_rw`](crate::File::open_rw) uses when nothing is asked for.
+    ///
+    /// Two files reach that fallback, and no others: one with a pre-v2
+    /// (non-latest-format) superblock, and one with a userblock (a non-zero base
+    /// address). Every other file a read-write open accepts is edited bounded,
+    /// whatever its [`FileSpaceStrategy`](crate::FileSpaceStrategy), whether or
+    /// not it persists its free space, and however large it is. A paged file with
+    /// no persisted free space is refused by *both* backings rather than
+    /// mirrored, so it is not a third case. The list being exhaustive is what
+    /// makes "prefer bounded" a guarantee to budget against: wherever
+    /// [`Bounded`](Self::Bounded) opens a file, `Auto` gives the same backing.
     Auto,
     /// Always build the whole-file mirror, whatever the file looks like. What
     /// [`File::open_rw`](crate::File::open_rw) did before it learned to dispatch.

--- a/tests/allocation_bounds.rs
+++ b/tests/allocation_bounds.rs
@@ -20,7 +20,10 @@
 //! else. That last part is also how a test here could go quiet, which is why each
 //! one asserts a floor as well as a ceiling — see [`allocation::Measured`].
 
-use hdf5_pure::{File, FileBuilder};
+use hdf5_pure::{
+    EditBacking, File, FileAccessProperties, FileBuilder, FileSpaceStrategy, MemoryStrategy,
+    SyncPolicy,
+};
 
 #[global_allocator]
 static ALLOC: heapscope::Alloc = heapscope::Alloc::system();
@@ -946,5 +949,114 @@ fn a_write_larger_than_the_gather_budget_is_not_copied_into_it() {
         measured.bytes < DATASET_BYTES * 3 / 2,
         "a staged commit must not copy its data into the gather buffer as well: \
          measured {measured} against a {DATASET_BYTES}-byte dataset"
+    );
+}
+
+/// A bounded read-write open holds a metadata-sized amount of the file, not a
+/// copy of it — and the mirror beside it is what makes that a measurement rather
+/// than a hope (issue #389).
+///
+/// This is the rule behind `MemoryStrategy::Auto` preferring the bounded engine:
+/// the choice is only worth making if the two backings really differ by the size
+/// of the file. The contrast is measured on the same file through the same
+/// appends, so nothing but the strategy separates the two figures.
+#[test]
+fn open_rw_of_a_persisting_fsm_file_does_not_allocate_the_file() {
+    // 16 MiB in 32 KiB chunks, persisting its free-space managers under the
+    // default FsmAggr strategy: the ordinary growing file of issue #389.
+    const CHUNK_ELEMS: usize = 4096;
+    const CHUNKS: usize = 512;
+    const APPENDS: usize = 4;
+    const BATCH_BYTES: u64 = (CHUNK_ELEMS * 8) as u64;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fsm.h5");
+    let data: Vec<u64> = (0..(CHUNK_ELEMS * CHUNKS) as u64).collect();
+    let mut builder = FileBuilder::new();
+    builder.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 0);
+    builder
+        .create_dataset("samples")
+        .with_u64_data(&data)
+        .with_shape(&[data.len() as u64])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[CHUNK_ELEMS as u64]);
+    builder.write(&path).unwrap();
+    drop(data);
+
+    let file_len = std::fs::metadata(&path).unwrap().len();
+    let batch: Vec<u64> = (0..CHUNK_ELEMS as u64).collect();
+
+    // One barrier at close rather than one per append; this test measures
+    // allocations, not `fsync` cadence.
+    let access = |strategy| {
+        FileAccessProperties::new()
+            .with_sync_policy(SyncPolicy::OnClose)
+            .with_memory_strategy(strategy)
+    };
+
+    let open_and_append = |name: &'static str, strategy| {
+        let (file, measured) = measure(name, || {
+            let file = File::open_rw_with_options(&path, access(strategy)).unwrap();
+            let mut ds = file.dataset("samples").unwrap();
+            for _ in 0..APPENDS {
+                ds.append(&batch).unwrap();
+            }
+            drop(ds);
+            file
+        });
+        let backing = file.edit_backing();
+        file.close().unwrap();
+        (backing, measured)
+    };
+
+    let (backing, bounded) =
+        open_and_append("bounded_open_rw_of_a_large_file", MemoryStrategy::Auto);
+    assert_eq!(
+        backing,
+        Some(EditBacking::Bounded),
+        "Auto must reach the bounded engine on this file, or the bounds below are \
+         measuring the mirror"
+    );
+
+    // The appended batches are staged inside this measurement, so their bytes are
+    // a floor a measurement of nothing cannot reach — and the session itself is
+    // returned from the region, so its retained allocations are in `live_bytes`.
+    assert!(
+        bounded.bytes >= BATCH_BYTES * APPENDS as u64,
+        "the appended batches are not in this measurement, so the ceilings below \
+         are bounding something other than the session: {bounded}"
+    );
+    assert!(
+        bounded.blocks > 0,
+        "no allocation was recorded for the open at all, so this region saw none \
+         of the work it names: {bounded}"
+    );
+
+    // What a bounded session keeps is the metadata it is holding plus whatever an
+    // append is building — a figure with no term in the file's length. Measured
+    // at 3.9 KiB live and 101 KiB at peak against a 16 MiB file, where the mirror
+    // below holds 32 MiB live, so a sixteenth of the file is orders above the one
+    // and orders below the other.
+    assert!(
+        bounded.live_bytes < file_len / 16,
+        "a bounded session must not retain a copy of the {file_len}-byte file: \
+         {bounded}"
+    );
+    assert!(
+        bounded.peak_bytes < file_len / 8,
+        "a bounded session must not build a copy of the {file_len}-byte file even \
+         transiently: {bounded}"
+    );
+
+    // The contrast that makes the ceilings above mean something: the same file,
+    // the same appends, one strategy apart.
+    let (backing, mirrored) =
+        open_and_append("mirrored_open_rw_of_a_large_file", MemoryStrategy::Mirrored);
+    assert_eq!(backing, Some(EditBacking::Mirrored));
+    assert!(
+        mirrored.live_bytes > file_len,
+        "the mirror is supposed to hold the whole {file_len}-byte file, so a \
+         measurement below that is not measuring the mirror and the bounded \
+         bounds above are not a contrast with anything: {mirrored}"
     );
 }

--- a/tests/memory_strategy.rs
+++ b/tests/memory_strategy.rs
@@ -8,10 +8,16 @@
 //! falls back, an explicit `Bounded` refuses, and either way the resulting `File`
 //! says which one it is, because "bounded" is a memory guarantee and a caller who
 //! was quietly given the mirror instead has no other way to notice.
+//!
+//! The other half is that the fallback set stays *small*, since every file added
+//! to it is a caller who silently pays `O(file size)` for a file the bounded
+//! engine could have edited (issue #389). The matrix at the end of this file
+//! pins it as a biconditional over the creation properties rather than as a list
+//! of examples: `Auto` mirrors a file if and only if `Bounded` refuses it.
 
 use hdf5_pure::{
     EditBacking, File, FileAccessProperties, FileBuilder, FileCreateProperties, FileSpaceStrategy,
-    MemoryStrategy,
+    LibVer, MemoryStrategy, SyncPolicy,
 };
 
 fn with_strategy(strategy: MemoryStrategy) -> FileAccessProperties {
@@ -402,4 +408,296 @@ fn create_refuses_a_pair_it_could_not_reopen_before_writing_anything() {
     )
     .unwrap();
     assert_eq!(file.edit_backing(), Some(EditBacking::Mirrored));
+}
+
+/// A file that persists its free-space managers under the default `FsmAggr`
+/// strategy — an ordinary growing file, and the one issue #389 reported as
+/// mirrored. Nothing about it is bounded-ineligible: version 3 superblock, no
+/// userblock.
+fn fsm_persisting_file(path: &std::path::Path) {
+    let mut b = FileBuilder::new();
+    b.with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 0);
+    b.create_dataset("samples")
+        .with_u64_data(&[0, 1, 2, 3])
+        .with_shape(&[4])
+        .with_maxshape(&[u64::MAX])
+        .with_chunks(&[4]);
+    b.write(path).unwrap();
+}
+
+/// Persisting free space is not a bounded-only limitation, so `open_rw` must
+/// edit such a file through the bounded engine rather than the whole-file mirror
+/// (issue #389). The mirror is for a pre-v2 superblock or a userblock, and this
+/// file is neither.
+#[test]
+fn open_rw_edits_a_persisting_fsm_file_bounded() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fsm.h5");
+    fsm_persisting_file(&path);
+
+    let file = File::open_rw(&path).unwrap();
+    assert_eq!(
+        file.edit_backing(),
+        Some(EditBacking::Bounded),
+        "a persisting FsmAggr file is bounded-eligible; mirroring it would spend \
+         O(file size) memory on a file the bounded engine edits"
+    );
+
+    let mut ds = file.dataset("samples").unwrap();
+    ds.append(&[4u64, 5, 6, 7]).unwrap();
+    drop(ds);
+    // A staged edit as well as the immediate append, so the commit this session
+    // performs is a real one rather than an empty transaction.
+    file.root()
+        .create_dataset("second", |b| {
+            b.with_u64_data(&[10, 11]);
+        })
+        .unwrap();
+    file.commit().unwrap();
+    file.close().unwrap();
+
+    let reopened = File::open(&path).unwrap();
+    assert_eq!(
+        reopened.dataset("samples").unwrap().read_u64().unwrap(),
+        vec![0, 1, 2, 3, 4, 5, 6, 7]
+    );
+    assert_eq!(
+        reopened.dataset("second").unwrap().read_u64().unwrap(),
+        vec![10, 11]
+    );
+    assert_eq!(
+        reopened.file_space_strategy(),
+        Some(FileSpaceStrategy::FsmAggr),
+        "the bounded session must leave the file's recorded strategy alone"
+    );
+}
+
+/// The reporter's exact call in issue #389: create a persisting `FsmAggr` file
+/// with a default access list, then append to an unlimited chunked dataset. The
+/// backing is decided once at open and does not drift as the file grows, so the
+/// second assertion is the one that pins "RSS tracks file length" as impossible
+/// rather than merely unmeasured.
+#[test]
+fn create_with_options_of_a_persisting_fsm_file_opens_bounded() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("created.h5");
+
+    let file = File::create_with_options(
+        &path,
+        FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 0),
+        FileAccessProperties::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        file.edit_backing(),
+        Some(EditBacking::Bounded),
+        "a default access list means MemoryStrategy::Auto, which must prefer the \
+         bounded engine on a file it can edit"
+    );
+
+    file.root()
+        .create_dataset("samples", |b| {
+            b.with_u64_data(&[0u64; 256])
+                .with_shape(&[256])
+                .with_maxshape(&[u64::MAX])
+                .with_chunks(&[256]);
+        })
+        .unwrap();
+    file.commit().unwrap();
+
+    let batch: Vec<u64> = (0..256).collect();
+    let mut ds = file.dataset("samples").unwrap();
+    for _ in 0..64 {
+        ds.append(&batch).unwrap();
+    }
+    drop(ds);
+
+    assert_eq!(
+        file.edit_backing(),
+        Some(EditBacking::Bounded),
+        "the backing is fixed at open, so a file grown by appends stays bounded"
+    );
+    file.close().unwrap();
+
+    let reopened = File::open(&path).unwrap();
+    assert_eq!(
+        reopened
+            .dataset("samples")
+            .unwrap()
+            .read_u64()
+            .unwrap()
+            .len(),
+        256 + 64 * 256
+    );
+}
+
+/// The invariant behind `Auto`, stated over the property space rather than over
+/// one file: `Auto` mirrors only where `Bounded` refuses.
+///
+/// One direction alone would not pin it. "Bounded succeeds implies Auto is
+/// bounded" is satisfied by an engine that never mirrors anything, and "Auto
+/// mirrored implies Bounded refuses" by one that always mirrors; together they
+/// say the fallback set is exactly the bounded-ineligible set, which is what
+/// makes the fallback list in `MemoryStrategy::Auto`'s documentation exhaustive
+/// rather than illustrative.
+#[test]
+fn auto_matches_bounded_on_every_pair_bounded_accepts() {
+    let fcpls = [
+        ("default", FileCreateProperties::new()),
+        (
+            "fsm_aggr-persisting",
+            FileCreateProperties::new().with_file_space_strategy(
+                FileSpaceStrategy::FsmAggr,
+                true,
+                0,
+            ),
+        ),
+        (
+            "fsm_aggr-transient",
+            FileCreateProperties::new().with_file_space_strategy(
+                FileSpaceStrategy::FsmAggr,
+                false,
+                0,
+            ),
+        ),
+        (
+            "aggr-persisting",
+            FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::Aggr, true, 0),
+        ),
+        (
+            "aggr-transient",
+            FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::Aggr, false, 0),
+        ),
+        (
+            "none-persisting",
+            FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::None, true, 0),
+        ),
+        (
+            "none-transient",
+            FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::None, false, 0),
+        ),
+        (
+            "page-persisting",
+            FileCreateProperties::new()
+                .with_file_space_strategy(FileSpaceStrategy::Page, true, 0)
+                .with_file_space_page_size(4096),
+        ),
+        (
+            "page-transient",
+            FileCreateProperties::new()
+                .with_file_space_strategy(FileSpaceStrategy::Page, false, 0)
+                .with_file_space_page_size(4096),
+        ),
+        ("userblock", FileCreateProperties::new().with_userblock(512)),
+        (
+            "libver-1.8",
+            FileCreateProperties::new().with_libver_bounds(LibVer::Earliest, LibVer::V18),
+        ),
+    ];
+
+    // One barrier per close rather than one per operation: this matrix creates
+    // and reopens two files per row, and measures none of it.
+    let access = |strategy| {
+        FileAccessProperties::new()
+            .with_sync_policy(SyncPolicy::OnClose)
+            .with_memory_strategy(strategy)
+    };
+    let backing_of = |file: File| -> Option<EditBacking> {
+        let backing = file.edit_backing();
+        file.close().unwrap();
+        backing
+    };
+
+    // A biconditional both of whose branches are unreachable holds vacuously, so
+    // the rows that took each one are counted and the counts are asserted below.
+    let (mut checked, mut mirrored) = (0, 0);
+
+    let dir = tempfile::tempdir().unwrap();
+    for (label, create) in fcpls {
+        let path = dir.path().join(format!("{label}.h5"));
+        let bounded_path = dir.path().join(format!("{label}-bounded.h5"));
+
+        // A pair no strategy can create says nothing about the fallback, and is
+        // pinned by `create_refuses_a_pair_it_could_not_reopen_before_writing_anything`.
+        let Ok(auto) =
+            File::create_with_options(&path, create, access(MemoryStrategy::Auto)).map(backing_of)
+        else {
+            continue;
+        };
+        let bounded =
+            File::create_with_options(&bounded_path, create, access(MemoryStrategy::Bounded))
+                .map(backing_of);
+        assert_matches_bounded(label, "create_with_options", auto, &bounded);
+
+        // Create and open share one dispatch, and this is what says so: the same
+        // file, reopened, resolves the same way.
+        let auto_reopened = File::open_rw_with_options(&path, access(MemoryStrategy::Auto))
+            .map(backing_of)
+            .unwrap_or_else(|e| panic!("{label}: Auto created this file and must reopen it: {e}"));
+        assert_eq!(
+            auto_reopened, auto,
+            "{label}: reopening must resolve to the backing the create resolved to"
+        );
+        let bounded_reopened =
+            File::open_rw_with_options(&path, access(MemoryStrategy::Bounded)).map(backing_of);
+        assert_matches_bounded(
+            label,
+            "open_rw_with_options",
+            auto_reopened,
+            &bounded_reopened,
+        );
+
+        checked += 1;
+        mirrored += usize::from(auto == Some(EditBacking::Mirrored));
+    }
+
+    assert_eq!(
+        mirrored, 1,
+        "the userblock is the only creatable property here the bounded engine \
+         refuses; another row reaching the mirror is a fallback set that grew"
+    );
+    assert!(
+        checked >= 9,
+        "only {checked} of the property rows were creatable at all, so this \
+         matrix is no longer covering the space it names"
+    );
+}
+
+/// The biconditional shared by both halves of the matrix above: `Auto` is
+/// bounded wherever `Bounded` is accepted, and mirrors only where it is refused.
+#[track_caller]
+fn assert_matches_bounded(
+    label: &str,
+    entry_point: &str,
+    auto: Option<EditBacking>,
+    bounded: &Result<Option<EditBacking>, hdf5_pure::Error>,
+) {
+    match bounded {
+        Ok(backing) => {
+            assert_eq!(
+                *backing,
+                Some(EditBacking::Bounded),
+                "{label}: an explicit Bounded that opens must report the bounded backing"
+            );
+            assert_eq!(
+                auto,
+                Some(EditBacking::Bounded),
+                "{label}: {entry_point} under Auto mirrored a file Bounded edits, which \
+                 is the O(file size) memory tax of issue #389"
+            );
+        }
+        Err(e) => {
+            assert_eq!(
+                auto,
+                Some(EditBacking::Mirrored),
+                "{label}: {entry_point} under Bounded refused ({e}), so Auto's only way \
+                 to open this file is the mirror"
+            );
+            assert!(
+                matches!(e, hdf5_pure::Error::EditUnsupported(_)),
+                "{label}: a bounded-only limitation must be reported as EditUnsupported, \
+                 got: {e:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
The reported behaviour did not reproduce. On `main` (macOS, release), the issue's exact call — `File::create_with_options` with `FileCreateProperties::new().with_file_space_strategy(FileSpaceStrategy::FsmAggr, true, 0)` and a default `FileAccessProperties` — resolves to the bounded engine, and resident memory does not track the file:

| scenario | `edit_backing()` | RSS | file grown to |
| --- | --- | --- | --- |
| `Auto` (default FAPL), unlimited chunked `u64` appends | `Some(Bounded)` | 6–7 MiB, flat | 128 MiB |
| same, 8192 × 8 KiB appends, filtered and unfiltered | `Some(Bounded)` | 6–7 MiB, flat | 128 MiB |
| same under `SyncPolicy::Always` | `Some(Bounded)` | 6–7 MiB, flat | 128 MiB |
| `MemoryStrategy::Mirrored` | `Some(Mirrored)` | 39 MiB | 32 MiB |

The only dispatch site is `WriteEngine::open_rw_with_strategy`, which opens bounded and falls back to the mirror solely when `bounded_only_limitation` fires — a superblock below version 2, or a non-zero base address (userblock). Create and open share that path, so no engine change was needed.

This PR pins the invariant instead, so a regression cannot land silently, and makes the documentation state the fallback set as exhaustive rather than illustrative.

- `MemoryStrategy::Auto`'s rustdoc now names the whole fallback set (pre-v2 superblock, userblock) and says that a paged file with no persisted free space is refused by both backings rather than being a third case.
- `docs/guide/editing.md`: the fallback set is the whole of it — size and file-space strategy do not enter into it — and the bounded section now says the metadata cache is off by default, with `FileAccessProperties::with_metadata_cache` / `MetadataCacheConfig` as the way to pin hot metadata against a budget independent of file length, measured with `File::metadata_cache_stats`.

No public API change, so no version bump and no changelog entry.

## Tests

`tests/memory_strategy.rs`:

- `open_rw_edits_a_persisting_fsm_file_bounded` — a persisting `FsmAggr` file opens `Bounded`, appends and commits, and round-trips with its recorded strategy intact.
- `create_with_options_of_a_persisting_fsm_file_opens_bounded` — the reported call with a default access list, still `Bounded` after 64 appends.
- `auto_matches_bounded_on_every_pair_bounded_accepts` — over eleven creation-property rows (`FsmAggr`/`Aggr`/`None`/`Page` × persist, userblock, libver 1.8): `Bounded` opens ⇒ `Auto` is bounded, and `Auto` mirrors ⇒ `Bounded` errors with `EditUnsupported`, through both `create_with_options` and `open_rw_with_options`. Counters assert that exactly one row (the userblock) reaches the mirror, so neither branch can hold vacuously.

`tests/allocation_bounds.rs`:

- `open_rw_of_a_persisting_fsm_file_does_not_allocate_the_file` — a 16 MiB persisting `FsmAggr` file, measured with `heapscope`: bounded holds 3.9 KiB live and 101 KiB at peak (bounds: `file_len / 16` and `file_len / 8`), against 32 MiB live for `Mirrored` on the same file and the same appends.

All four pass unchanged against main's engine. Mutating `bounded_only_limitation` to refuse persisting files fails all four while every pre-existing test in both binaries still passes, which is the regression they exist to catch.

## Gates run

`cargo fmt --all --check`, `cargo clippy --features "serde ndarray" --all-targets -- -D warnings`, `cargo test --lib` (1024 passed), `cargo test --test memory_strategy --test allocation_bounds` (15 + 14 passed), `cargo test --doc` (38 passed), `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --features "provenance zfp ndarray serde"`.

Closes #389
