### PR TITLE
Ignore record padding when reading an attribute with a null dataspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `Group::attrs` and `Dataset::attrs` read an attribute with a null dataspace in a version 1 object header as an empty array, where trailing record padding was previously returned as the value. Truncated attribute payloads are rejected with `FormatError::UnexpectedEof` ([#448](https://github.com/CramBL/hdf5-pure/issues/448)).
+
 ## [0.44.2] - 2026-09-10
 
 ### Changed

--- a/crates/crosscheck/tests/null_attr_padding.rs
+++ b/crates/crosscheck/tests/null_attr_padding.rs
@@ -1,0 +1,33 @@
+#![cfg(all(not(target_pointer_width = "32"), target_endian = "little"))]
+#![cfg(feature = "__hdf5-1.10")]
+
+use hdf5::Extents;
+
+use hdf5_pure::AttrValue;
+use hdf5_pure::File;
+
+#[test]
+fn a_null_dataspace_attribute_in_a_padded_header_record_reads_back_holding_nothing() {
+    // The C library writes version 1 headers with 8-byte record padding under `libver_earliest`.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("null-earliest.h5");
+    {
+        let file = hdf5::File::with_options()
+            .with_fapl(|p| p.libver_earliest())
+            .create(&path)
+            .unwrap();
+        file.new_attr::<i32>()
+            .shape(Extents::Null)
+            .create("empty")
+            .unwrap();
+        file.new_attr::<u8>()
+            .shape(Extents::Null)
+            .create("empty_u8")
+            .unwrap();
+        file.close().unwrap();
+    }
+
+    let attrs = File::open(&path).unwrap().root().attrs().unwrap();
+    assert_eq!(attrs.get("empty"), Some(&AttrValue::I32Array(Vec::new())));
+    assert_eq!(attrs.get("empty_u8"), Some(&AttrValue::U8Array(Vec::new())));
+}

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -458,7 +458,28 @@ pub fn message_shares_a_field(data: &[u8]) -> bool {
     }
 }
 
-/// Compute raw data size based on dataspace and datatype, then extract from message bytes.
+/// Reads an attribute's value bytes from its message, sized by the datatype
+/// and dataspace alone.
+///
+/// The Data field has no length of its own: the datatype and dataspace
+/// descriptions define its size ("The Attribute Message" of the [format
+/// specification, version 4.0][spec-attr]). A null dataspace has no elements
+/// ("The Dataspace Message" of the [format specification, version 4.0][spec-space]),
+/// so the field is empty. Any bytes past it in a version 1 object header
+/// record are the record's alignment padding: header messages are aligned on
+/// 8-byte boundaries there ("Version 1 Data Object Header Prefix" of the [format
+/// specification, version 4.0][spec-hdr]).
+///
+/// # Errors
+///
+/// Returns [`FormatError::OffsetOverflow`] if the element count times the
+/// element size overflows a `u64`, [`FormatError::ValueTooLargeForPlatform`]
+/// if that size does not fit a `usize`, and [`FormatError::UnexpectedEof`] if
+/// the message holds fewer bytes than the datatype and dataspace describe.
+///
+/// [spec-attr]: https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html#subsubsec_fmt4_dataobject_hdr_msg_attribute
+/// [spec-space]: https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html#subsubsec_fmt4_dataobject_hdr_msg_simple
+/// [spec-hdr]: https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html#subsubsec_fmt4_dataobject_hdr_prefix_one
 fn compute_raw_data(
     data: &[u8],
     pos: usize,
@@ -466,7 +487,7 @@ fn compute_raw_data(
     datatype: &Datatype,
 ) -> Result<Vec<u8>, FormatError> {
     let num_elements = dataspace.num_elements();
-    let elem_size = datatype.type_size() as u64;
+    let elem_size = u64::from(datatype.type_size());
     let expected_size = num_elements
         .checked_mul(elem_size)
         .ok_or(FormatError::OffsetOverflow {
@@ -474,13 +495,11 @@ fn compute_raw_data(
             length: elem_size,
         })?
         .to_usize()?;
-    let available = data.len().saturating_sub(pos);
-    let take = expected_size.min(available);
-    Ok(if take > 0 {
-        data[pos..pos + take].to_vec()
-    } else if available > 0 {
-        // Fallback: take whatever is available (e.g., for VL types where type_size may not match)
-        data[pos..].to_vec()
+    ensure_len(data, pos, expected_size)?;
+    Ok(if expected_size > 0 {
+        data.get(pos..pos + expected_size)
+            .map(<[u8]>::to_vec)
+            .unwrap_or_default()
     } else {
         Vec::new()
     })
@@ -1278,7 +1297,7 @@ mod tests {
         data.extend_from_slice(name);
         data.extend_from_slice(&dt_field);
         data.extend_from_slice(&ds_bytes);
-        data.extend_from_slice(&7i32.to_le_bytes());
+        data.extend_from_slice(&7.0f64.to_le_bytes());
         data
     }
 
@@ -1474,5 +1493,66 @@ mod tests {
         let attr = AttributeMessage::parse(&data, 8).unwrap();
         let strs = attr.read_as_strings().unwrap();
         assert_eq!(strs, vec!["abcd", "EFGH"]);
+    }
+
+    #[test]
+    fn a_null_dataspace_attribute_ignores_record_padding() {
+        // Five trailing zero bytes provide the record's 8-byte alignment padding.
+        let name = b"empty\0";
+        let dt_bytes = build_f64_dt();
+        let ds_bytes = vec![2u8, 0, 0, 2];
+
+        let name_size = u16::try_from(name.len()).unwrap();
+        let dt_size = u16::try_from(dt_bytes.len()).unwrap();
+        let ds_size = u16::try_from(ds_bytes.len()).unwrap();
+
+        let mut data = Vec::new();
+        data.push(3);
+        data.push(0);
+        data.extend_from_slice(&name_size.to_le_bytes());
+        data.extend_from_slice(&dt_size.to_le_bytes());
+        data.extend_from_slice(&ds_size.to_le_bytes());
+        data.push(1);
+        data.extend_from_slice(name);
+        data.extend_from_slice(&dt_bytes);
+        data.extend_from_slice(&ds_bytes);
+        data.extend_from_slice(&[0u8; 5]);
+
+        let attr = AttributeMessage::parse(&data, 8).unwrap();
+        assert_eq!(attr.raw_data, Vec::<u8>::new());
+    }
+
+    #[test]
+    fn a_truncated_attribute_payload_is_rejected() {
+        let name = b"truncated\0";
+        let dt_bytes = build_f64_dt();
+        let ds_bytes = build_scalar_ds();
+
+        let name_size = u16::try_from(name.len()).unwrap();
+        let dt_size = u16::try_from(dt_bytes.len()).unwrap();
+        let ds_size = u16::try_from(ds_bytes.len()).unwrap();
+
+        let mut data = Vec::new();
+        data.push(3);
+        data.push(0);
+        data.extend_from_slice(&name_size.to_le_bytes());
+        data.extend_from_slice(&dt_size.to_le_bytes());
+        data.extend_from_slice(&ds_size.to_le_bytes());
+        data.push(1);
+        data.extend_from_slice(name);
+        data.extend_from_slice(&dt_bytes);
+        data.extend_from_slice(&ds_bytes);
+        data.extend_from_slice(&[0u8; 4]);
+
+        let err = AttributeMessage::parse(&data, 8).unwrap_err();
+        let FormatError::UnexpectedEof {
+            expected,
+            available,
+        } = err
+        else {
+            panic!("expected UnexpectedEof, got {err:?}");
+        };
+        assert_eq!(available, data.len());
+        assert_eq!(expected, data.len() + 4);
     }
 }

--- a/src/reference_patch.rs
+++ b/src/reference_patch.rs
@@ -1031,6 +1031,7 @@ mod tests {
             size: 16,
             ref_type: ReferenceType::Object,
         };
+        attr.raw_data = vec![0u8; 16];
         let region = message_record(
             MessageType::Attribute,
             &attr.serialize_v3(crate::file_writer::LENGTH_SIZE),


### PR DESCRIPTION
Resolves #448 

- **Assert that a null dataspace attribute in a padded record reads back**
- **Ignore record padding when reading an attribute with a null dataspace**
