### PR TITLE
Release v0.44.1-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "hdf5-pure"
-version = "0.44.0"
+version = "0.44.1-rc.1"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdf5-pure"
-version = "0.44.0"
+version = "0.44.1-rc.1"
 edition = "2024"
 # `std::fs::File` advisory locking (used by the write/edit/read open paths for
 # concurrent-writer detection, issue #73) stabilized in Rust 1.89.


### PR DESCRIPTION
Release candidate v0.44.1-rc.1. The changelog stays under [Unreleased] until the final release.


### Fixed

- Files HDF5 2.0 writes under its latest library bounds are read. Their compound and array datatypes were rejected with `FormatError::InvalidDatatypeVersion`.
- `Group::named_datatype_references` reports the count a version 1 object header stores, where it reported 1 for every committed datatype in such a header.

### Changed

- Licensed under MIT or Apache-2.0, at your option, where it was MIT alone ([#511](https://github.com/CramBL/hdf5-pure/pull/511)).
- The repository moved to `CramBL/hdf5-pure`, and the documentation site to <https://crambl.github.io/hdf5-pure/>.
- Releases are published to crates.io through Trusted Publishing from the repository's Release workflow, with no long-lived token.


After merging, run the Release workflow with version 0.44.1-rc.1.
