### PR TITLE
Drop the portability guide's comparison with the reference library

### DIFF
--- a/docs/guide/portability.md
+++ b/docs/guide/portability.md
@@ -1,9 +1,8 @@
 `hdf5-pure` is pure Rust with no C dependencies and no build-time linkage to
-libhdf5, which gives it three portability properties that the reference library
-cannot offer: it compiles to WebAssembly, it compiles for `no_std` targets with
-`alloc`, and the files it produces are byte-compatible with the rest of the HDF5
-ecosystem. This page covers all three, including what is and is not available
-without `std`.
+libhdf5. It compiles to WebAssembly, it compiles for `no_std` targets with
+`alloc`, and it writes the standard on-disk format, which the reference HDF5 C
+library, `h5py` and MATLAB read. This page covers all three, including which
+capabilities `std` gates.
 
 ## WebAssembly
 


### PR DESCRIPTION
The opening's claim that the reference library cannot compile to WebAssembly
was wrong: libhdf5 compiles to WebAssembly, and the HDF Group's own browser
viewer runs on such a build. The paragraph lists what this crate offers, since
the guide describes the crate on its own terms.

Proof that libhdf5 compiles to WASM: https://myhdf5.hdfgroup.org/

... It's just that their WASM build is complicated and error prone. I've reported like 4 or 5 HDF5 reading bugs on the page the last few years.
