### PR TITLE
Read a region of a dataset along every dimension, not only a row window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Dataset::read_raw_region(start, count)` and the typed `read_f64_region` … `read_u64_region` / `read_string_region` read a box along every dimension — the block `H5Sselect_hyperslab` selects at unit stride — touching only the storage it overlaps, so a tile of an image or a window along an axis that is not the first costs its own size rather than the dataset's. A region past an edge is refused with the new `Error::InvalidRegion` rather than clamped ([#465](https://github.com/stephenberry/hdf5-pure/issues/465)).
+
 ## [0.44.0] - 2026-09-04
 
 Files that h5py and netCDF-4 write are editable in place now. `File::open_rw` edits an object that tracks attribute creation order and adds a dataset or group to one that tracks link creation order (h5py's `track_order=True`, and everything netCDF-4 writes), where every such object was refused, and it keeps the object header's timestamps and `H5Pset_attr_phase_change` thresholds across the rewrite instead of dropping both ([#416](https://github.com/stephenberry/hdf5-pure/issues/416), [#422](https://github.com/stephenberry/hdf5-pure/pull/422)). `File::open` and `File::open_streaming` read a file that shares object header messages (`H5Pset_shared_mesg_index`), resolving a datatype, dataspace, fill value, filter pipeline or attribute out of the shared-message heap, and `repack` rewrites such a file with every message stored inline ([#417](https://github.com/stephenberry/hdf5-pure/issues/417)). Deleting objects gives trailing space back to the filesystem rather than leaving `File::file_size()` at a high-water mark ([#418](https://github.com/stephenberry/hdf5-pure/issues/418)), and `WriteMarkPolicy::AllowSnapshot` lets a read-only open take a path-based snapshot of a file a page-buffered writer holds ([#419](https://github.com/stephenberry/hdf5-pure/issues/419)). Additive minor bump.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ for start in (0..rows).step_by(1_000_000) {
 }
 ```
 
+A box along every dimension — a tile of an image, one frame of a stack, a window along an axis that is not the first — is `read_raw_region(start, count)` and the typed `read_*_region` forms; like a row window, a region touches only the storage it overlaps.
+
 Use `File::open_streaming_with_options` to bound retained metadata and dataset chunk cache memory. `MetadataCacheConfig` mirrors the memory-budget role of `H5Pset_mdc_config`; `ChunkCacheConfig` mirrors the raw-data chunk-cache settings from `H5Pset_cache`, controlling decompressed chunk data and whether parsed chunk indexes are retained between repeated reads of the same dataset.
 
 ```rust

--- a/docs/guide/reading.md
+++ b/docs/guide/reading.md
@@ -181,6 +181,20 @@ Only the storage the window touches is read: a single bounded sub-read for compa
 
 Combined with a [streaming open](streaming.md#reading-a-large-dataset-a-window-at-a-time), this reads a dataset too large to hold in memory a fixed number of rows at a time.
 
+### Reading a region
+
+A row window cuts the leading dimension only. To read a box along every dimension — a tile of an image, one frame of a stack, or a window along an axis that is not the first — use `read_raw_region(start, count)` and the typed `read_f64_region` / `read_f32_region` / `read_i8_region` … `read_u64_region` / `read_string_region` counterparts. `start` and `count` have one entry per axis, and the result is row-major in the shape `count`: the whole read cut to that box, element for element. It is the block `H5Sselect_hyperslab` selects at unit stride, or the `start`/`count` pair of `nc_get_vara`.
+
+```rust
+use hdf5_pure::File;
+
+let file = File::open("frames.h5").unwrap();
+let ds = file.dataset("frames").unwrap(); // shape [100, 1080, 1920]
+let right_half = ds.read_u16_region(&[7, 0, 960], &[1, 1080, 960]).unwrap(); // frame 7, columns 960..
+```
+
+Only the storage the region overlaps is read: one bounded sub-read per contiguous run for compact and contiguous layouts, and just the chunks it meets for chunked layouts, so peak memory scales with the region (plus one chunk) rather than the dataset. Unlike a row window, a region is not clamped: every axis must end inside its dimension, and one that does not is refused with `Error::InvalidRegion` naming the axis, because a clamped region would come back in a shape the caller did not ask for. A zero `count` on any axis reads an empty `Vec`, and a region covering the dataset is the whole read. `read_string_region` resolves only the region's heap references, as `read_string_rows` does for a window.
+
 ### Datasets with unwritten storage
 
 HDF5 allocates a dataset's storage lazily, so a dataset can exist with a shape and have nothing behind it — created and never written, or written in part, leaving some chunks of a chunked dataset allocated and others not. Those regions read as the dataset's **fill value**: the value `with_fill_value` set, or the type's zero when none was set. This matches the reference C library, and it means a dataset another tool created but has not filled in yet reads as a full-size array of its fill value rather than failing.

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -103,6 +103,8 @@ for start in (0..rows).step_by(1_000_000) {
 
 The window is clamped to the dataset, so the final short window needs no special-casing. See [Reading a row window](reading.md#reading-a-row-window) for the full method list.
 
+A window need not be rows. `read_raw_region(start, count)` and the typed `read_*_region` forms read a box along every dimension — a tile, a frame, a band along an axis that is not the first — touching only the chunks the box meets, under the same bound. A dataset whose leading axis has length one, as netCDF writers record a single time step, streams along its next axis this way where a row window would be the whole plane. See [Reading a region](reading.md#reading-a-region).
+
 ## Tuning retained memory
 
 `File::open_streaming_with_options(path, FileAccessProperties)` bounds the memory the streaming backend retains. `FileAccessProperties::new()` returns the crate's default access behavior; you layer on two independent caches with its builder methods.

--- a/docs/reference/property-support.md
+++ b/docs/reference/property-support.md
@@ -105,8 +105,9 @@ The second reason is that on the path where a scan would thrash, there is no pru
 |---|---|---|
 | whole (`read_f64` and friends) | fills the cache, then stops offering | `rejections`; `evictions` stays 0 |
 | row window (`read_raw_rows`, `read_*_rows`) | plain LRU, since the chunk its successor needs is the one it finished on | `evictions`; `rejections` stays 0 |
+| region (`read_raw_region`, `read_*_region`) | plain LRU, as the row window it generalizes | `evictions`; `rejections` stays 0 |
 
-A row window is the one path that does evict, so it is the only place a `w0` analogue could ever pick a different victim. It would not pick a better one: the entry the next window needs is the one this read finished on, which is the most recently used and the last thing an LRU rule gives up, while the partially-consumed entries `w0` would additionally protect are the *leading* boundary chunks that a forward sweep never revisits. That is an argument about the access patterns these readers generate, not a proof for an arbitrary one.
+A row window — or a region, its general form — is the one path that does evict, so it is the only place a `w0` analogue could ever pick a different victim. It would not pick a better one: the entry the next window needs is the one this read finished on, which is the most recently used and the last thing an LRU rule gives up, while the partially-consumed entries `w0` would additionally protect are the *leading* boundary chunks that a forward sweep never revisits. That is an argument about the access patterns these readers generate, not a proof for an arbitrary one.
 
 ## Dataset-access properties (`dapl`)
 

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -738,40 +738,39 @@ fn plan_chunk_spans(
     )
 }
 
-/// Read the raw element bytes of the row window `[row_start, row_start + num_rows)`
-/// — a range along the leading dimension — decoding only the chunks it overlaps.
+/// Read the raw element bytes of the region `start[i] .. start[i] + count[i]`
+/// along every dimension, decoding only the chunks it meets.
 ///
-/// The windowed counterpart of [`read_chunked_data_from_source`]: peak memory is
-/// one window plus one chunk, not the whole dataset. `cache` holds the parsed index
-/// and decompressed chunks, so successive windows on the same handle walk the index
-/// once and reuse boundary chunks.
+/// The regional counterpart of [`read_chunked_data_from_source`]: peak memory is
+/// one region plus one chunk, not the whole dataset. A row window is the region
+/// spanning every inner dimension and is read through here. `cache` holds the
+/// parsed index and decompressed chunks, so successive regions on the same
+/// handle walk the index once and reuse boundary chunks.
 ///
-/// A chunk that spans the dataset's full inner extent (`chunk_dims[i] == ds_dims[i]`
-/// for `i >= 1` — every 1-D and frame-per-chunk layout) holds each row contiguously,
-/// so its contribution is a plain row band copied in one move. A chunk of an
-/// inner-split grid scatters into the window through the same N-D kernel the whole
-/// read uses ([`place_chunk`]), aimed at a window-shaped output. Either way only the
-/// chunks overlapping the window are decoded, and `num_rows * row_elems` elements
-/// are returned. Returns `Ok(None)` only for a rank-0 (scalar) chunked layout — a
-/// crafted-file corner with no leading dimension to window — so the caller falls
-/// back to a whole read. The caller clamps the window to the dataset.
+/// Each chunk contributes the box it shares with the region, moved by
+/// [`copy_box`]: a band of whole rows in one copy, an inner-split chunk one row
+/// at a time. Only the chunks meeting the region are decoded, and
+/// `product(count)` elements are returned. Returns `Ok(None)` only for a rank-0
+/// (scalar) chunked layout — a crafted-file corner with no axis to select
+/// along — so the caller falls back to a whole read. The caller holds the region
+/// inside the dataset.
 ///
 /// `pass` decides which chunks the cache keeps, and the answer differs by caller.
-/// A lone window wants [`CachePass::LRU`], so that what it retains is the chunks
-/// it *finished* on: its successor is the adjacent window, and the chunk they
-/// share is that last one. A window that is one step of a sweep across the whole
+/// A lone region wants [`CachePass::LRU`], so that what it retains is the chunks
+/// it *finished* on: its successor is the adjacent region, and the chunk they
+/// share is that last one. A region that is one step of a sweep across the whole
 /// dataset wants a real pass, shared by every step — the sweep never asks for a
 /// chunk twice, so offering each one to a cache already full is a copy and an
 /// eviction with no reader on the other side. See [`CachePass`].
-pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
+pub(crate) fn read_chunked_region_from_source<S: Source + ?Sized>(
     source: &S,
     spec: RawReadSpec<'_>,
     offset_size: u8,
     length_size: u8,
     cache: &ChunkCache,
     pass: CachePass,
-    row_start: u64,
-    num_rows: u64,
+    start: &[u64],
+    count: &[u64],
 ) -> Result<Option<Vec<u8>>, FormatError> {
     let RawReadSpec {
         layout,
@@ -795,92 +794,97 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     };
 
     let elem_size = datatype.element_size_usize()?;
-    let (rank, chunk_dims, ds_dims) = chunked_dims(chunk_dimensions, dataspace)?;
+    // The dataset's own extent is not needed here — the caller holds the region
+    // inside it — but the rank check that comes with it is.
+    let (rank, chunk_dims, _) = chunked_dims(chunk_dimensions, dataspace)?;
     ensure_chunk_bytes_representable(&chunk_dims, elem_size)?;
 
-    // A rank-0 (scalar) chunked layout has no leading dimension to window; fall
-    // back to the whole-dataset reader, which handles rank 0. Only a crafted
-    // file reaches this (valid chunked layouts are rank >= 1), but the reader
-    // parses untrusted input.
+    // A rank-0 (scalar) chunked layout has no axis to select along; fall back
+    // to the whole-dataset reader, which handles rank 0. Only a crafted file
+    // reaches this (valid chunked layouts are rank >= 1), but the reader parses
+    // untrusted input.
     if rank == 0 {
         return Ok(None);
     }
+    if start.len() != rank || count.len() != rank {
+        return Err(FormatError::ChunkedReadError(format!(
+            "region start has {} entries and count {} for a dataset of rank {rank}",
+            start.len(),
+            count.len()
+        )));
+    }
 
-    // When every chunk spans the dataset's full inner extent, each row is
-    // contiguous in its chunk and a window is one row band per chunk; an
-    // inner-split chunk grid instead scatters each chunk through the N-D kernel.
-    let full_inner = (1..rank).all(|i| chunk_dims[i] == ds_dims[i]);
+    // The region as `[lo, hi)` per axis, and the output's shape. The caller
+    // holds it inside the dataset, so `hi` never passes the dataset's edge.
+    let lo: Vec<usize> = start
+        .iter()
+        .map(|&s| s.to_usize())
+        .collect::<Result<_, _>>()?;
+    let out_dims: Vec<usize> = count
+        .iter()
+        .map(|&c| c.to_usize())
+        .collect::<Result<_, _>>()?;
+    let hi: Vec<usize> = lo
+        .iter()
+        .zip(&out_dims)
+        .map(|(&l, &n)| l.saturating_add(n))
+        .collect();
 
-    // Elements per row (product of the inner dims; 1 when 1-D). Checked so a
-    // crafted dataspace whose inner dims overflow `usize` errors instead of
-    // panicking (debug) or wrapping (release).
-    let row_elems: usize = ds_dims.iter().skip(1).try_fold(1usize, |acc, &d| {
+    // Elements of the region, checked: through a row window the count is the
+    // dataset's own inner extent, and a crafted dataspace can overflow `usize`
+    // where a real one cannot — it errors instead of panicking (debug) or
+    // wrapping (release).
+    let out_elems: usize = out_dims.iter().try_fold(1usize, |acc, &d| {
         acc.checked_mul(d).ok_or(FormatError::OffsetOverflow {
             offset: acc as u64,
             length: d as u64,
         })
     })?;
-    let row_bytes = row_elems
-        .checked_mul(elem_size.get())
-        .ok_or(FormatError::OffsetOverflow {
-            offset: row_elems as u64,
-            length: elem_size.get() as u64,
-        })?;
-
-    let out_rows = num_rows.to_usize()?;
-    let total_bytes = out_rows
-        .checked_mul(row_bytes)
-        .ok_or(FormatError::OffsetOverflow {
-            offset: out_rows as u64,
-            length: row_bytes as u64,
-        })?;
+    let total_bytes =
+        out_elems
+            .checked_mul(elem_size.get())
+            .ok_or(FormatError::OffsetOverflow {
+                offset: out_elems as u64,
+                length: elem_size.get() as u64,
+            })?;
     // Uncovered bytes are unallocated storage; see `assemble_chunks`.
     let mut output = fill.buffer(total_bytes)?;
     if total_bytes == 0 {
         return Ok(Some(output));
     }
 
-    // Scatter geometry for the inner-split path: the output is a dataset whose
-    // leading dimension is the window (`[out_rows, inner dims…]`), row-major.
-    // Checked before any I/O: crafted chunk dimensions (u32 each) can overflow
-    // the stride product where a real chunk's byte size cannot. For a full-inner
-    // chunk the product equals `row_elems`, already checked above.
-    let mut win_dims = ds_dims.clone();
-    win_dims[0] = out_rows;
-    let win_strides = row_major_strides(&win_dims)?;
+    // Copy geometry, checked before any I/O: crafted chunk dimensions (u32 each)
+    // can overflow the stride product where a real chunk's byte size cannot.
+    let out_strides = row_major_strides(&out_dims)?;
     let chunk_strides = row_major_strides(&chunk_dims)?;
 
-    // Unallocated chunk index: no storage exists, so every element of the window
-    // is fill. `output` already holds exactly that (it was built from the
-    // pattern), so the window is finished before any chunk is looked at — the
+    // Unallocated chunk index: no storage exists, so every element of the
+    // region is fill. `output` already holds exactly that (it was built from the
+    // pattern), so the region is finished before any chunk is looked at — the
     // same answer the whole-dataset readers give through `chunk_index_address`,
-    // which is what keeps `read_raw_rows` and `read_raw` agreeing over a dataset
-    // that was created and never written.
+    // which is what keeps `read_raw_region` and `read_raw` agreeing over a
+    // dataset that was created and never written.
     let Some(addr) = *btree_address else {
         return Ok(Some(output));
     };
 
-    let row_lo = row_start.to_usize()?;
-    let row_hi = row_lo.saturating_add(out_rows); // exclusive; caller clamped to the dataset
-    let cd0 = chunk_dims[0];
-
-    // A chunk contributes to the window when its rows meet `[row_lo, row_hi)`.
-    // Every list this function builds and every walk over one applies this test,
-    // so it is written once.
-    let overlaps = |c0: usize| c0 < row_hi && c0.saturating_add(cd0) > row_lo;
+    // A chunk contributes to the region when it meets `[lo, hi)` along every
+    // axis. Every list this function builds and every walk over one applies this
+    // test, so it is written once. A chunk offset too large for `usize` — a
+    // 32-bit target reading a crafted file — is kept rather than dropped: the
+    // walk below converts it again and reports the failure, and a filter that
+    // swallowed it here would turn that error into silence.
     let chunk_overlaps = |chunk: &ChunkInfo| {
-        match chunk.offsets.first().copied().unwrap_or(0).to_usize() {
-            Ok(c0) => overlaps(c0),
-            // A leading offset too large for `usize` — a 32-bit target reading a
-            // crafted file. Kept rather than dropped: the walk below converts it
-            // again and reports the failure, and a filter that swallowed it here
-            // would turn that error into silence.
-            Err(_) => true,
-        }
+        (0..rank).all(
+            |i| match chunk.offsets.get(i).copied().unwrap_or(0).to_usize() {
+                Ok(c0) => c0 < hi[i] && c0.saturating_add(chunk_dims[i]) > lo[i],
+                Err(_) => true,
+            },
+        )
     };
 
-    // Walk the index once, then reuse it for later windows on this handle —
-    // keeping only this window's chunks, since each `ChunkInfo` taken out of the
+    // Walk the index once, then reuse it for later regions on this handle —
+    // keeping only this region's chunks, since each `ChunkInfo` taken out of the
     // index owns a coordinate `Vec` and the rest would be allocated and dropped
     // unread. Sweeping a dataset window by window makes that a product rather
     // than a sum (issue #289).
@@ -908,76 +912,58 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     let chunk_dims_u64: Vec<u64> = chunk_dims.iter().map(|&d| d as u64).collect();
     let ctx = ChunkContext::from_datatype(&chunk_dims_u64, datatype)?;
 
-    // Coalesce over the window's own chunks. A plan built over the dataset's
-    // whole chunk list would put the rows on either side of the window inside a
-    // span and read them for nothing — an eight-row window measured 32 KB where
-    // it needed 64 bytes.
+    // Coalesce over the region's own chunks. A plan built over the dataset's
+    // whole chunk list would put the chunks on either side of the region inside
+    // a span and read them for nothing — an eight-row window measured 32 KB
+    // where it needed 64 bytes.
     let mut spans = plan_chunk_spans(&chunks, rank, cache, chunk_overlaps);
 
-    // One decoder for the whole window; see `FilterScratch`.
+    // One decoder for the whole region; see `FilterScratch`.
     let mut scratch = FilterScratch::new();
 
+    // The box a chunk shares with the region: its origin in the chunk, its
+    // origin in the output, and its extent. One set of buffers for every chunk.
+    let mut src_origin = vec![0usize; rank];
+    let mut dst_origin = vec![0usize; rank];
+    let mut shared = vec![0usize; rank];
+
     for chunk in &chunks {
-        let c0 = chunk.offsets.first().copied().unwrap_or(0).to_usize()?;
-        // This chunk's exclusive leading-dim end. The saturating add/mul here and
-        // below keep a crafted huge chunk offset or dimension from overflowing
-        // `usize` on 32-bit (a panic in debug, a silently wrong window in
-        // release): a saturated span still compares and clamps correctly, and
-        // `row_band_copy` bounds the copy to the bytes actually present. `dst` and
-        // `band` need no guard — both are bounded by the already-checked
-        // `total_bytes` allocation.
-        let c_end = c0.saturating_add(cd0);
-        if !overlaps(c0) {
-            continue; // no overlap with the window
+        // The saturating arithmetic keeps a crafted huge chunk offset or
+        // dimension from overflowing `usize` on 32-bit (a panic in debug, a
+        // silently wrong region in release): a saturated end still compares and
+        // clamps correctly, and `copy_box` bounds the copy to the bytes actually
+        // present. The index filter above is approximate on such a target, so a
+        // chunk that turns out not to meet the region is skipped here.
+        let mut meets = true;
+        for i in 0..rank {
+            let c0 = chunk.offsets.get(i).copied().unwrap_or(0).to_usize()?;
+            let from = c0.max(lo[i]);
+            let to = c0.saturating_add(chunk_dims[i]).min(hi[i]);
+            if from >= to {
+                meets = false;
+                break;
+            }
+            src_origin[i] = from - c0;
+            dst_origin[i] = from - lo[i];
+            shared[i] = to - from;
+        }
+        if !meets {
+            continue;
         }
 
-        // Rows of this chunk that fall in the window.
-        let lo = c0.max(row_lo);
-        let hi = c_end.min(row_hi);
-
-        // Inner-split scatter parameters. `place_chunk` takes non-negative
-        // offsets, so a chunk straddling the window start is instead entered
-        // `skip` leading slabs in (dim 0 is outermost, so one slab is
-        // `chunk_strides[0]` elements), and its leading dim becomes exactly
-        // the `hi - lo` slabs the window keeps, which also clips a chunk
-        // straddling the window end. A saturated `advance` (crafted dims) makes
-        // `bytes.get(advance..)` come up empty and the chunk copies nothing —
-        // the kernel's clamping discipline for short chunks.
-        let scatter: Option<(Vec<usize>, Vec<usize>, usize)> = if full_inner {
-            None
-        } else {
-            let mut offsets = Vec::with_capacity(rank);
-            for &o in chunk.offsets.iter().take(rank) {
-                offsets.push(o.to_usize()?);
-            }
-            let skip = lo - c0;
-            offsets[0] = lo - row_lo;
-            let mut dims = chunk_dims.clone();
-            dims[0] = hi - lo;
-            let advance = skip
-                .saturating_mul(chunk_strides[0])
-                .saturating_mul(elem_size.get());
-            Some((offsets, dims, advance))
-        };
-
-        // Byte offsets of the contiguous row band (full-inner path).
-        let src = (lo - c0).saturating_mul(row_bytes);
-        let dst = (lo - row_lo) * row_bytes;
-        let band = (hi - lo) * row_bytes;
-
-        let copy = |output: &mut [u8], bytes: &[u8]| match &scatter {
-            None => row_band_copy(output, dst, bytes, src, band, elem_size),
-            Some((offsets, dims, advance)) => place_chunk(
-                bytes.get(*advance..).unwrap_or(&[]),
-                output,
-                offsets,
-                dims,
-                &win_dims,
-                &win_strides,
+        let copy = |output: &mut [u8], bytes: &[u8]| {
+            copy_box(
+                bytes,
+                &chunk_dims,
                 &chunk_strides,
+                &src_origin,
+                output,
+                &out_dims,
+                &out_strides,
+                &dst_origin,
+                &shared,
                 elem_size,
-                rank,
-            ),
+            )
         };
 
         let coord = spatial_coord(chunk, rank);
@@ -1007,24 +993,79 @@ pub(crate) fn read_chunked_rows_from_source<S: Source + ?Sized>(
     Ok(Some(output))
 }
 
-/// Copy one chunk's overlapping row band into the window buffer at `dst`, clamped
-/// to the bytes present on each side (element-aligned). An edge or short chunk
-/// copies only its valid prefix and never reads or writes out of bounds — the same
-/// discipline as [`copy_chunk_to_output`].
-fn row_band_copy(
-    output: &mut [u8],
-    dst: usize,
-    chunk: &[u8],
-    src: usize,
-    band: usize,
+/// The first axis of the tail a box can move as one contiguous run: every axis
+/// after it the box spans fully in both the source and the destination array, so
+/// stepping along it lands on the next element in both.
+///
+/// A band of whole rows folds to axis 0 and moves in a single copy; a box that
+/// cuts the innermost axis folds to nothing and moves one row at a time. A
+/// scalar (empty `dims`) folds to axis 0 as well: its one element is one run.
+fn contiguous_tail(dims: &[usize], src_dims: &[usize], dst_dims: &[usize]) -> usize {
+    let mut run = dims.len().saturating_sub(1);
+    while run > 0 && dims[run] == src_dims[run] && dims[run] == dst_dims[run] {
+        run -= 1;
+    }
+    run
+}
+
+/// Copy the box `dims` at `src_origin` of the row-major array `src` (`src_dims`,
+/// `src_strides`) to `dst_origin` of the row-major array `dst` (`dst_dims`,
+/// `dst_strides`), in elements of `elem_size`. The box lies inside both arrays.
+///
+/// The contiguous tail ([`contiguous_tail`]) moves as one run, and the axes
+/// before it are walked with an odometer, one run per step. Each run is clamped
+/// to the bytes present on each side, on an element boundary, so a short
+/// (malformed) chunk copies only its valid prefix and never indexes out of
+/// bounds — the discipline of [`copy_chunk_to_output`].
+fn copy_box(
+    src: &[u8],
+    src_dims: &[usize],
+    src_strides: &[usize],
+    src_origin: &[usize],
+    dst: &mut [u8],
+    dst_dims: &[usize],
+    dst_strides: &[usize],
+    dst_origin: &[usize],
+    dims: &[usize],
     elem_size: NonZeroUsize,
 ) {
-    let mut len = band
-        .min(chunk.len().saturating_sub(src))
-        .min(output.len().saturating_sub(dst));
-    len -= len % elem_size;
-    if len > 0 {
-        output[dst..dst + len].copy_from_slice(&chunk[src..src + len]);
+    if dims.contains(&0) {
+        return;
+    }
+    let run = contiguous_tail(dims, src_dims, dst_dims);
+    let run_bytes = dims[run..]
+        .iter()
+        .fold(elem_size.get(), |acc, &d| acc.saturating_mul(d));
+    let steps: usize = dims[..run].iter().product();
+    let mut coord = vec![0usize; run];
+
+    for _ in 0..steps {
+        // Element offsets of this run on each side: the origin along every axis,
+        // plus the odometer along the axes before the tail.
+        let (mut s, mut d) = (0usize, 0usize);
+        for i in 0..dims.len() {
+            let k = coord.get(i).copied().unwrap_or(0);
+            s = s.saturating_add((src_origin[i] + k).saturating_mul(src_strides[i]));
+            d = d.saturating_add((dst_origin[i] + k).saturating_mul(dst_strides[i]));
+        }
+        let s = s.saturating_mul(elem_size.get());
+        let d = d.saturating_mul(elem_size.get());
+        let mut avail = run_bytes
+            .min(src.len().saturating_sub(s))
+            .min(dst.len().saturating_sub(d));
+        avail -= avail % elem_size;
+        if avail > 0 {
+            dst[d..d + avail].copy_from_slice(&src[s..s + avail]);
+        }
+
+        // Advance the odometer; the last axis before the tail varies fastest.
+        for i in (0..run).rev() {
+            coord[i] += 1;
+            if coord[i] < dims[i] {
+                break;
+            }
+            coord[i] = 0;
+        }
     }
 }
 
@@ -3081,14 +3122,14 @@ mod tests {
         }
     }
 
-    // --- Windowed row-read guards (read_chunked_rows_from_source) ---
+    // --- Regional read guards (read_chunked_region_from_source) ---
 
-    /// A rank-0 (scalar) chunked layout leaves `chunk_dims` empty; the windowed
+    /// A rank-0 (scalar) chunked layout leaves `chunk_dims` empty; the regional
     /// reader must fall back (`Ok(None)`) rather than index `chunk_dims[0]` and
     /// panic. Only a crafted file reaches this (valid chunked layouts are rank
     /// >= 1), but the reader parses untrusted input.
     #[test]
-    fn windowed_rows_rank0_chunked_falls_back() {
+    fn region_of_rank0_chunked_falls_back() {
         let layout = DataLayout::Chunked {
             chunk_dimensions: vec![8], // dimensionality 1 => rank 0
             btree_address: Some(0),
@@ -3104,15 +3145,15 @@ mod tests {
             max_dimensions: None,
         };
         let cache = ChunkCache::new();
-        let out = read_chunked_rows_from_source(
+        let out = read_chunked_region_from_source(
             &BytesSource::new(b""),
             RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
             CachePass::LRU,
-            0,
-            1,
+            &[],
+            &[],
         )
         .expect("rank-0 chunked must not panic");
         assert!(
@@ -3121,13 +3162,14 @@ mod tests {
         );
     }
 
-    /// Inner *dataspace* dimensions whose product overflows `usize` must error
-    /// rather than panic (debug) or wrap (release). The chunk edges stay small so
-    /// the per-chunk geometry guard passes and the `row_elems` check is what
+    /// A region whose element count overflows `usize` — here a row window over a
+    /// dataspace whose inner dimensions multiply past it — must error rather
+    /// than panic (debug) or wrap (release). The chunk edges stay small so the
+    /// per-chunk geometry guard passes and the region's own count is what
     /// catches the overflow. `(2^22)^3` overflows 64-bit `usize`; `(2^22)^2`
     /// already overflows 32-bit, so this holds on both.
     #[test]
-    fn windowed_rows_inner_dim_product_overflow_errors() {
+    fn region_element_count_overflow_errors() {
         let big: u32 = 1 << 22;
         let layout = DataLayout::Chunked {
             chunk_dimensions: vec![1, 2, 2, 2, 8],
@@ -3144,17 +3186,17 @@ mod tests {
             max_dimensions: None,
         };
         let cache = ChunkCache::new();
-        let err = read_chunked_rows_from_source(
+        let err = read_chunked_region_from_source(
             &BytesSource::new(b""),
             RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
             CachePass::LRU,
-            0,
-            1,
+            &[0, 0, 0, 0],
+            &[1, big.into(), big.into(), big.into()],
         )
-        .expect_err("overflowing inner-dim product must error");
+        .expect_err("an overflowing element count must error");
         assert!(
             matches!(err, FormatError::OffsetOverflow { .. }),
             "expected OffsetOverflow, got {err:?}"
@@ -3164,11 +3206,11 @@ mod tests {
     /// A chunk whose edges declare an impossible logical byte size — here a
     /// `(2^22)^3` element chunk of `f64`, far past the 4 GiB format limit — must
     /// be refused up front, even when the dataset itself is small. The per-chunk
-    /// geometry guard catches it before the windowed reader sizes any allocation
+    /// geometry guard catches it before the regional reader sizes any allocation
     /// or builds strides, so a crafted chunk extent cannot drive an out-of-memory
     /// abort. Checked before any I/O: the empty source would otherwise EOF first.
     #[test]
-    fn windowed_rows_huge_chunk_geometry_refused() {
+    fn region_huge_chunk_geometry_refused() {
         let big: u32 = 1 << 22;
         let layout = DataLayout::Chunked {
             chunk_dimensions: vec![2, big, big, big, 8],
@@ -3185,15 +3227,15 @@ mod tests {
             max_dimensions: None,
         };
         let cache = ChunkCache::new();
-        let err = read_chunked_rows_from_source(
+        let err = read_chunked_region_from_source(
             &BytesSource::new(b""),
             RawReadSpec::plain(&layout, &dataspace, &make_f64_type()),
             8,
             8,
             &cache,
             CachePass::LRU,
-            0,
-            1,
+            &[0, 0, 0, 0],
+            &[1, 2, 2, 2],
         )
         .expect_err("an impossible chunk geometry must error");
         assert!(
@@ -3203,16 +3245,16 @@ mod tests {
     }
 
     /// An unallocated chunk index (`btree_address == None`, e.g. a late-allocated
-    /// never-written dataset) reads as fill for a non-empty window, matching the
-    /// whole-dataset reader element for element, and as the empty buffer for a
-    /// zero-row one.
+    /// never-written dataset) reads as fill for a non-empty region, matching the
+    /// whole-dataset reader element for element, and as the empty buffer for an
+    /// empty one.
     ///
-    /// The window and the whole read reach the fill by different routes — the
-    /// window returns the buffer it built up front, the whole read builds one in
+    /// The region and the whole read reach the fill by different routes — the
+    /// region returns the buffer it built up front, the whole read builds one in
     /// `chunk_index_address` — so this compares them rather than asserting a
     /// literal on either.
     #[test]
-    fn windowed_rows_unallocated_index_matches_whole_read() {
+    fn region_over_unallocated_index_matches_whole_read() {
         let layout = DataLayout::Chunked {
             chunk_dimensions: vec![4, 8],
             btree_address: None,
@@ -3243,32 +3285,143 @@ mod tests {
                     .expect("an unallocated dataset reads as fill");
             assert_eq!(whole.len(), 80);
 
-            let window = read_chunked_rows_from_source(
+            let region = read_chunked_region_from_source(
                 &BytesSource::new(b""),
                 spec,
                 8,
                 8,
                 &cache,
                 CachePass::LRU,
-                2,
-                4,
+                &[2],
+                &[4],
             )
-            .expect("a window over an unallocated index reads as fill")
-            .expect("rank-1 windows are supported");
-            assert_eq!(window, whole[16..48], "the window must match those rows");
+            .expect("a region over an unallocated index reads as fill")
+            .expect("rank-1 regions are supported");
+            assert_eq!(
+                region,
+                whole[16..48],
+                "the region must match those elements"
+            );
 
-            let empty = read_chunked_rows_from_source(
+            let empty = read_chunked_region_from_source(
                 &BytesSource::new(b""),
                 spec,
                 8,
                 8,
                 &cache,
                 CachePass::LRU,
-                0,
-                0,
+                &[0],
+                &[0],
             )
-            .expect("empty window must still be Ok");
+            .expect("an empty region must still be Ok");
             assert_eq!(empty, Some(Vec::new()));
         }
+    }
+
+    // --- The box kernel (copy_box) ---
+
+    /// A band of whole rows is one run; a box that cuts the innermost axis moves
+    /// a row at a time; a scalar is one run of one element.
+    #[test]
+    fn contiguous_tail_folds_the_axes_a_box_spans_in_both_arrays() {
+        // Rows 1..3 of a [4, 6] chunk into a [2, 6] window: axis 1 spans both.
+        assert_eq!(contiguous_tail(&[2, 6], &[4, 6], &[2, 6]), 0);
+        // A [16, 4] chunk into a [64, 32, 8] window: the chunk's inner axis is
+        // 4 of the window's 8, so the tail is the innermost axis alone.
+        assert_eq!(contiguous_tail(&[16, 16, 4], &[64, 16, 4], &[64, 32, 8]), 2);
+        // Inner axes spanned in both: the leading one folds too, and a band of
+        // three whole slabs is one run however many slabs each array holds.
+        assert_eq!(contiguous_tail(&[3, 16, 4], &[64, 16, 4], &[8, 16, 4]), 0);
+        // The innermost axis spanned in both, the middle one cut: fold to axis 1.
+        assert_eq!(contiguous_tail(&[3, 5, 4], &[64, 16, 4], &[8, 5, 4]), 1);
+        assert_eq!(contiguous_tail(&[], &[], &[]), 0);
+    }
+
+    /// The box lands where it should, element for element, whether the tail
+    /// folds or not.
+    #[test]
+    fn copy_box_places_a_box_of_a_chunk_into_the_region() {
+        let one = nz(1);
+        // A [4, 6] source numbered 0..24; take the 2×3 box at (1, 2) into a
+        // [3, 5] destination at (1, 1).
+        let src: Vec<u8> = (0..24).collect();
+        let mut dst = vec![0xFFu8; 15];
+        copy_box(
+            &src,
+            &[4, 6],
+            &[6, 1],
+            &[1, 2],
+            &mut dst,
+            &[3, 5],
+            &[5, 1],
+            &[1, 1],
+            &[2, 3],
+            one,
+        );
+        assert_eq!(
+            dst,
+            [
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //
+                0xFF, 8, 9, 10, 0xFF, //
+                0xFF, 14, 15, 16, 0xFF,
+            ]
+        );
+        // Whole rows 1..3 of the same source into a [2, 6] destination: the
+        // folded run is the same bytes as the source's rows.
+        let mut band = vec![0u8; 12];
+        copy_box(
+            &src,
+            &[4, 6],
+            &[6, 1],
+            &[1, 0],
+            &mut band,
+            &[2, 6],
+            &[6, 1],
+            &[0, 0],
+            &[2, 6],
+            one,
+        );
+        assert_eq!(band, src[6..18]);
+    }
+
+    /// A short (malformed) chunk copies only the bytes it has, on an element
+    /// boundary, and never indexes past either buffer.
+    #[test]
+    fn copy_box_clamps_a_short_chunk_to_its_valid_prefix() {
+        let two = nz(2);
+        // Declared as [2, 4] elements of 2 bytes (16 bytes); only 7 present.
+        let src: Vec<u8> = (1..=7).collect();
+        let mut dst = vec![0u8; 16];
+        copy_box(
+            &src,
+            &[2, 4],
+            &[4, 1],
+            &[0, 0],
+            &mut dst,
+            &[2, 4],
+            &[4, 1],
+            &[0, 0],
+            &[2, 4],
+            two,
+        );
+        // Three whole elements of the first row; the seventh byte is half an
+        // element and stays out.
+        assert_eq!(&dst[..8], [1, 2, 3, 4, 5, 6, 0, 0]);
+        assert!(dst[8..].iter().all(|&b| b == 0));
+        // An empty box copies nothing.
+        let mut untouched = vec![9u8; 4];
+        copy_box(
+            &src,
+            &[2, 4],
+            &[4, 1],
+            &[0, 0],
+            &mut untouched,
+            &[1, 2],
+            &[2, 1],
+            &[0, 0],
+            &[0, 2],
+            two,
+        );
+        assert_eq!(untouched, [9, 9, 9, 9]);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1171,6 +1171,13 @@ pub enum Error {
     /// static rank (e.g. `read_array::<_, Ix2>`) did not match the dataset's
     /// runtime rank. Only constructed when the `ndarray` feature is enabled.
     Shape(String),
+    /// A region handed to [`Dataset::read_raw_region`](crate::Dataset::read_raw_region)
+    /// or a typed `read_*_region` does not fit the dataset: `start` and `count`
+    /// name a different number of axes than the dataset has, or an axis runs
+    /// past the dataset's extent. The message names the axis that runs past, or
+    /// the two ranks. A region is not clamped the way a row window is, because a
+    /// clamped region would come back in a shape the caller did not ask for.
+    InvalidRegion(String),
     /// A SWMR operation (e.g. [`crate::File::refresh`]) was requested on a file
     /// that was not opened for SWMR reading via `File::open_swmr`.
     SwmrUnsupported,
@@ -1355,6 +1362,7 @@ impl fmt::Display for Error {
             Error::NotANamedDatatype(path) => write!(f, "not a named datatype: {path}"),
             Error::MissingMessage(mt) => write!(f, "missing required message: {mt}"),
             Error::Shape(msg) => write!(f, "array shape error: {msg}"),
+            Error::InvalidRegion(msg) => write!(f, "region does not fit the dataset: {msg}"),
             Error::SwmrUnsupported => write!(
                 f,
                 "refresh requires a file opened with File::open_swmr (live handle)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub(crate) mod message_type;
 pub(crate) mod object_header;
 pub(crate) mod object_header_writer;
 pub(crate) mod read_spec;
+pub(crate) mod region;
 pub(crate) mod scaleoffset;
 pub(crate) mod shared_message;
 pub(crate) mod signature;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,6 +38,7 @@ use crate::libver::LibVer;
 use crate::message_type::MessageType;
 use crate::object_header::ObjectHeader;
 use crate::read_spec::RawReadSpec;
+use crate::region;
 use crate::shared_message::{self, BufferedResolver, SharedResolver, SourceResolver};
 use crate::signature;
 use crate::source::{
@@ -2132,11 +2133,141 @@ impl FileInner {
         }
     }
 
-    /// Windowed counterpart of [`read_dataset_raw`](Self::read_dataset_raw): read
-    /// the raw element bytes of the row window `[start_row, start_row + num_rows)`,
-    /// touching only the storage it overlaps. Reads through the same base-framed
-    /// `Source`, so on-disk addresses resolve the same way. The caller clamps
-    /// the window to the dataset.
+    /// Regional counterpart of [`read_dataset_raw`](Self::read_dataset_raw): read
+    /// the raw element bytes of `start[i] .. start[i] + count[i]` along every
+    /// dimension, touching only the storage the region overlaps. Reads through
+    /// the same base-framed `Source`, so on-disk addresses resolve the same way.
+    /// The caller holds the region inside the dataset.
+    fn read_dataset_raw_region(
+        &self,
+        spec: RawReadSpec<'_>,
+        cache: &ChunkCache,
+        pass: CachePass,
+        start: &[u64],
+        count: &[u64],
+    ) -> Result<Vec<u8>, FormatError> {
+        let (os, ls) = (self.offset_size(), self.length_size());
+        let (dl, ds, dt) = (spec.layout, spec.dataspace, spec.datatype);
+        let elem_size = dt.element_size_usize()?;
+        // Bytes of the region, checked: through a row window the count is the
+        // dataset's own inner extent, and a crafted dataspace can overflow
+        // `usize` where a real one cannot — it errors instead of panicking
+        // (debug) or wrapping (release).
+        let total_bytes = count.iter().try_fold(elem_size.get(), |acc, &d| {
+            acc.checked_mul(d.to_usize()?)
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: acc as u64,
+                    length: d,
+                })
+        })?;
+
+        // Compact data is inline in the layout message — no I/O, no framing.
+        if let DataLayout::Compact { data } = dl {
+            let mut out = vec![0u8; total_bytes];
+            for run in region::runs(&ds.dimensions, start, count)? {
+                let from = run.src.to_usize()?.checked_mul(elem_size.get()).ok_or(
+                    FormatError::OffsetOverflow {
+                        offset: run.src,
+                        length: elem_size.get() as u64,
+                    },
+                )?;
+                let len = run.len * elem_size.get();
+                let end = from.checked_add(len).ok_or(FormatError::OffsetOverflow {
+                    offset: from as u64,
+                    length: len as u64,
+                })?;
+                let bytes = data.get(from..end).ok_or(FormatError::DataSizeMismatch {
+                    expected: end,
+                    actual: data.len(),
+                })?;
+                let dst = run.dst * elem_size.get();
+                out[dst..dst + len].copy_from_slice(bytes);
+            }
+            return Ok(out);
+        }
+
+        let base = self.addr_offset;
+        match &self.backend {
+            Backend::InMemory(v) => {
+                let framed = frame(v, base)?;
+                read_region_framed(
+                    &BytesSource::new(framed),
+                    spec,
+                    os,
+                    ls,
+                    cache,
+                    pass,
+                    start,
+                    count,
+                    total_bytes,
+                )
+            }
+            Backend::Streaming(s) if base.is_zero() => read_region_framed(
+                s.as_ref(),
+                spec,
+                os,
+                ls,
+                cache,
+                pass,
+                start,
+                count,
+                total_bytes,
+            ),
+            Backend::Streaming(s) => {
+                let framed = BaseOffsetSource {
+                    inner: s.as_ref(),
+                    base,
+                };
+                read_region_framed(
+                    &framed,
+                    spec,
+                    os,
+                    ls,
+                    cache,
+                    pass,
+                    start,
+                    count,
+                    total_bytes,
+                )
+            }
+            Backend::Edit(m) => Self::with_engine(
+                m,
+                |data| {
+                    let framed = frame(data, base)?;
+                    read_region_framed(
+                        &BytesSource::new(framed),
+                        spec,
+                        os,
+                        ls,
+                        cache,
+                        pass,
+                        start,
+                        count,
+                        total_bytes,
+                    )
+                },
+                |s| {
+                    let framed = BaseOffsetSource { inner: s, base };
+                    read_region_framed(
+                        &framed,
+                        spec,
+                        os,
+                        ls,
+                        cache,
+                        pass,
+                        start,
+                        count,
+                        total_bytes,
+                    )
+                },
+            ),
+        }
+    }
+
+    /// The row window `[start_row, start_row + num_rows)` as the region that
+    /// spans every inner dimension; see
+    /// [`read_dataset_raw_region`](Self::read_dataset_raw_region). The caller
+    /// clamps the window to the dataset, and a 0-D scalar is one row.
     fn read_dataset_raw_rows(
         &self,
         spec: RawReadSpec<'_>,
@@ -2145,191 +2276,91 @@ impl FileInner {
         start_row: u64,
         num_rows: u64,
     ) -> Result<Vec<u8>, FormatError> {
-        let (os, ls) = (self.offset_size(), self.length_size());
-        let (dl, ds, dt) = (spec.layout, spec.dataspace, spec.datatype);
-        let elem_size = dt.element_size_usize()?;
-        // Elements per row (product of inner dims; 1 when 0-D or 1-D). Checked so
-        // a crafted dataspace whose inner dims overflow `usize` errors instead of
-        // panicking (debug) or wrapping (release).
-        let row_elems: usize = ds.dimensions.iter().skip(1).try_fold(1usize, |acc, &d| {
-            acc.checked_mul(d.to_usize()?)
-                .ok_or(FormatError::OffsetOverflow {
-                    offset: acc as u64,
-                    length: d,
-                })
-        })?;
-        let row_bytes =
-            row_elems
-                .checked_mul(elem_size.get())
-                .ok_or(FormatError::OffsetOverflow {
-                    offset: row_elems as u64,
-                    length: elem_size.get() as u64,
-                })?;
-
-        // Compact data is inline in the layout message — no I/O, no framing.
-        if let DataLayout::Compact { data } = dl {
-            let start = start_row.to_usize()?.checked_mul(row_bytes);
-            let len = num_rows.to_usize()?.checked_mul(row_bytes);
-            let (Some(start), Some(len)) = (start, len) else {
-                return Err(FormatError::OffsetOverflow {
-                    offset: start_row,
-                    length: row_bytes as u64,
-                });
+        let dims = &spec.dataspace.dimensions;
+        if dims.is_empty() {
+            // A scalar has no axis to window along: its one row is the whole
+            // read, and a window of no rows is empty — except over a `Virtual`
+            // layout, which is unsupported and must still error like `read_raw`
+            // does rather than be swallowed by the shortcut.
+            return if num_rows == 0 && !matches!(spec.layout, DataLayout::Virtual { .. }) {
+                Ok(Vec::new())
+            } else {
+                self.read_dataset_raw(spec, cache)
             };
-            let end = start.checked_add(len).ok_or(FormatError::OffsetOverflow {
-                offset: start as u64,
-                length: len as u64,
-            })?;
-            return data
-                .get(start..end)
-                .map(<[u8]>::to_vec)
-                .ok_or(FormatError::DataSizeMismatch {
-                    expected: end,
-                    actual: data.len(),
-                });
         }
-
-        let base = self.addr_offset;
-        match &self.backend {
-            Backend::InMemory(v) => {
-                let framed = frame(v, base)?;
-                read_rows_framed(
-                    &BytesSource::new(framed),
-                    spec,
-                    os,
-                    ls,
-                    cache,
-                    pass,
-                    start_row,
-                    num_rows,
-                    row_bytes,
-                )
-            }
-            Backend::Streaming(s) if base.is_zero() => read_rows_framed(
-                s.as_ref(),
-                spec,
-                os,
-                ls,
-                cache,
-                pass,
-                start_row,
-                num_rows,
-                row_bytes,
-            ),
-            Backend::Streaming(s) => {
-                let framed = BaseOffsetSource {
-                    inner: s.as_ref(),
-                    base,
-                };
-                read_rows_framed(
-                    &framed, spec, os, ls, cache, pass, start_row, num_rows, row_bytes,
-                )
-            }
-            Backend::Edit(m) => Self::with_engine(
-                m,
-                |data| {
-                    let framed = frame(data, base)?;
-                    read_rows_framed(
-                        &BytesSource::new(framed),
-                        spec,
-                        os,
-                        ls,
-                        cache,
-                        pass,
-                        start_row,
-                        num_rows,
-                        row_bytes,
-                    )
-                },
-                |s| {
-                    let framed = BaseOffsetSource { inner: s, base };
-                    read_rows_framed(
-                        &framed, spec, os, ls, cache, pass, start_row, num_rows, row_bytes,
-                    )
-                },
-            ),
-        }
+        let mut start = vec![0u64; dims.len()];
+        start[0] = start_row;
+        let mut count = dims.clone();
+        count[0] = num_rows;
+        self.read_dataset_raw_region(spec, cache, pass, &start, &count)
     }
 }
 
-/// Read a row window through an already base-framed `Source`. Contiguous
-/// layouts are one bounded sub-read; chunked layouts use the windowed chunk
-/// reader (only the rank-0 crafted-file corner falls back to a whole read
-/// plus slice).
-fn read_rows_framed<S: Source + ?Sized>(
+/// Read a region through an already base-framed `Source`. Contiguous layouts
+/// are one bounded sub-read per run of the region; chunked layouts use the
+/// regional chunk reader (only the rank-0 crafted-file corner falls back to a
+/// whole read).
+fn read_region_framed<S: Source + ?Sized>(
     source: &S,
     spec: RawReadSpec<'_>,
     os: u8,
     ls: u8,
     cache: &ChunkCache,
     pass: CachePass,
-    start_row: u64,
-    num_rows: u64,
-    row_bytes: usize,
+    start: &[u64],
+    count: &[u64],
+    total_bytes: usize,
 ) -> Result<Vec<u8>, FormatError> {
     let (dl, fill) = (spec.layout, spec.fill);
-    // A zero-row window reads nothing, uniformly across the *supported* layouts.
+    // An empty region reads nothing, uniformly across the *supported* layouts.
     // A `Virtual` layout is unsupported and must still error like `read_raw`
     // does, so it is excluded here and falls through to the match.
-    if num_rows == 0 && !matches!(dl, DataLayout::Virtual { .. }) {
+    if total_bytes == 0 && !matches!(dl, DataLayout::Virtual { .. }) {
         return Ok(Vec::new());
     }
     match dl {
         DataLayout::Compact { .. } => unreachable!("compact is handled before framing"),
         DataLayout::Contiguous { address, size } => {
-            // Unallocated storage: the window reads as the fill value, the same
+            // Unallocated storage: the region reads as the fill value, the same
             // answer the whole-dataset readers give for it.
             let Some(addr) = *address else {
-                let len = num_rows.to_usize()?.saturating_mul(row_bytes);
-                return fill.buffer(len);
+                return fill.buffer(total_bytes);
             };
-            let start =
-                start_row
-                    .checked_mul(row_bytes as u64)
-                    .ok_or(FormatError::OffsetOverflow {
-                        offset: start_row,
-                        length: row_bytes as u64,
-                    })?;
-            let len =
-                num_rows
-                    .to_usize()?
-                    .checked_mul(row_bytes)
-                    .ok_or(FormatError::OffsetOverflow {
-                        offset: num_rows,
-                        length: row_bytes as u64,
-                    })?;
-            // Never read past the dataset's own contiguous storage.
-            if start.saturating_add(len as u64) > *size {
-                return Err(FormatError::DataSizeMismatch {
-                    expected: start.to_usize()?.saturating_add(len),
-                    actual: (*size).to_usize()?,
-                });
+            let elem_size = spec.datatype.element_size_usize()?.get();
+            let mut out = vec![0u8; total_bytes];
+            for run in region::runs(&spec.dataspace.dimensions, start, count)? {
+                let from =
+                    run.src
+                        .checked_mul(elem_size as u64)
+                        .ok_or(FormatError::OffsetOverflow {
+                            offset: run.src,
+                            length: elem_size as u64,
+                        })?;
+                let len = run.len * elem_size;
+                // Never read past the dataset's own contiguous storage.
+                if from.saturating_add(len as u64) > *size {
+                    return Err(FormatError::DataSizeMismatch {
+                        expected: from.to_usize()?.saturating_add(len),
+                        actual: (*size).to_usize()?,
+                    });
+                }
+                let off = addr.checked_add(from).ok_or(FormatError::OffsetOverflow {
+                    offset: addr,
+                    length: from,
+                })?;
+                let dst = run.dst * elem_size;
+                source.read_at(off, &mut out[dst..dst + len])?;
             }
-            let off = addr.checked_add(start).ok_or(FormatError::OffsetOverflow {
-                offset: addr,
-                length: start,
-            })?;
-            source.read_exact_at(off, len)
+            Ok(out)
         }
         DataLayout::Chunked { .. } => {
-            match crate::chunked_read::read_chunked_rows_from_source(
-                source, spec, os, ls, cache, pass, start_row, num_rows,
+            match crate::chunked_read::read_chunked_region_from_source(
+                source, spec, os, ls, cache, pass, start, count,
             )? {
                 Some(bytes) => Ok(bytes),
-                // Rank-0 chunked (a crafted-file corner): fall back to a whole
-                // read, then slice.
-                None => {
-                    let full =
-                        data_read::read_raw_data_cached_from_source(source, spec, os, ls, cache)?;
-                    let start = start_row.to_usize()? * row_bytes;
-                    let len = num_rows.to_usize()? * row_bytes;
-                    full.get(start..start + len).map(<[u8]>::to_vec).ok_or(
-                        FormatError::DataSizeMismatch {
-                            expected: start + len,
-                            actual: full.len(),
-                        },
-                    )
-                }
+                // Rank-0 chunked (a crafted-file corner): the only region of a
+                // scalar is the scalar, which the whole read answers.
+                None => data_read::read_raw_data_cached_from_source(source, spec, os, ls, cache),
             }
         }
         DataLayout::Virtual { .. } => Err(FormatError::UnsupportedVirtualLayout),
@@ -6374,6 +6405,168 @@ the same commit to replace it",
         Ok(data_read::read_as_strings(&raw, &dt)?)
     }
 
+    /// Read the raw element bytes of the region `start[i] .. start[i] + count[i]`
+    /// along every dimension — the block `H5Sselect_hyperslab` selects at unit
+    /// stride, `h5dump --start --count`, or the `start`/`count` of `nc_get_vara`.
+    ///
+    /// The regional companion to [`read_raw`](Self::read_raw), and the general
+    /// form of [`read_raw_rows`](Self::read_raw_rows), which is the region that
+    /// spans every inner dimension. Only the storage the region overlaps is read
+    /// — one bounded sub-read per contiguous run for compact and contiguous
+    /// layouts, just the chunks it meets for chunked layouts — so peak memory
+    /// scales with the region plus one chunk, not the dataset. Use it for a tile
+    /// of an image, one frame of a stack, or a window along an axis that is not
+    /// the first.
+    ///
+    /// The result is row-major in the shape `count`, and its bytes match what
+    /// [`read_raw`](Self::read_raw) produces for those elements, so the typed
+    /// `read_*_region` helpers decode a region like their whole-dataset forms.
+    /// `start` and `count` have one entry per axis, and every axis must end
+    /// inside its dimension: a region past the edge is refused with
+    /// [`Error::InvalidRegion`](crate::Error::InvalidRegion) rather than clamped,
+    /// because a clamped region would come back in a shape the caller did not
+    /// ask for — a row window can clamp only because its rows keep their inner
+    /// shape however it is cut. A zero `count` on any axis reads an empty `Vec`,
+    /// and a region covering the dataset delegates to
+    /// [`read_raw`](Self::read_raw), so it never costs more than a whole read.
+    /// Variable-length string bytes are heap references, not text — use
+    /// [`read_string_region`](Self::read_string_region).
+    pub fn read_raw_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<u8>, Error> {
+        let dt = self.datatype()?;
+        let ds = self.dataspace()?;
+        let dl = self.read_layout()?;
+        region::fits(&ds.dimensions, start, count).map_err(Error::InvalidRegion)?;
+
+        // See `read_raw`: an unparseable fill value message is carried into the
+        // read rather than failing it up front.
+        let parsed_fill = self.fill_bytes();
+        let fill = match &parsed_fill {
+            Ok(b) => FillPattern::new(b.as_deref(), dt.element_size_usize()?),
+            Err(_) => FillPattern::UNKNOWN,
+        };
+
+        let pipeline = self.filter_pipeline_parsed();
+        let spec = RawReadSpec {
+            layout: &dl,
+            dataspace: &ds,
+            datatype: &dt,
+            pipeline: pipeline.as_ref(),
+            fill,
+        };
+
+        // A region covering the dataset is exactly a whole read: delegate, so it
+        // never costs a region-shaped copy on top of one.
+        if start.iter().all(|&s| s == 0) && count == ds.dimensions.as_slice() {
+            return Ok(self.file.read_dataset_raw(spec, &self.chunk_cache)?);
+        }
+
+        // A lone region's successor is the adjacent one, and the chunk they share
+        // is the one this read finishes on; `CachePass::LRU` is what retains it.
+        Ok(self.file.read_dataset_raw_region(
+            spec,
+            &self.chunk_cache,
+            CachePass::LRU,
+            start,
+            count,
+        )?)
+    }
+
+    /// Regional [`read_f64`](Self::read_f64) — decodes only the region.
+    pub fn read_f64_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<f64>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_f64(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_f32`](Self::read_f32) — decodes only the region.
+    pub fn read_f32_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<f32>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_f32(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_i8`](Self::read_i8) — decodes only the region.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "read_i8 reinterprets each stored byte as the signed i8 the caller requested"
+    )]
+    pub fn read_i8_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<i8>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(raw.iter().map(|&b| b as i8).collect())
+    }
+
+    /// Regional [`read_i16`](Self::read_i16) — decodes only the region.
+    pub fn read_i16_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<i16>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_i16(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_i32`](Self::read_i32) — decodes only the region.
+    pub fn read_i32_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<i32>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_i32(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_i64`](Self::read_i64) — decodes only the region.
+    pub fn read_i64_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<i64>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_i64(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_u8`](Self::read_u8) — reads only the region.
+    pub fn read_u8_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<u8>, Error> {
+        self.read_raw_region(start, count)
+    }
+
+    /// Regional [`read_u16`](Self::read_u16) — decodes only the region.
+    pub fn read_u16_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<u16>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_u16(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_u32`](Self::read_u32) — decodes only the region.
+    pub fn read_u32_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<u32>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_u32(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_u64`](Self::read_u64) — decodes only the region.
+    pub fn read_u64_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<u64>, Error> {
+        let raw = self.read_raw_region(start, count)?;
+        Ok(data_read::read_as_u64(&raw, &self.datatype()?)?)
+    }
+
+    /// Regional [`read_string`](Self::read_string).
+    ///
+    /// Fixed-length strings decode straight from the region. Variable-length
+    /// strings resolve only the region's heap references, so the memory bound
+    /// holds for them too, as it does for [`read_string_rows`](Self::read_string_rows).
+    pub fn read_string_region(&self, start: &[u64], count: &[u64]) -> Result<Vec<String>, Error> {
+        let dt = self.datatype()?;
+        let raw = self.read_raw_region(start, count)?;
+        if vl_data::is_vlen_string_datatype(&dt) {
+            // The region's heap references, read memory-bounded like any other
+            // fixed-size element; resolving only those against the global heap
+            // keeps the bound — the same resolution `read_string` runs over the
+            // whole dataset's references.
+            let ref_size = 4 + self.file.offset_size() as usize + 4;
+            let num_elements = (raw.len() / ref_size) as u64;
+            let mut strings = Vec::new();
+            self.file.with_source(|source| -> Result<(), Error> {
+                Ok(vl_data::visit_vl_strings_from_source(
+                    source,
+                    &raw,
+                    num_elements,
+                    self.file.offset_size(),
+                    self.file.length_size(),
+                    self.file.addr_offset,
+                    VlenStringReadOptions::default(),
+                    |string| strings.push(String::from(string)),
+                )?)
+            })?;
+            return Ok(strings);
+        }
+        Ok(data_read::read_as_strings(&raw, &dt)?)
+    }
+
     /// Interpret this dataset as an array of HDF5 object references
     /// (`H5R_OBJECT`) and resolve each, in storage order, to the [`Object`] it
     /// points at.
@@ -7935,7 +8128,7 @@ mod tests {
     /// buffer and not a zero-length fill, which is what a caller iterating past
     /// the end of a dataset sees.
     #[test]
-    fn read_rows_framed_zero_row_window_is_ok_even_when_unallocated() {
+    fn read_region_framed_empty_region_is_ok_even_when_unallocated() {
         let dl = DataLayout::Contiguous {
             address: None,
             size: 0,
@@ -7954,40 +8147,86 @@ mod tests {
             bit_precision: 64,
         };
         let cache = ChunkCache::new();
-        let out = read_rows_framed(
+        let out = read_region_framed(
             &BytesSource::new(b""),
             RawReadSpec::plain(&dl, &ds, &dt),
             8,
             8,
             &cache,
             CachePass::LRU,
+            &[0],
+            &[0],
             0,
-            0,
-            8,
         )
-        .expect("a zero-row window must be Ok(empty)");
+        .expect("an empty region must be Ok(empty)");
         assert!(out.is_empty());
 
         // A Virtual layout is unsupported and must still error for a zero-row
         // window, matching `read_raw`, rather than being swallowed by the early
         // return.
         let virtual_dl = DataLayout::Virtual { version: 4 };
-        let err = read_rows_framed(
+        let err = read_region_framed(
             &BytesSource::new(b""),
             RawReadSpec::plain(&virtual_dl, &ds, &dt),
             8,
             8,
             &cache,
             CachePass::LRU,
+            &[0],
+            &[0],
             0,
-            0,
-            8,
         )
-        .expect_err("a virtual layout must error even for a zero-row window");
+        .expect_err("a virtual layout must error even for an empty region");
         assert!(
             matches!(err, FormatError::UnsupportedVirtualLayout),
             "expected UnsupportedVirtualLayout, got {err:?}"
         );
+    }
+
+    /// A region of contiguous storage that was never allocated reads as the fill
+    /// value, sized to the region — the answer the whole-dataset readers give for
+    /// such storage, cut to the box asked for.
+    #[test]
+    fn read_region_framed_over_unallocated_contiguous_storage_is_fill() {
+        let dl = DataLayout::Contiguous {
+            address: None,
+            size: 0,
+        };
+        let ds = Dataspace {
+            space_type: crate::dataspace::DataspaceType::Simple,
+            rank: 2,
+            dimensions: vec![4, 4],
+            max_dimensions: None,
+        };
+        let dt = Datatype::FixedPoint {
+            size: 2,
+            byte_order: crate::datatype::DatatypeByteOrder::LittleEndian,
+            signed: false,
+            bit_offset: 0,
+            bit_precision: 16,
+        };
+        let seven = 7u16.to_le_bytes();
+        let spec = RawReadSpec {
+            layout: &dl,
+            dataspace: &ds,
+            datatype: &dt,
+            pipeline: None,
+            fill: FillPattern::new(Some(&seven), NonZeroUsize::new(2).unwrap()),
+        };
+        let cache = ChunkCache::new();
+        let out = read_region_framed(
+            &BytesSource::new(b""),
+            spec,
+            8,
+            8,
+            &cache,
+            CachePass::LRU,
+            &[1, 1],
+            &[2, 3],
+            12,
+        )
+        .expect("an unallocated region reads as fill");
+        assert_eq!(out, seven.repeat(6));
     }
 
     /// The window a typed whole-dataset read sweeps in is a budget in *stored

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,0 +1,302 @@
+//! A rectangular region of a dataset — `start[i] .. start[i] + count[i]` along
+//! every dimension — and where it lies in dense storage.
+//!
+//! A row window is the region that spans every inner dimension. The chunked
+//! reader meets a region chunk by chunk (`chunked_read`); a compact or
+//! contiguous layout stores the dataset as one row-major array, and a region of
+//! it is the runs [`runs`] yields.
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String, vec, vec::Vec};
+
+use crate::convert::TryToUsize;
+use crate::error::FormatError;
+
+/// Check that `start` and `count` have one entry per axis of `dims` and that
+/// every axis ends inside its dimension, or say which does not, worded for the
+/// caller who asked for the region.
+///
+/// A region is not clamped the way a row window is. A row keeps its full inner
+/// shape however the window is cut, so a clamped window is still rows; a
+/// clamped region would come back in a shape the caller did not ask for, so it
+/// is refused instead. A zero `count` is fine anywhere, including at the edge.
+pub(crate) fn fits(dims: &[u64], start: &[u64], count: &[u64]) -> Result<(), String> {
+    if start.len() != dims.len() || count.len() != dims.len() {
+        return Err(format!(
+            "start has {} entries and count {} for a dataset of rank {}",
+            start.len(),
+            count.len(),
+            dims.len()
+        ));
+    }
+    for (axis, ((&dim, &from), &len)) in dims.iter().zip(start).zip(count).enumerate() {
+        match from.checked_add(len) {
+            Some(end) if end <= dim => {}
+            _ => {
+                return Err(format!(
+                    "axis {axis}: {from}..{} runs past its extent of {dim}",
+                    from.saturating_add(len)
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// One contiguous stretch of a region in a row-major array: `len` elements,
+/// from element `src` of the array to element `dst` of the region's own buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Run {
+    pub src: u64,
+    pub dst: usize,
+    pub len: usize,
+}
+
+/// The runs of the region `start .. start + count` over a row-major array of
+/// `dims`, in storage order.
+///
+/// Trailing axes the region spans fully are contiguous in storage, so a run is
+/// cut at the last axis the region does not span — `count` elements there times
+/// every dimension after it — and there is one run per coordinate of the axes
+/// before. A region spanning everything is one run; an empty one has none.
+///
+/// The caller has checked the region against `dims` ([`fits`]); what is checked
+/// here is arithmetic. The array's strides are kept in `u64`, since a dataset
+/// may hold more elements than this platform addresses, and a crafted dataspace
+/// whose extent overflows errors rather than wrapping. The region's own buffer
+/// is allocated, so its strides and offsets are `usize`.
+pub(crate) fn runs(dims: &[u64], start: &[u64], count: &[u64]) -> Result<Runs, FormatError> {
+    let rank = dims.len();
+    debug_assert!(
+        start.len() == rank && count.len() == rank,
+        "`fits` or the row-window wrapper guarantees matching lengths"
+    );
+
+    let mut out_elems = 1usize;
+    for &c in count {
+        out_elems = out_elems
+            .checked_mul(c.to_usize()?)
+            .ok_or(FormatError::OffsetOverflow {
+                offset: out_elems as u64,
+                length: c,
+            })?;
+    }
+    if out_elems == 0 {
+        return Ok(Runs::none());
+    }
+    if rank == 0 {
+        // A scalar: the one element, whole.
+        return Ok(Runs::one(1));
+    }
+
+    // Strides in elements; the array's are checked up to and including its
+    // whole extent, so every offset inside it fits.
+    let mut array_strides = vec![1u64; rank];
+    for i in (0..rank - 1).rev() {
+        array_strides[i] =
+            array_strides[i + 1]
+                .checked_mul(dims[i + 1])
+                .ok_or(FormatError::OffsetOverflow {
+                    offset: array_strides[i + 1],
+                    length: dims[i + 1],
+                })?;
+    }
+    array_strides[0]
+        .checked_mul(dims[0])
+        .ok_or(FormatError::OffsetOverflow {
+            offset: array_strides[0],
+            length: dims[0],
+        })?;
+    let mut out_strides = vec![1usize; rank];
+    for i in (0..rank - 1).rev() {
+        // Each stride is a product of `count` entries, bounded by `out_elems`.
+        out_strides[i] = out_strides[i + 1] * count[i + 1].to_usize()?;
+    }
+
+    // The last axis the region does not span; everything after it is contiguous
+    // in both the array and the region. A region spanning everything pivots on
+    // axis 0 and is one run.
+    let pivot = (0..rank)
+        .rev()
+        .find(|&i| start[i] != 0 || count[i] != dims[i])
+        .unwrap_or(0);
+    let len = count[pivot].to_usize()? * out_strides[pivot];
+    // Unreachable once the extent check above passed — every offset inside the
+    // array fits — but the fold stays checked rather than trusting that.
+    let base = start
+        .iter()
+        .zip(&array_strides)
+        .try_fold(0u64, |acc, (&s, &stride)| {
+            acc.checked_add(s.checked_mul(stride)?)
+        })
+        .ok_or(FormatError::OffsetOverflow {
+            offset: start[pivot],
+            length: array_strides[pivot],
+        })?;
+    // One run per coordinate of the axes before the pivot — a factor of
+    // `out_elems`, so the product fits.
+    let remaining = count[..pivot]
+        .iter()
+        .try_fold(1usize, |acc, &c| c.to_usize().map(|c| acc * c))?;
+
+    Ok(Runs {
+        coord: vec![0; pivot],
+        count: count[..pivot].to_vec(),
+        array_strides: array_strides[..pivot].to_vec(),
+        out_strides: out_strides[..pivot].to_vec(),
+        base,
+        len,
+        remaining,
+    })
+}
+
+/// The runs of a region, in storage order; see [`runs`].
+#[derive(Debug)]
+pub(crate) struct Runs {
+    /// Odometer over the axes before the pivot, in region coordinates.
+    coord: Vec<usize>,
+    count: Vec<u64>,
+    array_strides: Vec<u64>,
+    out_strides: Vec<usize>,
+    /// Element offset of the first run in the array.
+    base: u64,
+    /// Elements per run.
+    len: usize,
+    remaining: usize,
+}
+
+impl Runs {
+    fn none() -> Self {
+        Self::one(0).with_remaining(0)
+    }
+
+    fn one(len: usize) -> Self {
+        Runs {
+            coord: Vec::new(),
+            count: Vec::new(),
+            array_strides: Vec::new(),
+            out_strides: Vec::new(),
+            base: 0,
+            len,
+            remaining: 1,
+        }
+    }
+
+    fn with_remaining(mut self, remaining: usize) -> Self {
+        self.remaining = remaining;
+        self
+    }
+}
+
+impl Iterator for Runs {
+    type Item = Run;
+
+    fn next(&mut self) -> Option<Run> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        // Offsets inside extents already checked in `runs`, so plain arithmetic.
+        let mut src = self.base;
+        let mut dst = 0usize;
+        for (i, &k) in self.coord.iter().enumerate() {
+            src += k as u64 * self.array_strides[i];
+            dst += k * self.out_strides[i];
+        }
+        // Advance the odometer; the last axis before the pivot varies fastest.
+        for i in (0..self.coord.len()).rev() {
+            self.coord[i] += 1;
+            if (self.coord[i] as u64) < self.count[i] {
+                break;
+            }
+            self.coord[i] = 0;
+        }
+        Some(Run {
+            src,
+            dst,
+            len: self.len,
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect(dims: &[u64], start: &[u64], count: &[u64]) -> Vec<(u64, usize, usize)> {
+        runs(dims, start, count)
+            .unwrap()
+            .map(|r| (r.src, r.dst, r.len))
+            .collect()
+    }
+
+    #[test]
+    fn a_region_that_ends_inside_every_axis_fits() {
+        assert_eq!(fits(&[4, 6], &[1, 2], &[3, 4]), Ok(()));
+        // Zero elements at the very edge is still inside.
+        assert_eq!(fits(&[4, 6], &[4, 6], &[0, 0]), Ok(()));
+        // A scalar has no axes to name.
+        assert_eq!(fits(&[], &[], &[]), Ok(()));
+    }
+
+    #[test]
+    fn a_region_past_an_edge_or_of_another_rank_is_named() {
+        let past = fits(&[4, 6], &[1, 5], &[3, 2]).unwrap_err();
+        assert!(
+            past.contains("axis 1") && past.contains("5..7") && past.contains("6"),
+            "{past}"
+        );
+        let rank = fits(&[4, 6], &[1], &[3, 2]).unwrap_err();
+        assert!(rank.contains("rank 2"), "{rank}");
+        // An overflowing end is past the edge, not wrapped back inside it.
+        assert!(fits(&[4], &[u64::MAX], &[2]).is_err());
+    }
+
+    #[test]
+    fn a_partial_inner_axis_cuts_one_run_per_outer_coordinate() {
+        // [4, 6] array, box of 2 rows by 3 columns at (1, 2): the inner axis is
+        // not spanned, so each row of the box is its own run.
+        assert_eq!(
+            collect(&[4, 6], &[1, 2], &[2, 3]),
+            vec![(8, 0, 3), (14, 3, 3)]
+        );
+        // An axis cut from its start is cut all the same.
+        assert_eq!(
+            collect(&[4, 6], &[0, 0], &[2, 3]),
+            vec![(0, 0, 3), (6, 3, 3)]
+        );
+    }
+
+    #[test]
+    fn spanned_trailing_axes_fold_into_the_run() {
+        // Whole rows: one run per band, however many columns.
+        assert_eq!(collect(&[4, 6], &[1, 0], &[2, 6]), vec![(6, 0, 12)]);
+        // [2, 3, 4] with the last axis spanned: the pivot is axis 1, a run is
+        // `count[1] * dims[2]` elements, one per coordinate of axis 0.
+        assert_eq!(
+            collect(&[2, 3, 4], &[0, 1, 0], &[2, 2, 4]),
+            vec![(4, 0, 8), (16, 8, 8)]
+        );
+        // Everything: one run of the whole array.
+        assert_eq!(collect(&[4, 6], &[0, 0], &[4, 6]), vec![(0, 0, 24)]);
+    }
+
+    #[test]
+    fn an_empty_region_has_no_runs_and_a_scalar_has_one() {
+        assert!(collect(&[4, 6], &[1, 2], &[0, 3]).is_empty());
+        assert_eq!(collect(&[], &[], &[]), vec![(0, 0, 1)]);
+    }
+
+    #[test]
+    fn an_extent_that_overflows_errors_instead_of_wrapping() {
+        let err = runs(&[u64::MAX, u64::MAX], &[0, 0], &[1, 1]).unwrap_err();
+        assert!(matches!(err, FormatError::OffsetOverflow { .. }), "{err:?}");
+    }
+}

--- a/tests/allocation_bounds.rs
+++ b/tests/allocation_bounds.rs
@@ -91,6 +91,66 @@ fn windowed_row_read_allocates_on_the_order_of_the_window() {
 }
 
 #[test]
+fn regional_read_allocates_on_the_order_of_the_region() {
+    // The fixture of the row-window bound above, cut along its inner axes as
+    // well: a [64, 16, 4] box at (992, 8, 2) meets two leading bands and, on
+    // each inner axis, both chunk columns — eight 32 KiB chunks for a 32 KiB
+    // region. The ceiling rules out a reader that falls back to the whole
+    // dataset and cuts the box out of it; the output is the floor.
+    const N0: usize = 2048;
+    const ROW_ELEMS: usize = 32 * 8;
+    const DATASET_BYTES: usize = N0 * ROW_ELEMS * 8;
+
+    let data: Vec<f64> = (0..N0 * ROW_ELEMS).map(|i| i as f64).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    builder
+        .create_dataset("t")
+        .with_f64_data(&data)
+        .with_shape(&[N0 as u64, 32, 8])
+        .with_chunks(&[64, 16, 4])
+        .with_deflate(3);
+    builder.write(&path).unwrap();
+    drop(data);
+
+    let file = File::open_streaming(&path).unwrap();
+    let ds = file.dataset("t").unwrap();
+
+    let (start, count) = ([992u64, 8, 2], [64u64, 16, 4]);
+    let (region, measured) = measure("regional_read", || {
+        ds.read_f64_region(&start, &count).unwrap()
+    });
+
+    assert!(
+        measured.peak_bytes < (DATASET_BYTES / 4) as u64,
+        "peak allocation during the regional read must be bounded by the region, \
+         not the {DATASET_BYTES}-byte dataset; measured {measured}"
+    );
+
+    // The read's own output is in this measurement, so its size is a floor a
+    // measurement of nothing cannot reach.
+    const REGION_BYTES: usize = 64 * 16 * 4 * 8;
+    assert!(
+        measured.live_bytes >= REGION_BYTES as u64,
+        "the region this read returned is not in its own measurement, so the \
+         ceiling above is bounding something other than the read: {measured}"
+    );
+
+    // The region must still be the right elements, in row-major order.
+    let mut expected = Vec::with_capacity(REGION_BYTES / 8);
+    for i in 0..count[0] {
+        for j in 0..count[1] {
+            for k in 0..count[2] {
+                let flat = ((start[0] + i) * 32 + start[1] + j) * 8 + start[2] + k;
+                expected.push(flat as f64);
+            }
+        }
+    }
+    assert_eq!(region, expected);
+}
+
+#[test]
 fn windowed_vlen_string_read_allocates_on_the_order_of_the_window() {
     // ~4 MiB of variable-length string payload: 32k rows of 128-byte strings,
     // plus ~512 KiB of heap references in the dataset itself. The writer packs

--- a/tests/region_read.rs
+++ b/tests/region_read.rs
@@ -1,0 +1,625 @@
+//! Tests for the regional read API: `Dataset::read_raw_region` and the typed
+//! `read_*_region` helpers.
+//!
+//! The invariant under test everywhere: a region must be byte-for-byte the
+//! whole-dataset read cut to that box — for every layout (contiguous, chunked,
+//! inner-chunked grids, filtered), on both the in-memory and the streaming
+//! backend, and across edge regions (empty, one element, boxes straddling chunk
+//! boundaries on inner axes, the whole dataset). What separates a region from a
+//! row window is the axis it cuts, so every fixture here cuts an inner one.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use hdf5_pure::{Error, File, FileBuilder, FormatError, Source};
+
+/// Open the bytes produced by `build` on both backends: buffered (in-memory) and
+/// streaming (from a temp file). The regional read dispatches per backend, so
+/// every case is checked on both. The `TempDir` is returned so it outlives the
+/// streaming file handle.
+fn on_both_backends(build: impl FnOnce(&mut FileBuilder)) -> (File, File, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.h5");
+    let mut builder = FileBuilder::new();
+    build(&mut builder);
+    builder.write(&path).unwrap();
+
+    let buffered = File::open(&path).unwrap();
+    let streaming = File::open_streaming(&path).unwrap();
+    (buffered, streaming, dir)
+}
+
+/// `full` cut to the box `start .. start + count` of a row-major array of
+/// `dims`, the slow way — one element at a time — so the reader's run and chunk
+/// arithmetic is checked against something that has none.
+fn cut<T: Copy>(full: &[T], dims: &[u64], start: &[u64], count: &[u64]) -> Vec<T> {
+    let rank = dims.len();
+    let n = count.iter().product::<u64>() as usize;
+    let mut out = Vec::with_capacity(n);
+    let mut at = vec![0u64; rank];
+    for _ in 0..n {
+        let mut flat = 0u64;
+        for i in 0..rank {
+            flat = flat * dims[i] + start[i] + at[i];
+        }
+        out.push(full[flat as usize]);
+        for i in (0..rank).rev() {
+            at[i] += 1;
+            if at[i] < count[i] {
+                break;
+            }
+            at[i] = 0;
+        }
+    }
+    out
+}
+
+/// Regions worth checking for a dataset of `dims`: the whole, the first
+/// element, a box in the middle, the last element, an empty box at the far
+/// corner, and the last column — a band that spans every axis but the last.
+fn regions(dims: &[u64]) -> Vec<(Vec<u64>, Vec<u64>)> {
+    let rank = dims.len();
+    let zeros = vec![0u64; rank];
+    let ones = vec![1u64; rank];
+    let last: Vec<u64> = dims.iter().map(|&d| d - 1).collect();
+    let quarter: Vec<u64> = dims.iter().map(|&d| d / 4).collect();
+    let half: Vec<u64> = dims.iter().map(|&d| (d / 2).max(1)).collect();
+    let mut column_start = zeros.clone();
+    let mut column_count = dims.to_vec();
+    if rank > 0 {
+        column_start[rank - 1] = last[rank - 1];
+        column_count[rank - 1] = 1;
+    }
+    vec![
+        (zeros.clone(), dims.to_vec()),
+        (zeros, ones.clone()),
+        (quarter, half),
+        (last, ones),
+        (dims.to_vec(), vec![0; rank]),
+        (column_start, column_count),
+    ]
+}
+
+fn boxes(extra: &[(&[u64], &[u64])]) -> Vec<(Vec<u64>, Vec<u64>)> {
+    extra
+        .iter()
+        .map(|(s, c)| (s.to_vec(), c.to_vec()))
+        .collect()
+}
+
+fn check_f64(file: &File, name: &str, dims: &[u64], extra: &[(&[u64], &[u64])]) {
+    let ds = file.dataset(name).unwrap();
+    let full = ds.read_f64().unwrap();
+    for (start, count) in regions(dims).into_iter().chain(boxes(extra)) {
+        let region = ds
+            .read_f64_region(&start, &count)
+            .unwrap_or_else(|e| panic!("region {start:?} + {count:?}: {e}"));
+        assert_eq!(
+            region,
+            cut(&full, dims, &start, &count),
+            "region {start:?} + {count:?} of {dims:?}"
+        );
+    }
+}
+
+fn check_u8(file: &File, name: &str, dims: &[u64], extra: &[(&[u64], &[u64])]) {
+    let ds = file.dataset(name).unwrap();
+    let full = ds.read_u8().unwrap();
+    for (start, count) in regions(dims).into_iter().chain(boxes(extra)) {
+        let region = ds
+            .read_u8_region(&start, &count)
+            .unwrap_or_else(|e| panic!("region {start:?} + {count:?}: {e}"));
+        assert_eq!(
+            region,
+            cut(&full, dims, &start, &count),
+            "region {start:?} + {count:?} of {dims:?}"
+        );
+    }
+}
+
+fn check_u16(file: &File, name: &str, dims: &[u64], extra: &[(&[u64], &[u64])]) {
+    let ds = file.dataset(name).unwrap();
+    let full = ds.read_u16().unwrap();
+    for (start, count) in regions(dims).into_iter().chain(boxes(extra)) {
+        let region = ds
+            .read_u16_region(&start, &count)
+            .unwrap_or_else(|e| panic!("region {start:?} + {count:?}: {e}"));
+        assert_eq!(
+            region,
+            cut(&full, dims, &start, &count),
+            "region {start:?} + {count:?} of {dims:?}"
+        );
+    }
+}
+
+fn check_f32(file: &File, name: &str, dims: &[u64], extra: &[(&[u64], &[u64])]) {
+    let ds = file.dataset(name).unwrap();
+    let full = ds.read_f32().unwrap();
+    for (start, count) in regions(dims).into_iter().chain(boxes(extra)) {
+        let region = ds
+            .read_f32_region(&start, &count)
+            .unwrap_or_else(|e| panic!("region {start:?} + {count:?}: {e}"));
+        assert_eq!(
+            region,
+            cut(&full, dims, &start, &count),
+            "region {start:?} + {count:?} of {dims:?}"
+        );
+    }
+}
+
+#[test]
+fn contiguous_2d_cuts_columns_into_one_run_per_row() {
+    // [12, 10] contiguous: a box that cuts the inner axis is one storage run
+    // per row of the box; a box spanning the inner axis is a single run.
+    let dims = [12u64, 10];
+    let data: Vec<f64> = (0..120).map(|i| f64::from(i) * 0.5).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("c").with_f64_data(&data).with_shape(&dims);
+    });
+    let extra: &[(&[u64], &[u64])] = &[
+        (&[1, 2], &[3, 4]),
+        (&[0, 5], &[12, 5]),
+        (&[0, 0], &[12, 5]), // the first columns: cut from its start
+        (&[5, 0], &[1, 10]),
+        (&[11, 9], &[1, 1]),
+    ];
+    check_f64(&buffered, "c", &dims, extra);
+    check_f64(&streaming, "c", &dims, extra);
+}
+
+#[test]
+fn contiguous_3d_folds_the_axes_a_region_spans() {
+    // [4, 5, 6] u8: a box spanning the innermost axis folds it into the run of
+    // the axis above; a box cutting it does not.
+    let dims = [4u64, 5, 6];
+    let data: Vec<u8> = (0..120).map(|i| (i * 7 % 251) as u8).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("v").with_u8_data(&data).with_shape(&dims);
+    });
+    let extra: &[(&[u64], &[u64])] = &[
+        (&[1, 1, 0], &[2, 3, 6]),
+        (&[0, 0, 2], &[4, 5, 2]),
+        (&[2, 0, 0], &[1, 5, 6]),
+    ];
+    check_u8(&buffered, "v", &dims, extra);
+    check_u8(&streaming, "v", &dims, extra);
+}
+
+#[test]
+fn inner_chunked_2d_grid_straddles_chunks_on_both_axes() {
+    // [23, 10] in [4, 3] chunks, deflated: neither dimension is a multiple of
+    // its chunk extent, so the last chunk row and column overhang the dataset,
+    // and a box can start and end inside a chunk on either axis.
+    let dims = [23u64, 10];
+    let data: Vec<f64> = (0..230).map(|i| f64::from(i) * 0.5 - 3.0).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("e")
+            .with_f64_data(&data)
+            .with_shape(&dims)
+            .with_chunks(&[4, 3])
+            .with_deflate(4);
+    });
+    let extra: &[(&[u64], &[u64])] = &[
+        (&[3, 2], &[5, 5]),  // straddles a chunk boundary on both axes
+        (&[0, 9], &[23, 1]), // the last column, through every chunk row
+        (&[22, 9], &[1, 1]), // the corner element of the overhanging chunk
+        (&[4, 3], &[4, 3]),  // exactly one chunk
+        (&[2, 1], &[20, 8]), // most of the dataset, edges inside chunks
+    ];
+    check_f64(&buffered, "e", &dims, extra);
+    check_f64(&streaming, "e", &dims, extra);
+}
+
+#[test]
+fn a_band_of_whole_rows_is_the_row_window() {
+    // A region spanning every inner axis is a row window, and the two must
+    // agree element for element — the window is read through the region.
+    let data: Vec<f64> = (0..200).map(f64::from).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("d")
+            .with_f64_data(&data)
+            .with_shape(&[50, 4])
+            .with_chunks(&[8, 4])
+            .with_deflate(2);
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("d").unwrap();
+        for (start, count) in [(6u64, 5u64), (0, 8), (7, 1), (47, 3)] {
+            assert_eq!(
+                ds.read_f64_region(&[start, 0], &[count, 4]).unwrap(),
+                ds.read_f64_rows(start, count).unwrap(),
+                "rows {start}..{}",
+                start + count
+            );
+        }
+    }
+}
+
+#[test]
+fn frames_of_a_4d_stack_with_shuffle_and_deflate() {
+    // [10, 2, 6, 3] u16, one half-frame per chunk, shuffled and deflated: a
+    // frame is one region, and a box across frames meets a chunk in each.
+    let dims = [10u64, 2, 6, 3];
+    let data: Vec<u16> = (0..360).map(|i| (i * 37 % 65521) as u16).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("stack")
+            .with_u16_data(&data)
+            .with_shape(&dims)
+            .with_chunks(&[1, 2, 3, 3])
+            .with_shuffle()
+            .with_deflate(4);
+    });
+    let extra: &[(&[u64], &[u64])] = &[
+        (&[4, 0, 0, 0], &[1, 2, 6, 3]), // one frame
+        (&[2, 1, 2, 1], &[3, 1, 3, 2]), // a box across three frames
+        (&[9, 1, 5, 2], &[1, 1, 1, 1]), // the last element
+    ];
+    check_u16(&buffered, "stack", &dims, extra);
+    check_u16(&streaming, "stack", &dims, extra);
+}
+
+#[test]
+fn a_unit_leading_axis_windows_along_the_next_one() {
+    // The shape netCDF writers give a single time step — `[1, rows, columns]`
+    // — where a row window is the whole plane: a region cuts the second axis.
+    let dims = [1u64, 40, 9];
+    let data: Vec<f32> = (0..360).map(|i| i as f32 * 0.25).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("plane")
+            .with_f32_data(&data)
+            .with_shape(&dims)
+            .with_chunks(&[1, 8, 9])
+            .with_deflate(1);
+    });
+    let extra: &[(&[u64], &[u64])] = &[
+        (&[0, 13, 0], &[1, 10, 9]), // a band of rows, straddling two chunks
+        (&[0, 0, 4], &[1, 40, 2]),  // two columns through every chunk
+        (&[0, 32, 0], &[1, 8, 9]),  // exactly the last chunk
+    ];
+    check_f32(&buffered, "plane", &dims, extra);
+    check_f32(&streaming, "plane", &dims, extra);
+}
+
+/// A source that counts the bytes it serves. That counter is what makes the
+/// test below load-bearing rather than decorative: a read that quietly
+/// materialized the plane and cut the region out of it would still return the
+/// right numbers, and only the byte count separates that from reading the
+/// chunks the region meets.
+struct Counting {
+    bytes: Vec<u8>,
+    served: Arc<AtomicU64>,
+}
+
+impl Source for Counting {
+    fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), FormatError> {
+        let at = usize::try_from(offset).expect("the fixture fits this platform");
+        let end = at + buf.len();
+        if end > self.bytes.len() {
+            return Err(FormatError::UnexpectedEof {
+                expected: end,
+                available: self.bytes.len(),
+            });
+        }
+        buf.copy_from_slice(&self.bytes[at..end]);
+        self.served.fetch_add(buf.len() as u64, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[test]
+fn a_region_reads_only_the_chunks_it_meets() {
+    // [1, 400, 64] f32 in [1, 8, 64] chunks — 50 chunks of 2 KiB, unfiltered
+    // so bytes served are bytes stored. A 16-row band at row 100 meets three
+    // chunks (96..104, 104..112, 112..120); a whole-plane read would serve all
+    // fifty.
+    const ROWS: u64 = 400;
+    const COLS: u64 = 64;
+    const CHUNK_ROWS: u64 = 8;
+    const CHUNK_BYTES: u64 = CHUNK_ROWS * COLS * 4;
+    let data: Vec<f32> = (0..ROWS * COLS).map(|i| i as f32).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("plane.h5");
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("plane")
+            .with_f32_data(&data)
+            .with_shape(&[1, ROWS, COLS])
+            .with_chunks(&[1, CHUNK_ROWS, COLS]);
+        b.write(&path).unwrap();
+    }
+    let whole = std::fs::read(&path).unwrap();
+    let served = Arc::new(AtomicU64::new(0));
+    let file = File::from_source(Counting {
+        bytes: whole,
+        served: Arc::clone(&served),
+    })
+    .unwrap();
+    let ds = file.dataset("plane").unwrap();
+
+    let before = served.load(Ordering::Relaxed);
+    let band = ds.read_f32_region(&[0, 100, 0], &[1, 16, COLS]).unwrap();
+    let cost = served.load(Ordering::Relaxed) - before;
+    assert_eq!(
+        band,
+        cut(&data, &[1, ROWS, COLS], &[0, 100, 0], &[1, 16, COLS]),
+        "a region read through a source differs from what was written"
+    );
+    // Three chunks of data plus the chunk index, walked once. The index of
+    // fifty chunks is a few KiB; a plane materialized whole is 100 KiB.
+    let bound = 3 * CHUNK_BYTES + 16 * 1024;
+    assert!(
+        cost <= bound,
+        "a 16-row region served {cost} bytes, above its three chunks plus index ({bound})"
+    );
+
+    // The adjacent band starts in the chunk the first one finished on, which
+    // the cache retained; its other chunk is new.
+    let before = served.load(Ordering::Relaxed);
+    let next = ds.read_f32_region(&[0, 116, 0], &[1, 8, COLS]).unwrap();
+    let cost = served.load(Ordering::Relaxed) - before;
+    assert_eq!(
+        next,
+        cut(&data, &[1, ROWS, COLS], &[0, 116, 0], &[1, 8, COLS])
+    );
+    assert!(
+        cost <= CHUNK_BYTES,
+        "the adjacent band served {cost} bytes; the chunk it shares with its \
+         predecessor should come from the cache and only the new one from the source"
+    );
+}
+
+#[test]
+fn a_region_past_the_edge_or_of_another_rank_is_refused() {
+    let data: Vec<f64> = (0..48).map(f64::from).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("g")
+            .with_f64_data(&data)
+            .with_shape(&[6, 8])
+            .with_chunks(&[2, 4]);
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("g").unwrap();
+
+        // Past the edge on the inner axis: refused, naming the axis, rather
+        // than clamped to a 3×2 box the caller did not ask for.
+        let err = ds.read_raw_region(&[2, 6], &[3, 3]).unwrap_err();
+        match &err {
+            Error::InvalidRegion(msg) => {
+                assert!(msg.contains("axis 1") && msg.contains("6..9"), "{msg}");
+            }
+            other => panic!("expected InvalidRegion, got {other:?}"),
+        }
+        assert!(err.to_string().contains("region does not fit"), "{err}");
+
+        // The wrong number of axes.
+        assert!(matches!(
+            ds.read_f64_region(&[2], &[3, 3]),
+            Err(Error::InvalidRegion(_))
+        ));
+        assert!(matches!(
+            ds.read_f64_region(&[0, 0, 0], &[6, 8, 1]),
+            Err(Error::InvalidRegion(_))
+        ));
+
+        // One past the edge is past the edge.
+        assert!(matches!(
+            ds.read_raw_region(&[0, 7], &[6, 2]),
+            Err(Error::InvalidRegion(_))
+        ));
+
+        // A zero count anywhere is an empty read, at the far corner included.
+        assert!(ds.read_f64_region(&[2, 3], &[0, 3]).unwrap().is_empty());
+        assert!(ds.read_f64_region(&[6, 8], &[0, 0]).unwrap().is_empty());
+        assert!(ds.read_raw_region(&[0, 0], &[6, 0]).unwrap().is_empty());
+    }
+}
+
+#[test]
+fn typed_regions_match_their_whole_reads() {
+    let dims = [6u64, 5, 4];
+    let n = 120usize;
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("i16")
+            .with_i16_data(&(0..n).map(|i| i as i16 - 60).collect::<Vec<_>>())
+            .with_shape(&dims)
+            .with_chunks(&[2, 5, 2]);
+        b.create_dataset("u16")
+            .with_u16_data(&(0..n).map(|i| i as u16 * 3).collect::<Vec<_>>())
+            .with_shape(&dims)
+            .with_chunks(&[3, 2, 4])
+            .with_deflate(1);
+        b.create_dataset("i32")
+            .with_i32_data(&(0..n).map(|i| i as i32 * -7).collect::<Vec<_>>())
+            .with_shape(&dims);
+        b.create_dataset("u8")
+            .with_u8_data(&(0..n).map(|i| i as u8).collect::<Vec<_>>())
+            .with_shape(&dims)
+            .with_chunks(&[6, 1, 4]);
+        b.create_dataset("f32")
+            .with_f32_data(&(0..n).map(|i| i as f32 / 3.0).collect::<Vec<_>>())
+            .with_shape(&dims)
+            .with_chunks(&[1, 5, 4])
+            .with_shuffle()
+            .with_deflate(3);
+    });
+    let (start, count) = (&[1u64, 1, 1], &[4u64, 3, 2]);
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("i16").unwrap();
+        assert_eq!(
+            ds.read_i16_region(start, count).unwrap(),
+            cut(&ds.read_i16().unwrap(), &dims, start, count)
+        );
+        let ds = file.dataset("u16").unwrap();
+        assert_eq!(
+            ds.read_u16_region(start, count).unwrap(),
+            cut(&ds.read_u16().unwrap(), &dims, start, count)
+        );
+        let ds = file.dataset("i32").unwrap();
+        assert_eq!(
+            ds.read_i32_region(start, count).unwrap(),
+            cut(&ds.read_i32().unwrap(), &dims, start, count)
+        );
+        // The widening decoders read the same file.
+        assert_eq!(
+            ds.read_i64_region(start, count).unwrap(),
+            cut(&ds.read_i64().unwrap(), &dims, start, count)
+        );
+        assert_eq!(
+            ds.read_f64_region(start, count).unwrap(),
+            cut(&ds.read_f64().unwrap(), &dims, start, count)
+        );
+        let ds = file.dataset("u8").unwrap();
+        assert_eq!(
+            ds.read_u8_region(start, count).unwrap(),
+            cut(&ds.read_u8().unwrap(), &dims, start, count)
+        );
+        assert_eq!(
+            ds.read_i8_region(start, count).unwrap(),
+            cut(&ds.read_i8().unwrap(), &dims, start, count)
+        );
+        assert_eq!(
+            ds.read_u32_region(start, count).unwrap(),
+            cut(&ds.read_u32().unwrap(), &dims, start, count)
+        );
+        assert_eq!(
+            ds.read_u64_region(start, count).unwrap(),
+            cut(&ds.read_u64().unwrap(), &dims, start, count)
+        );
+        let ds = file.dataset("f32").unwrap();
+        assert_eq!(
+            ds.read_f32_region(start, count).unwrap(),
+            cut(&ds.read_f32().unwrap(), &dims, start, count)
+        );
+    }
+}
+
+#[test]
+fn read_raw_region_matches_read_raw() {
+    // The raw path is what every typed helper decodes from; its bytes must be
+    // the whole read's bytes cut element by element.
+    let dims = [9u64, 7];
+    let data: Vec<f64> = (0..63).map(|i| f64::from(i) * 1.5).collect();
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("r")
+            .with_f64_data(&data)
+            .with_shape(&dims)
+            .with_chunks(&[4, 3])
+            .with_deflate(2);
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("r").unwrap();
+        let raw = ds.read_raw().unwrap();
+        let (elems, rest) = raw.as_chunks::<8>();
+        assert!(rest.is_empty(), "f64 elements are whole");
+        for (start, count) in regions(&dims)
+            .into_iter()
+            .chain(boxes(&[(&[2, 2], &[5, 3])]))
+        {
+            let expected: Vec<u8> = cut(elems, &dims, &start, &count).concat();
+            assert_eq!(
+                ds.read_raw_region(&start, &count).unwrap(),
+                expected,
+                "region {start:?} + {count:?}"
+            );
+        }
+        // The whole dataset as a region is the whole read.
+        assert_eq!(ds.read_raw_region(&[0, 0], &dims).unwrap(), raw);
+    }
+}
+
+#[test]
+fn vlen_strings_region_resolves_only_its_own_cells() {
+    // Variable-length strings are heap-backed; `read_string_region` resolves
+    // the references of the region's cells, in the region's row-major order.
+    let words = [
+        "a", "bb", "ccc", "dddd", "e", "ff", "ggg", "hhhh", "i", "jj", "kkk", "llll",
+    ];
+    let (buffered, streaming, _dir) = on_both_backends(|b| {
+        b.create_dataset("grid")
+            .with_vlen_strings(&words)
+            .with_shape(&[3, 4]);
+    });
+    for file in [&buffered, &streaming] {
+        let ds = file.dataset("grid").unwrap();
+        let all = ds.read_string().unwrap();
+        assert_eq!(all.len(), 12);
+        assert_eq!(
+            ds.read_string_region(&[1, 1], &[2, 2]).unwrap(),
+            vec!["ff", "ggg", "jj", "kkk"]
+        );
+        assert_eq!(
+            ds.read_string_region(&[0, 3], &[3, 1]).unwrap(),
+            vec!["dddd", "hhhh", "llll"]
+        );
+        assert_eq!(ds.read_string_region(&[0, 0], &[3, 4]).unwrap(), all);
+        assert!(ds.read_string_region(&[1, 1], &[0, 2]).unwrap().is_empty());
+
+        // Lockstep with the raw path: the string count of a region equals the
+        // number of elements `read_raw_region` reads for the same region.
+        let elem = ds.datatype().unwrap().type_size() as usize;
+        for (start, count) in [([1u64, 1], [2u64, 2]), ([0, 3], [3, 1]), ([2, 0], [1, 4])] {
+            let n_strings = ds.read_string_region(&start, &count).unwrap().len();
+            let n_raw = ds.read_raw_region(&start, &count).unwrap().len() / elem;
+            assert_eq!(n_strings, n_raw, "region {start:?} + {count:?}");
+        }
+    }
+}
+
+#[test]
+fn a_region_skips_the_chunk_columns_it_misses() {
+    // [256, 256] f32 in [32, 32] chunks: an 8×8 grid of 4 KiB chunks, 256 KiB
+    // in all, unfiltered so bytes served are bytes stored. What a row window
+    // cannot do is skip a chunk column; the byte count is what shows a region
+    // doing it.
+    const SIDE: u64 = 256;
+    const CHUNK: u64 = 32;
+    const CHUNK_BYTES: u64 = CHUNK * CHUNK * 4;
+    let data: Vec<f32> = (0..SIDE * SIDE).map(|i| i as f32).collect();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("grid.h5");
+    {
+        let mut b = FileBuilder::new();
+        b.create_dataset("grid")
+            .with_f32_data(&data)
+            .with_shape(&[SIDE, SIDE])
+            .with_chunks(&[CHUNK, CHUNK]);
+        b.write(&path).unwrap();
+    }
+    let whole = std::fs::read(&path).unwrap();
+    let served = Arc::new(AtomicU64::new(0));
+    let file = File::from_source(Counting {
+        bytes: whole,
+        served: Arc::clone(&served),
+    })
+    .unwrap();
+    let ds = file.dataset("grid").unwrap();
+
+    // A box inside one chunk column and two chunk rows: two chunks. The rows
+    // it spans hold sixteen chunks, the dataset sixty-four.
+    let before = served.load(Ordering::Relaxed);
+    let inner = ds.read_f32_region(&[100, 100], &[50, 20]).unwrap();
+    let cost = served.load(Ordering::Relaxed) - before;
+    assert_eq!(inner, cut(&data, &[SIDE, SIDE], &[100, 100], &[50, 20]));
+    let bound = 2 * CHUNK_BYTES + 16 * 1024;
+    assert!(
+        cost <= bound,
+        "a box inside one chunk column served {cost} bytes, above its two chunks plus index ({bound}); \
+         the rows it spans would be {} bytes",
+        16 * CHUNK_BYTES
+    );
+
+    // A whole chunk column: eight chunks, two of them the cache still holds
+    // from the box above, and the index already walked.
+    let before = served.load(Ordering::Relaxed);
+    let column = ds.read_f32_region(&[0, 96], &[SIDE, 32]).unwrap();
+    let cost = served.load(Ordering::Relaxed) - before;
+    assert_eq!(column, cut(&data, &[SIDE, SIDE], &[0, 96], &[SIDE, 32]));
+    assert!(
+        cost <= 6 * CHUNK_BYTES,
+        "a chunk column served {cost} bytes; at most six new chunks were due"
+    );
+}

--- a/tests/region_read_crosscheck.rs
+++ b/tests/region_read_crosscheck.rs
@@ -1,0 +1,184 @@
+// Crosschecks link the reference HDF5 C library (the `hdf5-metno` dev-dependency),
+// which is gated to 64-bit little-endian targets; skip them elsewhere so the pure-Rust
+// suite can run under `cross test --target i686-...`.
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
+//! The reference C library as the oracle for a regional read.
+//!
+//! It writes the fixtures — the compact layout among them, which this crate's
+//! writer never produces — and reads every region back through
+//! `H5Sselect_hyperslab`, so a region here is checked against the selection the
+//! format defines rather than against this crate's own whole read cut in Rust,
+//! which is what `tests/region_read.rs` does.
+
+use hdf5::dataset::Layout as CLayout;
+use hdf5::{Hyperslab, Selection, SliceOrIndex};
+use hdf5_pure::{File, Layout};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use tempfile::tempdir;
+
+/// The C library is not thread-safe across concurrent file handles in this
+/// harness; serialize every test that touches it.
+static C_LIB: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn c_lib_guard() -> MutexGuard<'static, ()> {
+    C_LIB
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+const ROWS: usize = 15;
+const COLS: usize = 11;
+
+fn values() -> Vec<f64> {
+    (0..ROWS * COLS).map(|i| i as f64 * 0.5 - 7.0).collect()
+}
+
+/// The C library's read of the box `start .. start + count` of a 2-D dataset,
+/// through a hyperslab selection at unit stride. An axis one element wide is
+/// selected by index, which drops it from the result, so the typed slice
+/// readers see a rank they can name: a vector for one remaining axis, a matrix
+/// for two. A box one element wide on both axes leaves no axis and is not among
+/// the boxes checked here.
+fn c_region(ds: &hdf5::Dataset, start: [u64; 2], count: [u64; 2]) -> Vec<f64> {
+    let axes: Vec<SliceOrIndex> = (0..2)
+        .map(|i| {
+            if count[i] == 1 {
+                SliceOrIndex::Index(start[i] as usize)
+            } else {
+                SliceOrIndex::SliceCount {
+                    start: start[i] as usize,
+                    step: 1,
+                    count: count[i] as usize,
+                    block: 1,
+                }
+            }
+        })
+        .collect();
+    let remaining = axes
+        .iter()
+        .filter(|a| !matches!(a, SliceOrIndex::Index(_)))
+        .count();
+    let selection = Selection::from(Hyperslab::from(axes));
+    match remaining {
+        1 => ds.read_slice_1d::<f64, _>(selection).unwrap().to_vec(),
+        2 => ds
+            .read_slice_2d::<f64, _>(selection)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect(),
+        _ => unreachable!("BOXES leave one or two axes"),
+    }
+}
+
+/// Boxes of a `[15, 11]` dataset: the whole, one straddling chunk boundaries on
+/// both axes of a `[4, 3]` grid, the last column, exactly one chunk, most of
+/// the dataset with edges inside chunks, one whole row, a two-wide column, and
+/// the first four columns — an inner axis cut from its start.
+const BOXES: [([u64; 2], [u64; 2]); 8] = [
+    ([0, 0], [15, 11]),
+    ([0, 0], [15, 4]),
+    ([3, 2], [5, 5]),
+    ([0, 10], [15, 1]),
+    ([4, 3], [4, 3]),
+    ([2, 1], [12, 9]),
+    ([7, 0], [1, 11]),
+    ([5, 4], [8, 2]),
+];
+
+fn check(path: &std::path::Path, name: &str) {
+    let c = hdf5::File::open(path).unwrap();
+    let c_ds = c.dataset(name).unwrap();
+    for file in [
+        File::open(path).unwrap(),
+        File::open_streaming(path).unwrap(),
+    ] {
+        let ds = file.dataset(name).unwrap();
+        for (start, count) in BOXES {
+            assert_eq!(
+                ds.read_f64_region(&start, &count).unwrap(),
+                c_region(&c_ds, start, count),
+                "{name}: region {start:?} + {count:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn c_regions_of_every_layout_match_the_c_librarys_hyperslab_read() {
+    let _c = c_lib_guard();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("regions.h5");
+    let data = values();
+    {
+        let f = hdf5::File::create(&path).unwrap();
+        f.new_dataset::<f64>()
+            .layout(CLayout::Compact)
+            .shape((ROWS, COLS))
+            .create("compact")
+            .unwrap()
+            .write_raw(&data)
+            .unwrap();
+        f.new_dataset::<f64>()
+            .layout(CLayout::Contiguous)
+            .shape((ROWS, COLS))
+            .create("contiguous")
+            .unwrap()
+            .write_raw(&data)
+            .unwrap();
+        f.new_dataset::<f64>()
+            .chunk((4, 3))
+            .deflate(4)
+            .shape((ROWS, COLS))
+            .create("chunked")
+            .unwrap()
+            .write_raw(&data)
+            .unwrap();
+        f.close().unwrap();
+    }
+    // The compact source really is compact, or this test proves nothing about
+    // that arm of the reader.
+    {
+        let f = File::open(&path).unwrap();
+        assert!(
+            matches!(
+                f.dataset("compact").unwrap().layout().unwrap(),
+                Layout::Compact { .. }
+            ),
+            "expected a compact source layout"
+        );
+    }
+    for name in ["compact", "contiguous", "chunked"] {
+        check(&path, name);
+    }
+}
+
+/// A dataset the C library created and never wrote has no storage behind it;
+/// a region of it is the fill value, the same answer the C library gives for
+/// the hyperslab.
+#[test]
+fn c_regions_of_unwritten_storage_read_as_the_fill_the_c_library_reads() {
+    let _c = c_lib_guard();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("blank.h5");
+    {
+        let f = hdf5::File::create(&path).unwrap();
+        f.new_dataset::<f64>()
+            .chunk((4, 3))
+            .fill_value(-1.5f64)
+            .shape((ROWS, COLS))
+            .create("chunked")
+            .unwrap();
+        f.new_dataset::<f64>()
+            .layout(CLayout::Contiguous)
+            .fill_value(2.25f64)
+            .shape((ROWS, COLS))
+            .create("contiguous")
+            .unwrap();
+        f.close().unwrap();
+    }
+    for name in ["chunked", "contiguous"] {
+        check(&path, name);
+    }
+}


### PR DESCRIPTION
Closes #465.

## Why

`read_raw_rows` and the typed `read_*_rows` cut the leading dimension only. That is the
right shape for a table or a signal, and the wrong one for three things I keep meeting:

- a dataset whose leading axis has length one — a netCDF-4 granule written with a
  unit `time` axis, Sentinel-5P L2 for one, is `[1, rows, columns]` — where a row
  window is the whole plane;
- a tile of an image, or a frame of a stack, where the axis to cut is not the first;
- a column band, which no row window expresses at all.

I hit the first one reading Sentinel-5P granules (`[1, 4172, 450]` f32) in a
WebAssembly module fed by host byte ranges: the only window the crate offered was the
7.5 MB plane, for a 256-row strip of 0.46 MB.

## What

- `Dataset::read_raw_region(start, count)` and the typed `read_f64_region` …
  `read_u64_region` / `read_string_region`: the block `H5Sselect_hyperslab` selects at
  unit stride, or the `start`/`count` pair of `nc_get_vara`. The result is row-major in
  the shape `count`, byte-for-byte the whole read cut to that box.
- A region past an edge is refused with the new `Error::InvalidRegion` naming the axis,
  rather than clamped. A row window can clamp because its rows keep their inner shape
  however it is cut; a clamped region would come back in a shape the caller did not ask
  for, and a caller who wants clamping computes it in one line. `Error` is
  `#[non_exhaustive]`, so the variant is additive.
- The row window is now the region that spans every inner dimension, read through the
  same body: `read_dataset_raw_rows` builds `start`/`count` and calls
  `read_dataset_raw_region`. The row-specific chunked reader and `row_band_copy` are gone;
  every existing row-window test runs over the new path.
- Chunked storage: a chunk contributes the box it shares with the region, moved by one
  kernel (`copy_box`) that folds the trailing axes the box spans in both arrays into a
  single run — a band of whole rows is one copy, as before; an inner-split chunk moves a
  row at a time, as before. Index walked once and cached; spans, scratch and
  `CachePass` unchanged.
- Contiguous and compact storage: the region is a sequence of runs (`region::runs`),
  one per coordinate of the axes before the last unspanned one; each run is one bounded
  `read_at` into the output, so a column band of a contiguous dataset is one read per
  row of the band and never a whole-row band in memory.

## Tests

- `tests/region_read.rs`: a region equals the whole read cut element by element, on both
  backends, for contiguous 2-D/3-D, an inner-chunked deflated grid with overhang, a 4-D
  shuffled+deflated stack, the `[1, rows, columns]` shape, vlen strings, every typed
  reader, and the raw path; a band of whole rows equals `read_*_rows`; refusals name the
  axis; zero counts are empty.
- `a_region_reads_only_the_chunks_it_meets` counts bytes through a `Source`: a 16-row
  band of a 50-chunk plane serves its three chunks plus the index, and the adjacent band
  serves at most one new chunk — the boundary chunk comes from the cache. Only the byte
  count separates this from a reader that materializes the plane and cuts.
- `tests/region_read_crosscheck.rs`: the C library writes compact, contiguous and
  chunked fixtures — compact this crate's writer never produces — and reads every box
  back through a hyperslab selection; ours must match, including over never-written
  storage with a fill value.
- `tests/allocation_bounds.rs`: a region cutting inner axes peaks well under the
  dataset — the ceiling rules out a whole-read fallback — with the output as the floor.
- Unit tests: `region::fits`/`runs`, `contiguous_tail`, `copy_box` (placement, short
  chunk clamp, empty box), the crafted-file guards carried over from the row reader
  (rank 0, element-count overflow, impossible chunk geometry, unallocated index), and an
  unallocated contiguous region reading as fill.

## Docs

`docs/guide/reading.md` gains "Reading a region"; `docs/guide/streaming.md` and the
README gain a paragraph; `docs/reference/property-support.md` gains the row for the
cache signal. `CHANGELOG.md` has an `[Unreleased]` entry. Additive only, so no version
bump.

## What I ran

`cargo test --lib` (1136), `--test region_read` (12), `--test region_read_crosscheck` (2),
`--test partial_read` (16), `--test typed_whole_read` (7), `--test allocation_bounds` (17),
`--test streaming_reader` (7), `--test chunk_cache_stats` (13), `cargo test --doc` (39),
`cargo nextest run --locked` on the default feature set (2394 tests across 132 binaries)
and with `--features zfp` (2437),
`cargo clippy --features "serde ndarray" --all-targets -- -D warnings`, `cargo fmt --all
--check`, and `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --features "provenance
zfp ndarray serde"` — all clean.

Mutations, each applied by hand and caught by the named tests: `contiguous_tail` never
folding (the `contiguous_tail` unit test — a performance property, so nothing else
moves); the chunk overlap test looking at axis 0 only (both byte-counting tests); the
`runs` pivot needing both a nonzero start and a short count (the `runs` unit test — this
one survived until a box cut from its start on an inner axis was added, which is why
`[0, 0] + [12, 5]`, `[0, 0] + [2, 3]` and the crosscheck's `[0, 0] + [15, 4]` are
there); `fits` allowing one element past the edge (`a_region_past_the_edge…` and the
`fits` unit test); `copy_box` ignoring `dst_origin` (the `copy_box` unit test and the
streaming window tests in `reader.rs`); the row-window wrapper reading to the end
(`reader.rs` window tests); a contiguous run landing at its element offset instead of
its byte offset (`contiguous_2d…`, the vlen and typed region tests); the run odometer
wrapping one step late (`contiguous_3d…`, the typed region test); the region bypassing
the chunk cache (both byte-counting tests).

Not run here: the `ndarray`, `serde` and combined feature configurations of the CI
matrix — this 7 GB machine runs out of memory building the test binaries a second and
third time over, so those are left to CI; `--all-features`, which turns on
`matio-crosscheck` and links the system `libmatio` this machine lacks (CI excludes that
feature on purpose); and the heap baseline, pinned to aarch64 macOS. The change touches
no feature-gated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01813gJe3XZfE9zQA3RpJDRf
