### PR TITLE
Use unstable sorts where keys are unique (#404)

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1923,7 +1923,12 @@ impl PagedEdit {
     fn reusable_sections(&self) -> Vec<(u64, u64)> {
         let mut out = self.meta.sections();
         out.extend(self.raw.sections());
-        out.sort_by_key(|&(addr, _)| addr);
+        out.sort_unstable_by_key(|&(addr, _)| addr);
+        debug_assert!(
+            out.windows(2).all(|w| w[0].0 < w[1].0),
+            "the same address is free in both the metadata and the raw list, so \
+             the two page-type lists have stopped being disjoint"
+        );
         out
     }
 }
@@ -2899,7 +2904,12 @@ impl WriteEngine {
                     tagged.push((s, ty));
                 }
             }
-            tagged.sort_by_key(|(s, _)| s.addr);
+            // Distinct sections have distinct addresses in any well-formed file,
+            // so the tie-break never arises; only a malformed manager can
+            // advertise one address twice, and the overlap guard below already
+            // discards the second of any such pair. No `debug_assert` here: this
+            // parses untrusted bytes, which must not panic a debug build.
+            tagged.sort_unstable_by_key(|(s, _)| s.addr);
             let mut prev_end = 0u64;
             for (s, ty) in tagged {
                 let Some(end) = s.addr.checked_add(s.size) else {
@@ -2943,7 +2953,9 @@ impl WriteEngine {
         )
         .map(|(sections, _)| sections)
         {
-            sections.sort_by_key(|s| s.addr);
+            // Unique addresses in any well-formed file; see the paged branch
+            // above for why a duplicate is harmless and unasserted here.
+            sections.sort_unstable_by_key(|s| s.addr);
             let mut prev_end = 0u64;
             for s in sections {
                 let Some(end) = s.addr.checked_add(s.size) else {
@@ -3593,7 +3605,12 @@ impl WriteEngine {
                 }
                 let mut out = pg.meta.sections();
                 out.extend(raw.sections());
-                out.sort_by_key(|&(addr, _)| addr);
+                out.sort_unstable_by_key(|&(addr, _)| addr);
+                debug_assert!(
+                    out.windows(2).all(|w| w[0].0 < w[1].0),
+                    "the same address is free in both the metadata and the raw \
+                     list, so the two page-type lists have stopped being disjoint"
+                );
                 out
             }
             (None, false) => {
@@ -6005,6 +6022,10 @@ impl WriteEngine {
         // group's new address is known.
         let mut relocations: BTreeMap<u64, u64> = BTreeMap::new();
         let mut by_depth = keys.clone();
+        // Stable on purpose: `keys` comes from a `BTreeMap`, so equal-depth
+        // groups arrive in path order, and this order is the order they are
+        // placed in — which fixes every address the commit writes. An unstable
+        // sort may permute a depth group, and the file's layout with it.
         by_depth.sort_by_key(|k| std::cmp::Reverse(k.len())); // deepest first
         for key in &by_depth {
             let (mut region, deletes, copies, writes, attrs) = {
@@ -6055,6 +6076,8 @@ impl WriteEngine {
             // caught up front by `preflight_reference_targets`.
             let mut group_datasets: Vec<FlatDataset> =
                 flat.remove(key).into_iter().flatten().collect();
+            // Stable on purpose: this is a partition, and the relative order
+            // within each half is what the paragraph above promises.
             group_datasets.sort_by_key(|fd| fd.reference_targets.is_some());
             for mut fd in group_datasets {
                 // Place each variable-length attribute's global heap collection
@@ -9500,6 +9523,8 @@ impl WriteEngine {
         superblock: &Superblock,
     ) -> Result<(), Error> {
         let mut by_depth = keys.to_vec();
+        // Stable on purpose, for the same reason as the apply loop's copy: this
+        // simulation is only faithful if it walks the groups in that same order.
         by_depth.sort_by_key(|k| std::cmp::Reverse(k.len()));
         let mut sim_addr: BTreeMap<PathKey, u64> = BTreeMap::new();
         for key in &by_depth {
@@ -9509,6 +9534,7 @@ impl WriteEngine {
                 // placed (and so become resolvable) before any reference
                 // dataset in the same group.
                 let mut ordered: Vec<&FlatDataset> = datasets.to_vec();
+                // Stable on purpose, like the loop it mirrors.
                 ordered.sort_by_key(|fd| fd.reference_targets.is_some());
                 for fd in ordered {
                     if let Some(patches) = &fd.reference_targets {

--- a/src/free_space_manager.rs
+++ b/src/free_space_manager.rs
@@ -217,6 +217,8 @@ pub(crate) fn serialize_file_fsm(
             None => by_size.push((s.size, vec![s.addr])),
         }
     }
+    // The loop above keeps one entry per distinct size, so there is no tie to
+    // break and stability is not load-bearing here.
     by_size.sort_by_key(|(size, _)| *size);
     for (size, mut offsets) in by_size {
         offsets.sort_unstable();
@@ -552,7 +554,12 @@ pub(crate) fn plan_paged_managers(
         }
     }
     slot6.extend(unclassified.iter().copied());
-    slot6.sort_by_key(|s| s.addr);
+    slot6.sort_unstable_by_key(|s| s.addr);
+    debug_assert!(
+        slot6.windows(2).all(|w| w[0].addr < w[1].addr),
+        "one address is free in more than one of the metadata, raw, and \
+         unclassified lists, so they have stopped being disjoint"
+    );
 
     let mut slots = [u64::MAX; NUM_FILE_FSM_MANAGERS];
     let mut blocks = Vec::new();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1535,7 +1535,12 @@ impl FileInner {
             self.superblock.offset_size,
         )
         .unwrap_or_default();
-        sections.sort_by_key(|s| s.addr);
+        // Distinct sections have distinct addresses in any well-formed file, so
+        // the tie-break never arises; only a malformed manager can advertise one
+        // address twice, and which of the pair is reported first is already
+        // unspecified. No `debug_assert` here: this parses untrusted bytes, which
+        // must not panic a debug build.
+        sections.sort_unstable_by_key(|s| s.addr);
         sections.into_iter().map(|s| (s.addr, s.size)).collect()
     }
 

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -450,7 +450,7 @@ fn populate<S: GroupSink>(
 
     // Datasets, sorted by name.
     let mut dataset_names = src.datasets()?;
-    dataset_names.sort();
+    dataset_names.sort_unstable();
     for name in dataset_names {
         let child_path = join(path, &name);
         if drop.contains(&child_path) {
@@ -470,7 +470,7 @@ fn populate<S: GroupSink>(
 
     // Subgroups, sorted by name; built depth-first into a FinishedGroup.
     let mut group_names = src.groups()?;
-    group_names.sort();
+    group_names.sort_unstable();
     for name in group_names {
         let child_path = join(path, &name);
         if drop.contains(&child_path) {
@@ -1235,7 +1235,10 @@ where
     S: AttrSink + ?Sized,
     F: FnOnce() -> Result<std::collections::HashMap<String, AttrValue>, Error>,
 {
-    messages.sort_by(|a, b| a.name.cmp(&b.name));
+    // Attribute names are unique within an object header, so the tie-break never
+    // arises; a duplicate would mean a malformed source header, and the two would
+    // be copied in one arbitrary order either way.
+    messages.sort_unstable_by(|a, b| a.name.cmp(&b.name));
     // An attribute naming a committed (`H5Tcommit`) datatype is re-pointed at the
     // same type in the output, exactly as a dataset's committed element type is.
     // The source address is what says *which* committed object, so two attributes

--- a/src/type_builders.rs
+++ b/src/type_builders.rs
@@ -434,6 +434,9 @@ impl ExplicitCompoundTypeBuilder {
             }
         }
 
+        // Stable on purpose: two fields at one offset are rejected as an overlap
+        // just below, and stability is what makes that error name them in
+        // declaration order rather than an arbitrary one.
         self.fields.sort_by_key(|field| field.byte_offset);
         for fields in self.fields.windows(2) {
             let first_end = fields[0].byte_offset + u64::from(fields[0].datatype.type_size());


### PR DESCRIPTION
Converted the sorts whose keys carry no meaningful ties: the free-list unions in `PagedEdit::reusable_sections` and the reserve-folding branch of `reusable_free_space`, the paged manager plan's generic-large slot in `plan_paged_managers`, the two free-section sorts in `WriteEngine`'s reopen seeding, `File::persisted_free_space`, and repack's dataset-name, group-name, and attribute-name sorts. The three in-memory address sorts gained a `debug_assert!` that the sorted addresses strictly increase, each naming the disjointness invariant that would have to have broken for a duplicate to appear; the three that sort sections parsed off disk got a comment instead of an assert, since a malformed manager can advertise one address twice and parsing untrusted bytes must not panic a debug build.

Left stable, now with a line saying why: the `reference_targets.is_some()` partitions in the apply loop and its preflight mirror, the two `Reverse(k.len())` depth sorts (equal-depth groups are placed in the order they are sorted into, so that order fixes every address the commit writes), and the compound field-offset sort (stability is what makes the overlap error name the fields in declaration order). `serialize_file_fsm`'s `by_size` sort is also left alone; its comment records the finding that the loop building `by_size` keeps one entry per distinct size, so stability there is not load-bearing either way.

No behaviour change, so no changelog entry and no version bump.

Closes #404

## Tests

No new tests: this is a no-op refactor, and the gate is the existing suite's byte-identity and layout assertions (`tests/sync_policy.rs`, `tests/write_read_roundtrip.rs`, the free-space and paged-mutation binaries), which also exercise the new `debug_assert!`s since the test profile is a debug build.

## Gates run

`cargo fmt --all --check`, `cargo clippy --features "serde ndarray" --all-targets -- -D warnings`, `cargo test --lib` (1054 passed), `cargo nextest run --features "serde ndarray"` (2515 passed), `cargo test --doc` (39 passed), and `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --features "provenance zfp ndarray serde"`.
