### PR TITLE
Re-record the allocation baseline after #398

### DIFF
--- a/tests/baselines/chunked_write_read.txt
+++ b/tests/baselines/chunked_write_read.txt
@@ -5,5 +5,5 @@ currBytes 0
 currBlocks 0
 maxBytes 33672401
 maxBlocks 2086
-totalBytes 43479200
+totalBytes 43479224
 totalBlocks 8968


### PR DESCRIPTION
PR #398 moved the aarch64 allocation baseline by 24 bytes (one small allocation in the paged free-space bookkeeping it added), which reddened the \`Allocation baseline (macOS aarch64)\` job on main. This re-records \`tests/baselines/chunked_write_read.txt\` per the Allocation gates section of CLAUDE.md.

Gates run: \`HEAPSCOPE_UPDATE_BASELINE=1 cargo test --features heap-baseline --test allocation_baseline\` on main at 2a8a48f, then the same test without the update flag.