### PR TITLE
Drop an unused no_std Vec import in read_spec

### DIFF
--- a/src/read_spec.rs
+++ b/src/read_spec.rs
@@ -16,9 +16,6 @@
 //! layer at once, and the sites that must decide what it is are the few that
 //! build the spec.
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 use crate::convert::TryToUsize;
 use crate::data_layout::DataLayout;
 use crate::dataspace::Dataspace;


### PR DESCRIPTION
`src/read_spec.rs` imported `alloc::vec::Vec` under `no_std` without using it, so every `cargo check --no-default-features` printed an unused-import warning. Import removed; no behaviour change and no changelog entry.

Gates run: `cargo check --no-default-features` (0 warnings), `cargo check --no-default-features --target wasm32-unknown-unknown`, `cargo fmt --all --check`, `cargo clippy --features "serde ndarray" --lib -- -D warnings`, `cargo test --lib` (1064 passed).