### PR TITLE
Fix B-tree v1 type-1 chunk offset key sizing and parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `Dataset::read` and `Group::get` read files whose superblock pairs unequal address and length widths, where raw data chunk B-tree v1 keys, symbol table entries, and group B-tree keys were previously sized by the wrong width, resulting in corrupted reads or parse failures ([#546](https://github.com/CramBL/hdf5-pure/issues/546)).
 - Fletcher32 checksum calculation folds running sums to 16 bits matching libhdf5's `H5_checksum_fletcher32`, where chunks whose sums folded to non-zero multiples of 65,535 previously caused `FormatError::Fletcher32Mismatch` on files written by libhdf5 or caused libhdf5 to reject chunks written by `with_fletcher32` ([#428](https://github.com/CramBL/hdf5-pure/issues/428)).
 - `Group::attrs` and `Dataset::attrs` read an attribute with a null dataspace in a version 1 object header as an empty array, where trailing record padding was previously returned as the value. Truncated attribute payloads are rejected with `FormatError::UnexpectedEof` ([#448](https://github.com/CramBL/hdf5-pure/issues/448)).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +364,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "half"
@@ -452,6 +487,7 @@ dependencies = [
  "hdf5-pure",
  "ndarray",
  "proptest",
+ "rstest",
  "serde",
  "tempfile",
  "test-util",
@@ -694,6 +730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +920,50 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948203e6d13b83e51a90d7cf236dd58a0065f23f4b902f00f306e7eb2bd09b9c"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d92eaf7b6e51e12471d71ddc72608e7151573de44099aacfbb1128177c0da4"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+# The `:main` images carry the prefixed cross linker (`i686-linux-gnu-gcc`,
+# `s390x-linux-gnu-gcc`) that the `portability::test-*` recipes set. The
+# `:0.2.5` release images predate it. Pinned to the current `:main` digests.
+# Bump both together when cross releases again.
+[target.i686-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i686-unknown-linux-gnu@sha256:ffd906743f91aa05afcda004d23c9b8be0410d8da51ab6ed5aef203ae883385d"
+
+[target.s390x-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/s390x-unknown-linux-gnu@sha256:c19e71febe5381884583fb26ad797c51fd80daa8d731a73b3d2cccbe35b61ec7"

--- a/crates/crosscheck/Cargo.toml
+++ b/crates/crosscheck/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = "3"
 serde = { version = "1", features = ["derive"] }
 ndarray = ">=0.16, <0.18"
 proptest = "1"
+rstest = "0.27"
 
 [[test]]
 name = "libver_matrix"

--- a/crates/crosscheck/tests/chunk_btree_offset_width.rs
+++ b/crates/crosscheck/tests/chunk_btree_offset_width.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use hdf5::plist::file_create::{Sizeof, SizeofInfo};
+use hdf5_pure::File;
+use rstest::rstest;
+use tempfile::tempdir;
+
+fn write_c_chunked_file(path: &Path, sizeof_addr: Sizeof, sizeof_size: Sizeof) {
+    let sizes = SizeofInfo {
+        sizeof_addr,
+        sizeof_size,
+    };
+    let f = hdf5::File::with_options()
+        .with_create_plist(|p| p.sizes(sizes))
+        .create(path)
+        .unwrap();
+
+    // 1D dataset of 10 elements, chunk size 5 -> 2 chunks
+    let ds = f
+        .new_dataset::<i32>()
+        .chunk((5,))
+        .shape((10,))
+        .create("dset1d")
+        .unwrap();
+    let data: Vec<i32> = (0..10).collect();
+    ds.write(&data).unwrap();
+
+    // 2D dataset of 4x4 elements, chunk size 2x2 -> 4 chunks
+    let ds2d = f
+        .new_dataset::<i32>()
+        .chunk((2, 2))
+        .shape((4, 4))
+        .create("dset2d")
+        .unwrap();
+    let data2d: Vec<i32> = (0..16).collect();
+    ds2d.write_raw(&data2d).unwrap();
+
+    f.close().unwrap();
+}
+
+#[rstest]
+#[case(Sizeof::Bytes2, Sizeof::Bytes2)]
+#[case(Sizeof::Bytes4, Sizeof::Bytes4)]
+#[case(Sizeof::Bytes2, Sizeof::Bytes8)]
+#[case(Sizeof::Bytes4, Sizeof::Bytes8)]
+#[case(Sizeof::Bytes8, Sizeof::Bytes2)]
+#[case(Sizeof::Bytes8, Sizeof::Bytes4)]
+#[case(Sizeof::Bytes4, Sizeof::Bytes2)]
+#[case(Sizeof::Bytes2, Sizeof::Bytes4)]
+fn read_chunked_dataset_with_various_offset_and_length_sizes(
+    #[case] sizeof_addr: Sizeof,
+    #[case] sizeof_size: Sizeof,
+) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_sizes.h5");
+    write_c_chunked_file(&path, sizeof_addr, sizeof_size);
+
+    let pure_file = File::open(&path).unwrap();
+    let pure_ds = pure_file.dataset("dset1d").unwrap();
+    let read_back: Vec<i32> = pure_ds.read_i32().unwrap();
+    let expected: Vec<i32> = (0..10).collect();
+    assert_eq!(read_back, expected);
+
+    let pure_ds2d = pure_file.dataset("dset2d").unwrap();
+    let read_back2d: Vec<i32> = pure_ds2d.read_i32().unwrap();
+    let expected2d: Vec<i32> = (0..16).collect();
+    assert_eq!(read_back2d, expected2d);
+}

--- a/scripts/portability.just
+++ b/scripts/portability.just
@@ -21,8 +21,15 @@ cast-gate:
     cargo clean -p hdf5-pure --target i686-unknown-linux-gnu
     cargo clippy --locked --target i686-unknown-linux-gnu --lib --features "serde zfp provenance ndarray" -- -D clippy::cast_possible_truncation -D clippy::cast_possible_wrap -D unfulfilled_lint_expectations
 
-test-32bit:
-    cross test --locked --target i686-unknown-linux-gnu --no-default-features --features "std checksum deflate zfp serde ndarray provenance" --lib --test write_read_roundtrip --test serde_roundtrip --test zfp_roundtrip --test streaming_reader --test dense_attr_limits --test dense_attr_vlen --test attr_message_size_limit --test userblock_dense_attrs --test c_1_8_read_compat --test fixed_strings
+test-32bit FEATURES="std checksum deflate zfp serde ndarray provenance":
+    cross test \
+        --config 'build.rustc-wrapper=""' \
+        --config 'target."i686-unknown-linux-gnu".linker="i686-linux-gnu-gcc"' \
+        --config 'target."x86_64-unknown-linux-gnu".linker="cc"' \
+        --locked \
+        --target i686-unknown-linux-gnu \
+        --no-default-features \
+        --features "{{ FEATURES }}"
 
 test-big-endian:
     cross test --locked --target s390x-unknown-linux-gnu --no-default-features --features "std checksum deflate zfp serde ndarray provenance" --lib --test write_read_roundtrip --test serde_roundtrip --test complex_bulk_array --test complex_integer --test streaming_reader --test vlen_strings --test fixed_strings

--- a/scripts/portability.just
+++ b/scripts/portability.just
@@ -32,4 +32,11 @@ test-32bit FEATURES="std checksum deflate zfp serde ndarray provenance":
         --features "{{ FEATURES }}"
 
 test-big-endian:
-    cross test --locked --target s390x-unknown-linux-gnu --no-default-features --features "std checksum deflate zfp serde ndarray provenance" --lib --test write_read_roundtrip --test serde_roundtrip --test complex_bulk_array --test complex_integer --test streaming_reader --test vlen_strings --test fixed_strings
+    cross test \
+        --config 'build.rustc-wrapper=""' \
+        --config 'target."s390x-unknown-linux-gnu".linker="s390x-linux-gnu-gcc"' \
+        --config 'target."x86_64-unknown-linux-gnu".linker="cc"' \
+        --locked \
+        --target s390x-unknown-linux-gnu \
+        --no-default-features \
+        --features "std checksum deflate zfp serde ndarray provenance"

--- a/scripts/soundness.just
+++ b/scripts/soundness.just
@@ -6,7 +6,7 @@ default: miri heap-baseline
 # holds unsafe code, when a filter selects no tests, or when the selected tests
 # do not run. Each of those would otherwise pass without checking anything, as
 # happened in #113.
-miri:
+miri $CARGO_TERM_COLOR="always" $MIRIFLAGS="-Zmiri-strict-provenance" $RUSTUP_TOOLCHAIN="nightly":
     #!/usr/bin/env bash
     set -euo pipefail
     log="$(mktemp)"
@@ -17,7 +17,7 @@ miri:
             echo "$file holds no unsafe code; point this recipe at the code that does." >&2
             exit 1
         fi
-        MIRIFLAGS=-Zmiri-strict-provenance cargo miri test --locked --no-default-features \
+        cargo miri test --locked --no-default-features \
             --features std,serde --lib "$filter" 2>&1 | tee "$log"
         if grep -q "running 0 tests" "$log"; then
             echo "Miri ran no tests for $filter: the --lib filter matched nothing." >&2

--- a/src/btree_v1.rs
+++ b/src/btree_v1.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 
 use crate::address::BaseAddress;
-use crate::bytes::{read_offset, read_optional_offset};
+use crate::bytes::{read_length, read_offset, read_optional_offset};
 use crate::convert::TryToUsize;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -53,16 +53,17 @@ pub struct BTreeV1Node {
 impl BTreeV1Node {
     /// Parse a B-tree v1 node at the given offset in the file data.
     ///
-    /// For type 0 (group) nodes, keys are offset_size bytes each (heap name offsets).
+    /// For type 0 (group) nodes, keys are `length_size` bytes each (heap name offsets).
     pub fn parse(
         file_data: &[u8],
         offset: usize,
         offset_size: u8,
-        _length_size: u8,
+        length_size: u8,
     ) -> Result<BTreeV1Node, FormatError> {
         // signature(4) + node_type(1) + node_level(1) + entries_used(2),
         // then left_sibling(offset_size) + right_sibling(offset_size).
         let os = offset_size as usize;
+        let ls = length_size as usize;
         let header_size = btree_v1_node_header_size(offset_size);
         if header_size > file_data.len() || offset > file_data.len() - header_size {
             return Err(FormatError::UnexpectedEof {
@@ -85,10 +86,10 @@ impl BTreeV1Node {
         let right_sibling = read_optional_offset(file_data, pos, offset_size)?;
         pos += os;
 
-        // For type 0: keys are offset_size bytes, children are offset_size bytes
+        // For type 0: keys are `length_size` bytes, children are `offset_size` bytes
         // Layout: key[0], child[0], key[1], child[1], ..., key[N-1], child[N-1], key[N]
         let eu = entries_used as usize;
-        let key_size = os; // For type 0, key = offset_size
+        let key_size = ls; // For type 0, key = `length_size`
         let needed = eu * (key_size + os) + key_size; // eu children + (eu+1) keys
         if needed > file_data.len() || pos > file_data.len() - needed {
             return Err(FormatError::UnexpectedEof {
@@ -102,7 +103,7 @@ impl BTreeV1Node {
 
         for i in 0..eu {
             // key[i]
-            let key = read_offset(file_data, pos, offset_size)?;
+            let key = read_length(file_data, pos, length_size)?;
             keys.push(key);
             pos += key_size;
             // child[i]
@@ -112,7 +113,7 @@ impl BTreeV1Node {
             let _ = i;
         }
         // final key
-        let key = read_offset(file_data, pos, offset_size)?;
+        let key = read_length(file_data, pos, length_size)?;
         keys.push(key);
 
         Ok(BTreeV1Node {
@@ -143,9 +144,10 @@ impl BTreeV1Node {
         let entries_used = u16::from_le_bytes([prefix[6], prefix[7]]) as usize;
 
         // For type 0: header + entries_used*(key + child) + a trailing key,
-        // with key and child each `offset_size` bytes wide.
+        // with child `offset_size` bytes wide and key `length_size` bytes wide.
         let os = offset_size as usize;
-        let total = btree_v1_node_header_size(offset_size) + entries_used * (os + os) + os;
+        let ls = length_size as usize;
+        let total = btree_v1_node_header_size(offset_size) + entries_used * (ls + os) + ls;
         let buf = source.read_metadata_at(address, total)?;
         Self::parse(&buf, 0, offset_size, length_size)
     }
@@ -303,6 +305,7 @@ mod tests {
         left: Option<u64>,
         right: Option<u64>,
         offset_size: u8,
+        length_size: u8,
     ) -> Vec<u8> {
         assert_eq!(keys.len(), children.len() + 1);
         let entries_used = children.len() as u16;
@@ -319,16 +322,16 @@ mod tests {
         write_offset(&mut buf, left.unwrap_or(undef), offset_size);
         write_offset(&mut buf, right.unwrap_or(undef), offset_size);
         for i in 0..children.len() {
-            write_offset(&mut buf, keys[i], offset_size);
+            write_offset(&mut buf, keys[i], length_size);
             write_offset(&mut buf, children[i], offset_size);
         }
-        write_offset(&mut buf, *keys.last().unwrap(), offset_size);
+        write_offset(&mut buf, *keys.last().unwrap(), length_size);
         buf
     }
 
     #[test]
     fn parse_leaf_node() {
-        let data = build_btree_node(0, 0, &[0, 5, 10], &[0x100, 0x200], None, None, 8);
+        let data = build_btree_node(0, 0, &[0, 5, 10], &[0x100, 0x200], None, None, 8, 8);
         let node = BTreeV1Node::parse(&data, 0, 8, 8).unwrap();
         assert_eq!(node.node_type, 0);
         assert_eq!(node.node_level, 0);
@@ -341,22 +344,32 @@ mod tests {
 
     #[test]
     fn parse_with_siblings_none() {
-        let data = build_btree_node(0, 0, &[0, 8], &[0x300], None, None, 8);
+        let data = build_btree_node(0, 0, &[0, 8], &[0x300], None, None, 8, 8);
         let node = BTreeV1Node::parse(&data, 0, 8, 8).unwrap();
         assert_eq!(node.left_sibling, None);
         assert_eq!(node.right_sibling, None);
     }
 
     #[test]
+    fn parse_leaf_node_differing_offset_and_length_sizes() {
+        let data = build_btree_node(0, 0, &[0x10, 0x20], &[0x300], None, None, 4, 8);
+        let node = BTreeV1Node::parse(&data, 0, 4, 8).unwrap();
+        assert_eq!(node.entries_used, 1);
+        assert_eq!(node.keys, vec![0x10, 0x20]);
+        assert_eq!(node.children, vec![0x300]);
+    }
+
+    #[test]
     fn parse_internal_node_and_collect() {
         // Build a 2-level tree: one internal node pointing to two leaf nodes
         let os: u8 = 8;
+        let ls: u8 = 8;
         let leaf1_offset: usize = 0;
         let leaf2_offset: usize = 256;
         let internal_offset: usize = 512;
 
-        let leaf1 = build_btree_node(0, 0, &[0, 5], &[0xA00], None, None, os);
-        let leaf2 = build_btree_node(0, 0, &[5, 10], &[0xB00], None, None, os);
+        let leaf1 = build_btree_node(0, 0, &[0, 5], &[0xA00], None, None, os, ls);
+        let leaf2 = build_btree_node(0, 0, &[5, 10], &[0xB00], None, None, os, ls);
         let internal = build_btree_node(
             0,
             1,
@@ -365,6 +378,7 @@ mod tests {
             None,
             None,
             os,
+            ls,
         );
 
         let mut file = vec![0u8; 1024];
@@ -373,14 +387,14 @@ mod tests {
         file[internal_offset..internal_offset + internal.len()].copy_from_slice(&internal);
 
         let snods =
-            collect_symbol_table_nodes(&file, internal_offset as u64, os, os, BaseAddress::ZERO)
+            collect_symbol_table_nodes(&file, internal_offset as u64, os, ls, BaseAddress::ZERO)
                 .unwrap();
         assert_eq!(snods, vec![0xA00, 0xB00]);
     }
 
     #[test]
     fn invalid_signature() {
-        let mut data = build_btree_node(0, 0, &[0, 1], &[0x100], None, None, 8);
+        let mut data = build_btree_node(0, 0, &[0, 1], &[0x100], None, None, 8, 8);
         data[0] = b'X';
         let err = BTreeV1Node::parse(&data, 0, 8, 8).unwrap_err();
         assert_eq!(err, FormatError::InvalidBTreeSignature);
@@ -388,7 +402,7 @@ mod tests {
 
     #[test]
     fn collect_wrong_node_type() {
-        let data = build_btree_node(1, 0, &[0, 1], &[0x100], None, None, 8);
+        let data = build_btree_node(1, 0, &[0, 1], &[0x100], None, None, 8, 8);
         let mut file = vec![0u8; 512];
         file[..data.len()].copy_from_slice(&data);
         let err = collect_symbol_table_nodes(&file, 0, 8, 8, BaseAddress::ZERO).unwrap_err();
@@ -397,7 +411,7 @@ mod tests {
 
     #[test]
     fn parse_4byte_offsets() {
-        let data = build_btree_node(0, 0, &[0, 4], &[0x50], None, None, 4);
+        let data = build_btree_node(0, 0, &[0, 4], &[0x50], None, None, 4, 4);
         let node = BTreeV1Node::parse(&data, 0, 4, 4).unwrap();
         assert_eq!(node.entries_used, 1);
         assert_eq!(node.children, vec![0x50]);
@@ -409,11 +423,12 @@ mod tests {
         // Listing a malicious v1 group must error via the depth guard rather
         // than recurse until the stack overflows (an uncatchable abort).
         let os: u8 = 8;
-        let node = build_btree_node(0, 1, &[0, 0], &[0], None, None, os);
+        let ls: u8 = 8;
+        let node = build_btree_node(0, 1, &[0, 0], &[0], None, None, os, ls);
         let mut file = vec![0u8; 1024];
         file[..node.len()].copy_from_slice(&node);
 
-        let err = collect_symbol_table_nodes(&file, 0, os, os, BaseAddress::ZERO).unwrap_err();
+        let err = collect_symbol_table_nodes(&file, 0, os, ls, BaseAddress::ZERO).unwrap_err();
         assert_eq!(err, FormatError::NestingDepthExceeded);
     }
 }

--- a/src/chunked_read.rs
+++ b/src/chunked_read.rs
@@ -70,13 +70,15 @@ pub struct ChunkInfo {
     pub address: u64,
 }
 
-/// Size of a single key in a version 1 B-tree of type 1 (raw data chunks):
-/// `chunk_size(4) + filter_mask(4) + ndims * offset_size`. The `ndims` trailing
-/// offsets are the per-dimension scaled chunk coordinates (rank + 1 values, the
-/// extra one being the element-offset dimension). (HDF5 format spec, "Disk
-/// Format: Level 1A1 — Version 1 B-trees", type 1 key.)
-const fn chunk_record_key_size(ndims: usize, offset_size: usize) -> usize {
-    4 + 4 + ndims * offset_size
+/// The size in bytes of a key in a version 1 B-tree of type 1 (raw data chunks):
+/// the chunk byte size (4), the filter mask (4), and `ndims` 64-bit offsets (8 bytes each).
+/// The offsets are `(D + 1)` coordinates: one per dataset dimension, followed by a trailing
+/// element offset that is always zero. The key is defined in "Version 1 B-trees" of the
+/// [format specification, version 4.0][spec].
+///
+/// [spec]: https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t4.html#subsubsec_fmt4_infra_btrees_v1
+const fn chunk_record_key_size(ndims: usize) -> usize {
+    4 + 4 + ndims * 8
 }
 
 /// Traverse B-tree v1 type 1 to collect all chunk locations.
@@ -136,7 +138,7 @@ fn collect_chunk_info_inner(
 
     let mut pos = offset + header_size; // first key, past signature/siblings
 
-    let key_size = chunk_record_key_size(ndims, os);
+    let key_size = chunk_record_key_size(ndims);
 
     if node_level == 0 {
         // Leaf node: keys and children interleaved
@@ -167,8 +169,15 @@ fn collect_chunk_info_inner(
             let mut offsets = Vec::with_capacity(ndims);
             let mut kp = pos + 8;
             for _ in 0..ndims {
-                offsets.push(read_offset(file_data, kp, offset_size)?);
-                kp += os;
+                let bytes = file_data
+                    .get(kp..kp + 8)
+                    .ok_or(FormatError::UnexpectedEof {
+                        expected: kp.saturating_add(8),
+                        available: file_data.len(),
+                    })?;
+                // Invariant: slice length is exactly 8 bytes.
+                offsets.push(u64::from_le_bytes(bytes.try_into().unwrap()));
+                kp += 8;
             }
             pos += key_size;
 
@@ -278,7 +287,7 @@ fn collect_chunk_btree_node_spans_inner<S: Source + ?Sized>(
     }
     let node_level = header[5];
     let entries_used = u16::from_le_bytes([header[6], header[7]]) as usize;
-    let key_size = chunk_record_key_size(ndims, os);
+    let key_size = chunk_record_key_size(ndims);
 
     // The reader-consumed body: `entries_used` (key, child) pairs and a trailing
     // key. This is the conservative node extent (see the doc comment).
@@ -370,7 +379,7 @@ fn collect_chunk_info_from_source_inner<S: Source + ?Sized>(
     let entries_used = u16::from_le_bytes([header[6], header[7]]) as usize;
 
     // Key/child region begins right after the header (siblings already included).
-    let key_size = chunk_record_key_size(ndims, os);
+    let key_size = chunk_record_key_size(ndims);
     let needed = entries_used * (key_size + os) + key_size;
     let body_addr =
         btree_address
@@ -392,8 +401,13 @@ fn collect_chunk_info_from_source_inner<S: Source + ?Sized>(
             let mut offsets = Vec::with_capacity(ndims);
             let mut kp = pos + 8;
             for _ in 0..ndims {
-                offsets.push(read_offset(&body, kp, offset_size)?);
-                kp += os;
+                let bytes = body.get(kp..kp + 8).ok_or(FormatError::UnexpectedEof {
+                    expected: kp.saturating_add(8),
+                    available: body.len(),
+                })?;
+                // Invariant: slice length is exactly 8 bytes.
+                offsets.push(u64::from_le_bytes(bytes.try_into().unwrap()));
+                kp += 8;
             }
             pos += key_size;
             let address = read_offset(&body, pos, offset_size)?;
@@ -2304,7 +2318,7 @@ mod tests {
                 } else {
                     0
                 };
-                write_offset(&mut buf, off, offset_size);
+                buf.extend_from_slice(&off.to_le_bytes());
             }
             // Child: address
             write_offset(&mut buf, chunk.address, offset_size);
@@ -2314,7 +2328,7 @@ mod tests {
         buf.extend_from_slice(&0u32.to_le_bytes()); // chunk_size
         buf.extend_from_slice(&0u32.to_le_bytes()); // filter_mask
         for _ in 0..ndims {
-            write_offset(&mut buf, u64::MAX, offset_size);
+            buf.extend_from_slice(&u64::MAX.to_le_bytes());
         }
 
         buf
@@ -2380,7 +2394,7 @@ mod tests {
             buf.extend_from_slice(&0u32.to_le_bytes()); // key: chunk_size
             buf.extend_from_slice(&0u32.to_le_bytes()); // key: filter_mask
             for _ in 0..ndims {
-                write_offset(&mut buf, 0, offset_size);
+                buf.extend_from_slice(&0u64.to_le_bytes());
             }
             write_offset(&mut buf, addr, offset_size); // child node address
         }
@@ -2388,7 +2402,7 @@ mod tests {
         buf.extend_from_slice(&0u32.to_le_bytes());
         buf.extend_from_slice(&0u32.to_le_bytes());
         for _ in 0..ndims {
-            write_offset(&mut buf, u64::MAX, offset_size);
+            buf.extend_from_slice(&u64::MAX.to_le_bytes());
         }
         buf
     }

--- a/src/chunked_write.rs
+++ b/src/chunked_write.rs
@@ -4971,8 +4971,13 @@ mod tests {
             .ok()?;
         if !o.status.success() {
             let err = String::from_utf8_lossy(&o.stderr);
-            if err.contains("No module named") {
-                return None; // h5py not installed — skip
+            // Under QEMU user emulation, a missing binary yields exit status 127
+            // with empty standard error.
+            if o.status.code() == Some(127) && err.is_empty()
+                || err.contains("No module named")
+                || err.contains("not found")
+            {
+                return None;
             }
             panic!("h5py: {err}");
         }

--- a/src/group_v1.rs
+++ b/src/group_v1.rs
@@ -63,6 +63,7 @@ pub fn resolve_v1_group_entries(
             file_data,
             base_address.absolute(snod_addr)?.to_usize()?,
             offset_size,
+            length_size,
         )?;
         for entry in &snod.entries {
             let name = heap.read_string(file_data, entry.link_name_offset)?;
@@ -116,7 +117,8 @@ pub fn resolve_v1_group_entries_from_source<S: Source + ?Sized>(
     for snod_addr in snod_addrs {
         // SNOD addresses from the B-tree are relative to base_address.
         let snod_offset = base_address.absolute(snod_addr)?;
-        let snod = SymbolTableNode::parse_from_source(source, snod_offset, offset_size)?;
+        let snod =
+            SymbolTableNode::parse_from_source(source, snod_offset, offset_size, length_size)?;
         for entry in &snod.entries {
             let name = heap.read_string_in_segment(&segment, entry.link_name_offset)?;
             entries.push(GroupEntry {
@@ -168,7 +170,7 @@ mod tests {
         // Pad to nice offset
         let snod_offset = (snod_offset + 7) & !7;
 
-        let entry_size = os + os + 4 + 4 + 16;
+        let entry_size = ls + os + 4 + 4 + 16;
         let snod_size = 8 + children.len() * entry_size;
         let btree_offset = snod_offset + snod_size;
         let btree_offset = (btree_offset + 7) & !7;
@@ -180,7 +182,7 @@ mod tests {
             heap_data_size as u64
         };
         let btree_header_size = crate::btree_v1::btree_v1_node_header_size(offset_size);
-        let btree_keys_children = os + os + os; // key[0] + child[0] + key[1]
+        let btree_keys_children = ls + os + ls; // key[0] + child[0] + key[1]
         let total_size = btree_offset + btree_header_size + btree_keys_children + 64;
 
         let mut file = vec![0u8; total_size];
@@ -229,13 +231,13 @@ mod tests {
             pos += 2;
             for (idx, &(_, obj_addr, cache_type)) in children.iter().enumerate() {
                 // link_name_offset
-                match offset_size {
+                match length_size {
                     4 => file[pos..pos + 4]
                         .copy_from_slice(&(name_offsets[idx] as u32).to_le_bytes()),
                     8 => file[pos..pos + 8].copy_from_slice(&name_offsets[idx].to_le_bytes()),
                     _ => {}
                 }
-                pos += os;
+                pos += ls;
                 // object_header_address
                 match offset_size {
                     4 => file[pos..pos + 4].copy_from_slice(&(obj_addr as u32).to_le_bytes()),
@@ -271,12 +273,12 @@ mod tests {
                 pos += os;
             }
             // key[0]
-            match offset_size {
+            match length_size {
                 4 => file[pos..pos + 4].copy_from_slice(&0u32.to_le_bytes()),
                 8 => file[pos..pos + 8].copy_from_slice(&0u64.to_le_bytes()),
                 _ => {}
             }
-            pos += os;
+            pos += ls;
             // child[0] = snod_offset
             match offset_size {
                 4 => file[pos..pos + 4].copy_from_slice(&(snod_offset as u32).to_le_bytes()),
@@ -285,7 +287,7 @@ mod tests {
             }
             pos += os;
             // key[1]
-            match offset_size {
+            match length_size {
                 4 => file[pos..pos + 4].copy_from_slice(&(last_key as u32).to_le_bytes()),
                 8 => file[pos..pos + 8].copy_from_slice(&last_key.to_le_bytes()),
                 _ => {}

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -166,9 +166,10 @@ impl Superblock {
         let consistency_flags = LittleEndian::read_u32(&d[20..24]);
 
         let os = usize::from(offset_width.get());
+        let ls = usize::from(length_width.get());
         // 4 addresses + root symbol table entry
         let var_start = 24;
-        let sym_entry_size = os + os + 4 + 4 + 16; // link_name_off, obj_hdr_addr, cache_type, reserved, scratch
+        let sym_entry_size = ls + os + 4 + 4 + 16;
         let total = var_start + 4 * os + sym_entry_size;
         bytes::ensure_len(d, 0, total)?;
 
@@ -183,8 +184,8 @@ impl Superblock {
         pos += os;
 
         // Root symbol table entry
-        let _link_name_offset = bytes::read_offset_width(d, pos, offset_width)?;
-        pos += os;
+        let _link_name_offset = bytes::read_length_width(d, pos, length_width)?;
+        pos += ls;
         let object_header_addr = bytes::read_offset_width(d, pos, offset_width)?;
 
         Ok(Superblock {
@@ -228,8 +229,9 @@ impl Superblock {
         // d[26..28] reserved
 
         let os = usize::from(offset_width.get());
+        let ls = usize::from(length_width.get());
         let var_start = 28;
-        let sym_entry_size = os + os + 4 + 4 + 16;
+        let sym_entry_size = ls + os + 4 + 4 + 16;
         let total = var_start + 4 * os + sym_entry_size;
         bytes::ensure_len(d, 0, total)?;
 
@@ -244,8 +246,8 @@ impl Superblock {
         pos += os;
 
         // Root symbol table entry
-        let _link_name_offset = bytes::read_offset_width(d, pos, offset_width)?;
-        pos += os;
+        let _link_name_offset = bytes::read_length_width(d, pos, length_width)?;
+        pos += ls;
         let object_header_addr = bytes::read_offset_width(d, pos, offset_width)?;
 
         Ok(Superblock {

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::bytes::read_length;
 use crate::bytes::read_offset;
 use crate::error::FormatError;
 use crate::source::Source;
@@ -63,6 +64,7 @@ impl SymbolTableNode {
         file_data: &[u8],
         offset: usize,
         offset_size: u8,
+        length_size: u8,
     ) -> Result<SymbolTableNode, FormatError> {
         // signature(4) + version(1) + reserved(1) + number_of_symbols(2) = 8
         if 8 > file_data.len() || offset > file_data.len() - 8 {
@@ -85,8 +87,9 @@ impl SymbolTableNode {
             u16::from_le_bytes([file_data[offset + 6], file_data[offset + 7]]) as usize;
 
         let os = offset_size as usize;
-        // Each entry: link_name_offset(os) + obj_hdr_addr(os) + cache_type(4) + reserved(4) + scratch(16)
-        let entry_size = os + os + 4 + 4 + 16;
+        let ls = length_size as usize;
+        // Each entry: link_name_offset(ls) + obj_hdr_addr(os) + cache_type(4) + reserved(4) + scratch(16)
+        let entry_size = ls + os + 4 + 4 + 16;
         let entries_start = offset + 8;
         let needed = entries_start + num_symbols * entry_size;
         if needed > file_data.len() {
@@ -99,8 +102,8 @@ impl SymbolTableNode {
         let mut entries = Vec::with_capacity(num_symbols);
         let mut pos = entries_start;
         for _ in 0..num_symbols {
-            let link_name_offset = read_offset(file_data, pos, offset_size)?;
-            pos += os;
+            let link_name_offset = read_length(file_data, pos, length_size)?;
+            pos += ls;
             let object_header_address = read_offset(file_data, pos, offset_size)?;
             pos += os;
             let cache_type = u32::from_le_bytes([
@@ -135,6 +138,7 @@ impl SymbolTableNode {
         source: &S,
         address: u64,
         offset_size: u8,
+        length_size: u8,
     ) -> Result<SymbolTableNode, FormatError> {
         let header = source.read_metadata_at(address, 8)?;
         if &header[0..4] != b"SNOD" {
@@ -147,11 +151,12 @@ impl SymbolTableNode {
         let num_symbols = u16::from_le_bytes([header[6], header[7]]) as usize;
 
         let os = offset_size as usize;
-        // link_name_offset(os) + obj_hdr_addr(os) + cache_type(4) + reserved(4) + scratch(16)
-        let entry_size = os + os + 4 + 4 + 16;
+        let ls = length_size as usize;
+        // link_name_offset(ls) + obj_hdr_addr(os) + cache_type(4) + reserved(4) + scratch(16)
+        let entry_size = ls + os + 4 + 4 + 16;
         let total = 8 + num_symbols * entry_size;
         let buf = source.read_metadata_at(address, total)?;
-        Self::parse(&buf, 0, offset_size)
+        Self::parse(&buf, 0, offset_size, length_size)
     }
 }
 
@@ -179,7 +184,7 @@ mod tests {
         assert_eq!(msg.local_heap_address, 0x900);
     }
 
-    fn build_snod(entries: &[(u64, u64, u32)], offset_size: u8) -> Vec<u8> {
+    fn build_snod(entries: &[(u64, u64, u32)], offset_size: u8, length_size: u8) -> Vec<u8> {
         let mut buf = Vec::new();
         // Pad so SNOD is at offset 0
         buf.extend_from_slice(b"SNOD");
@@ -187,15 +192,14 @@ mod tests {
         buf.push(0); // reserved
         buf.extend_from_slice(&(entries.len() as u16).to_le_bytes());
         for &(name_off, ohdr_addr, cache_type) in entries {
+            match length_size {
+                4 => buf.extend_from_slice(&(name_off as u32).to_le_bytes()),
+                8 => buf.extend_from_slice(&name_off.to_le_bytes()),
+                _ => panic!("test length_size"),
+            }
             match offset_size {
-                4 => {
-                    buf.extend_from_slice(&(name_off as u32).to_le_bytes());
-                    buf.extend_from_slice(&(ohdr_addr as u32).to_le_bytes());
-                }
-                8 => {
-                    buf.extend_from_slice(&name_off.to_le_bytes());
-                    buf.extend_from_slice(&ohdr_addr.to_le_bytes());
-                }
+                4 => buf.extend_from_slice(&(ohdr_addr as u32).to_le_bytes()),
+                8 => buf.extend_from_slice(&ohdr_addr.to_le_bytes()),
                 _ => panic!("test offset_size"),
             }
             buf.extend_from_slice(&cache_type.to_le_bytes());
@@ -207,8 +211,8 @@ mod tests {
 
     #[test]
     fn parse_snod_two_entries() {
-        let data = build_snod(&[(0, 0x100, 0), (8, 0x200, 1)], 8);
-        let snod = SymbolTableNode::parse(&data, 0, 8).unwrap();
+        let data = build_snod(&[(0, 0x100, 0), (8, 0x200, 1)], 8, 8);
+        let snod = SymbolTableNode::parse(&data, 0, 8, 8).unwrap();
         assert_eq!(snod.entries.len(), 2);
         assert_eq!(snod.entries[0].link_name_offset, 0);
         assert_eq!(snod.entries[0].object_header_address, 0x100);
@@ -219,25 +223,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_snod_differing_offset_and_length_sizes() {
+        let data = build_snod(&[(0x12345678, 0x100, 0)], 4, 8);
+        let snod = SymbolTableNode::parse(&data, 0, 4, 8).unwrap();
+        assert_eq!(snod.entries.len(), 1);
+        assert_eq!(snod.entries[0].link_name_offset, 0x12345678);
+        assert_eq!(snod.entries[0].object_header_address, 0x100);
+    }
+
+    #[test]
     fn parse_snod_empty() {
-        let data = build_snod(&[], 8);
-        let snod = SymbolTableNode::parse(&data, 0, 8).unwrap();
+        let data = build_snod(&[], 8, 8);
+        let snod = SymbolTableNode::parse(&data, 0, 8, 8).unwrap();
         assert_eq!(snod.entries.len(), 0);
     }
 
     #[test]
     fn parse_snod_invalid_signature() {
-        let mut data = build_snod(&[], 8);
+        let mut data = build_snod(&[], 8, 8);
         data[0] = b'X';
-        let err = SymbolTableNode::parse(&data, 0, 8).unwrap_err();
+        let err = SymbolTableNode::parse(&data, 0, 8, 8).unwrap_err();
         assert_eq!(err, FormatError::InvalidSymbolTableNodeSignature);
     }
 
     #[test]
     fn parse_snod_invalid_version() {
-        let mut data = build_snod(&[], 8);
+        let mut data = build_snod(&[], 8, 8);
         data[4] = 2; // bad version
-        let err = SymbolTableNode::parse(&data, 0, 8).unwrap_err();
+        let err = SymbolTableNode::parse(&data, 0, 8, 8).unwrap_err();
         assert_eq!(err, FormatError::InvalidSymbolTableNodeVersion(2));
     }
 }

--- a/tests/allocation_bounds.rs
+++ b/tests/allocation_bounds.rs
@@ -20,6 +20,11 @@
 //! else. That last part is also how a test here could go quiet, which is why each
 //! one asserts a floor as well as a ceiling — see [`allocation::Measured`].
 
+// heapscope unwinds with the frame-pointer convention, which it implements for
+// x86_64 and aarch64 only, and on any other target the profiler errors at
+// startup.
+#![cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+
 use hdf5_pure::{
     EditBacking, File, FileAccessProperties, FileBuilder, FileSpaceStrategy, MemoryStrategy,
     SyncPolicy,

--- a/tests/swmr_concurrent.rs
+++ b/tests/swmr_concurrent.rs
@@ -36,8 +36,13 @@ print(n, int(d[0]) if n else 0, int(d[-1]) if n else 0)
         .ok()?;
     if !out.status.success() {
         let err = String::from_utf8_lossy(&out.stderr);
-        if err.contains("No module named") {
-            return None; // h5py not installed — skip
+        // Under QEMU user emulation, a missing binary yields exit status 127
+        // with empty standard error.
+        if out.status.code() == Some(127) && err.is_empty()
+            || err.contains("No module named")
+            || err.contains("not found")
+        {
+            return None;
         }
         panic!("h5py read ({mode}) failed: {err}");
     }


### PR DESCRIPTION
Resolves #546 
Resolves https://github.com/CramBL/hdf5-pure/issues/429

- **Add `rstest` to crosscheck dev-dependencies**
- **Fix B-tree v1 type-1 chunk offset key sizing and parsing**
